### PR TITLE
fix: Update the getChambers function on Regsitry

### DIFF
--- a/script/Chamber.s.sol
+++ b/script/Chamber.s.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.19;
 
 import "forge-std/Script.sol";
-import { Registry } from "../src/Registry.sol";
+import { Chamber } from "../src/Chamber.sol";
 import "forge-std/console2.sol";
 
-contract DeployRegistry is Script {
+contract DeployChamber is Script {
 
     function run() external {
         vm.startBroadcast();
-        Registry registryImpl = new Registry();
+        Chamber chamberImpl = new Chamber();
         vm.stopBroadcast();
-        console2.log("Registry Implementation: ", address(registryImpl));
+        console2.log("Chamber Implementation: ", address(chamberImpl));
     }
 }

--- a/script/RegistryProxy.s.sol
+++ b/script/RegistryProxy.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "forge-std/Script.sol";
+import { Registry } from "../src/Registry.sol";
+import { Chamber } from "../src/Chamber.sol";
+import { Proxy } from "../src/Proxy.sol";
+import "forge-std/console2.sol";
+
+contract DeployRegistryProxy is Script {
+
+    function run() external {
+
+        vm.startBroadcast();
+        Chamber chamberImpl = new Chamber();
+        vm.stopBroadcast();
+        console2.log("Chamber Implementation address: ", address(chamberImpl));
+
+        vm.startBroadcast();
+
+        Registry registryImpl = new Registry();
+        bytes memory data = abi.encodeWithSelector(Registry.initialize.selector, address(chamberImpl), msg.sender);
+        Proxy registry = new Proxy(address(registryImpl), data, msg.sender);
+        vm.stopBroadcast();
+        console2.log("Registry Proxy address: ", address(registry));
+    }
+}

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -35,6 +35,7 @@ contract Registry is IRegistry, Initializable, Ownable {
 
     /// @inheritdoc IRegistry
     function getChambers(uint8 limit, uint8 skip) external view returns (ChamberData[] memory) {
+        if (limit > totalChambers && totalChambers <= 255) limit = uint8(totalChambers);
         ChamberData[] memory _chambers = new ChamberData[](limit);
         for (uint8 i = 0; i < limit; i++) {
             _chambers[i] = chambers[i + skip];


### PR DESCRIPTION
Fix returning too many chambers of null values
Adds scripts for deployment implementations of Chamber and Registry
Updates the DeployRegistryProxy script to handle the main deployment