### PR TITLE
GasOptimisation-OnlyForLoop Done

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -135,7 +135,8 @@ contract Chamber {
         uint index = head;
         _rankings = new uint256[](leaders);
         _stakes = new uint256[](leaders);
-        for (uint i = 0; i < leaders; i++) {
+        uint leadersNumber = leaders;
+        for (uint i = 0; i < leadersNumber; i++) {
             _rankings[i] = index;
             _stakes[i] = totalStake[index];
             index = list[index][_PREV];
@@ -176,8 +177,8 @@ contract Chamber {
         require(!voted[_proposalId][_tokenId], "NFT has already voted.");
 
         bool detected;
-
-        for (uint i = 0; i < proposals[_proposalId].voters.length; i++) {
+        uint proposalsVotersLength = proposals[_proposalId].voters.length;
+        for (uint i = 0; i < proposalsVotersLength; i++) {
             if (_tokenId == proposals[_proposalId].voters[i]) { detected = true; break; }
         }
 


### PR DESCRIPTION
## Description 
The length of the `leaders` and `voters` arrays are stored in variables called `leadersNumber` and `proposalsVotersLength`, respectively. This allows the loop to iterate through the arrays without having to call the `length()` function on the arrays multiple times. Calling a state variable costs gas, so storing the length of the arrays in memory variables can save gas.

## Gas Optimisation
### Old Code Snapshot
```bash
ChamberTest:test_proposal_cycle() (gas: 1526914)
LinkedListTest:test_LinkedList_init() (gas: 15238)
LinkedListTest:test_LinkedList_stake(uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96) (runs: 256, μ: 1645755, ~: 1645571)
LinkedListTest:test_LinkedList_unstake(uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96) (runs: 256, μ: 1895612, ~: 1895240)
ProposalTest:test_chamber_LORE() (gas: 4018255)
```
### New Code Snapshot
```bash
ChamberTest:test_proposal_cycle() (gas: 1524826)
LinkedListTest:test_LinkedList_init() (gas: 15238)
LinkedListTest:test_LinkedList_stake(uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96) (runs: 256, μ: 1640488, ~: 1640182)
LinkedListTest:test_LinkedList_unstake(uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96,uint96) (runs: 256, μ: 1887051, ~: 1890052)
ProposalTest:test_chamber_LORE() (gas: 4012383)
```
### Difference
```bash
ChamberTest:test_proposal_cycle(): -2088 gas
LinkedListTest:test_LinkedList_init(): 0 gas
LinkedListTest:test_LinkedList_stake(): -5,389 gas
LinkedListTest:test_LinkedList_unstake(): -5,188 gas
ProposalTest:test_chamber_LORE(): -5,872 gas
```