### PR TITLE
feat: EIP-712 Compliance for Signature Verification

### DIFF
--- a/src/interfaces/IChamber.sol
+++ b/src/interfaces/IChamber.sol
@@ -117,6 +117,10 @@ interface IChamber {
     /// @param tokenId  The Id of the memberToken to demote from 
     function demote(uint256 amount, uint8 tokenId) external;
 
+    /// @notice Returns the domain separator for this contract, as defined in the EIP-712 standard.
+    /// @return bytes32 The domain separator hash.
+    function domainSeparator() external view returns (bytes32);
+
     /// @notice verify Signature function
     /// @param  proposalId The ID of the proposal to approve
     /// @param  tokenId    The ID of the NFT to vote 


### PR DESCRIPTION
- Added support for [EIP-712](https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator), enhancing signature verification for increased security.
- Introduces `DOMAIN_SEPARATOR_TYPEHASH`, `domainSeparator`, and `encodeData` functions to comply with EIP-712 standards.
```solidity
bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;

function domainSeparator() public view returns (bytes32) {...}

function encodeData(...) internal view returns(bytes memory) {...}
```
---
This pull request focuses on enhancing the security of the smart contract through EIP-712 compliance.