### PR TITLE
refactor: Upgrade all uint8 to uint256 

### DIFF
--- a/src/GuardManager.sol
+++ b/src/GuardManager.sol
@@ -21,12 +21,12 @@ interface Guard is IERC165{
         address[] memory to,
         uint256[] memory value,
         bytes[] memory data,
-        uint8[5] memory voters,
+        uint256[5] memory voters,
         IChamber.State state,
         bytes memory signature,
         address executor,
-        uint8 proposalId,
-        uint8 tokenId
+        uint256 proposalId,
+        uint256 tokenId
     )external;
     
     /// @notice Checks after execution of transaction.

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -34,10 +34,10 @@ contract Registry is IRegistry, Initializable, Ownable {
     }
 
     /// @inheritdoc IRegistry
-    function getChambers(uint8 limit, uint8 skip) external view returns (ChamberData[] memory) {
-        if (limit > totalChambers && totalChambers <= 255) limit = uint8(totalChambers);
+    function getChambers(uint256 limit, uint256 skip) external view returns (ChamberData[] memory) {
+        if (limit > totalChambers && totalChambers <= 255) limit = uint256(totalChambers);
         ChamberData[] memory _chambers = new ChamberData[](limit);
-        for (uint8 i = 0; i < limit; i++) {
+        for (uint256 i = 0; i < limit; i++) {
             _chambers[i] = chambers[i + skip];
         }
         return _chambers;

--- a/src/example/DenyTransactionGuard.sol
+++ b/src/example/DenyTransactionGuard.sol
@@ -43,12 +43,12 @@ contract DenyTransactionGuard is BaseGuard {
         address[] memory to,
         uint256[] memory,
         bytes[] memory,
-        uint8[5] memory ,
+        uint256[5] memory ,
         IChamber.State,
         bytes memory ,
         address,
-        uint8,
-        uint8
+        uint256,
+        uint256
     ) external view override {
         require(!checkAddressBlacklisted(to), "You are sending the transaction to an unallowed address");
     }

--- a/src/interfaces/IChamber.sol
+++ b/src/interfaces/IChamber.sol
@@ -17,8 +17,8 @@ interface IChamber is IGuardManager{
         address[]   target;
         uint256[]   value;
         bytes[]     data;
-        uint8[5]    voters;
-        uint8       approvals;
+        uint256[5]    voters;
+        uint256       approvals;
         uint256     nonce;
         State       state;
     }
@@ -31,19 +31,19 @@ interface IChamber is IGuardManager{
     /// @param promoter   The address of the promoter
     /// @param amt        The amount of "govToken" delegated
     /// @param tokenId    The ID of the NFT that tokens will be promoted against
-    event Promoted(address promoter, uint256 amt, uint8 tokenId);
+    event Promoted(address promoter, uint256 amt, uint256 tokenId);
 
     /// @notice Emitted upon demote()
     /// @param demoter   The address of the demoter
     /// @param amt       The amount of "govToken" demoted
     /// @param tokenId   The ID of the NFT that tokens were demoted against
-    event Demoted(address demoter, uint256 amt, uint8 tokenId);
+    event Demoted(address demoter, uint256 amt, uint256 tokenId);
     
     /// @notice Emitted when a proposal is approved
     /// @param proposalId The unique identifier of the approved proposal
     /// @param tokenId    The tokenId that the proposal was associated with
     /// @param approvals  The total number of approvals that the proposal received
-    event ProposalApproved(uint8 proposalId, uint8 tokenId, uint256 approvals);
+    event ProposalApproved(uint256 proposalId, uint256 tokenId, uint256 approvals);
 
     /// @notice Emitted when a proposal is created
     /// @param proposalId    The unique identifier of the created proposal
@@ -52,11 +52,11 @@ interface IChamber is IGuardManager{
     /// @param data          The array of data payloads associated with each target
     /// @param voters        The array of voters associated with each target
     /// @param nonce         The nonce associated with the created proposal
-    event ProposalCreated(uint8 proposalId, address[] target, uint256[] value, bytes[] data, uint8[5] voters, uint256 nonce);
+    event ProposalCreated(uint256 proposalId, address[] target, uint256[] value, bytes[] data, uint256[5] voters, uint256 nonce);
 
     /// @notice Emitted when a proposal is executed
     /// @param proposalId The unique identifier of the executed proposal
-    event ProposalExecuted(uint8 proposalId);
+    event ProposalExecuted(uint256 proposalId);
 
     /// @notice Emitted when Ether is received
     /// @param sender The address of the sender of the Ether
@@ -80,28 +80,28 @@ interface IChamber is IGuardManager{
     /// @notice Returns the amount of govToken delegated against a given tokenId by an account
     /// @param account The address of the account to query
     /// @param tokenId The ID of the NFT to query
-    function accountDelegation(address account, uint8 tokenId) external view returns (uint256);
+    function accountDelegation(address account, uint256 tokenId) external view returns (uint256);
 
     /// @notice Returns the total amount of govToken delegated against a given tokenId
     /// @param tokenId The ID of the NFT to query
-    function totalDelegation(uint8 tokenId) external view returns (uint256);
+    function totalDelegation(uint256 tokenId) external view returns (uint256);
 
     /// @notice Returns the total number of proposals
-    function proposalCount() external view returns (uint8);
+    function proposalCount() external view returns (uint256);
 
     /// @notice Returns the number of approvals and the state of a proposal
     /// @param proposalId The ID of the proposal to query
-    function proposal(uint8 proposalId) external view returns (uint8 approvals, State state);
+    function proposal(uint256 proposalId) external view returns (uint256 approvals, State state);
 
     /// @notice Returns two arrays, the leaders and their delegations
-    function getLeaderboard() external view returns (uint8[] memory, uint256[] memory);
+    function getLeaderboard() external view returns (uint256[] memory, uint256[] memory);
 
 
     /// @notice approve Proposal function
     /// @param  proposalId The ID of the proposal to approve
     /// @param  tokenId    The ID of the NFT to vote 
     /// @param  signature  The cryptographic signature to be verified
-    function approveProposal(uint8 proposalId, uint8 tokenId,bytes memory signature) external;
+    function approveProposal(uint256 proposalId, uint256 tokenId,bytes memory signature) external;
 
     /// @notice create Proposal function
     /// @param  target The address of contract to send transaction
@@ -112,12 +112,12 @@ interface IChamber is IGuardManager{
     /// @notice Promotes an amount of govToken against a provided memberToken Id
     /// @param amount   The amount of govToken for promotion
     /// @param tokenId  The Id of the memberToken to promote
-    function promote(uint256 amount, uint8 tokenId) external;
+    function promote(uint256 amount, uint256 tokenId) external;
 
     /// @notice Demotes an amount of govToken from the provided memberToken Id
     /// @param amount   The amount of govToken for demotion
     /// @param tokenId  The Id of the memberToken to demote from 
-    function demote(uint256 amount, uint8 tokenId) external;
+    function demote(uint256 amount, uint256 tokenId) external;
 
     /// @notice Returns the domain separator for this contract, as defined in the EIP-712 standard.
     /// @return bytes32 The domain separator hash.
@@ -127,12 +127,12 @@ interface IChamber is IGuardManager{
     /// @param  proposalId The ID of the proposal to approve
     /// @param  tokenId    The ID of the NFT to vote 
     /// @param  signature  The cryptographic signature to be verified
-    function verifySignature(uint8 proposalId, uint8 tokenId, bytes memory signature) external view returns (bool);
+    function verifySignature(uint256 proposalId, uint256 tokenId, bytes memory signature) external view returns (bool);
 
     /// @notice construct Message Hash function
     /// @param  proposalId The ID of the proposal to approve
     /// @param  tokenId    The ID of the NFT to vote 
-    function constructMessageHash(uint8 proposalId, uint8 tokenId) external view returns (bytes32);
+    function constructMessageHash(uint256 proposalId, uint256 tokenId) external view returns (bytes32);
 
     /**************************************************
         Errors

--- a/src/interfaces/IRegistry.sol
+++ b/src/interfaces/IRegistry.sol
@@ -50,7 +50,7 @@ interface IRegistry {
     /// @param  limit The maximum number of Chambers to return
     /// @param  skip  The number of Chambers to skip
     /// @return       ChamberData[] An array of ChamberData structs
-    function getChambers(uint8 limit, uint8 skip) external view returns (ChamberData[] memory);
+    function getChambers(uint256 limit, uint256 skip) external view returns (ChamberData[] memory);
 
     /// @notice Sets the Chamber version
     /// @param chamberVersion The address of the Chamber version

--- a/test/Chamber.t.sol
+++ b/test/Chamber.t.sol
@@ -25,7 +25,7 @@ contract ChamberTest is Test {
     address registryProxyAddr;
     address chamberProxyAddr;
 
-    function getSignature(uint8 _proposalId, uint8 _tokenId, uint256 _privateKey)public view returns(bytes memory){
+    function getSignature(uint256 _proposalId, uint256 _tokenId, uint256 _privateKey)public view returns(bytes memory){
         bytes32 digest = chamber.constructMessageHash(_proposalId,_tokenId);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v); 
@@ -60,7 +60,7 @@ contract ChamberTest is Test {
         chamber.promote(250_000 ether, 4);
         chamber.promote(70_000 ether, 5);
 
-        (uint8[] memory leaders, uint256[] memory delegations) = chamber.getLeaderboard();
+        (uint256[] memory leaders, uint256[] memory delegations) = chamber.getLeaderboard();
         (leaders, delegations);
         vm.stopPrank();
     }
@@ -268,7 +268,7 @@ contract ChamberTest is Test {
         chamber.promote(2_000 ether, 2);
         chamber.promote(1_000 ether, 1);
 
-        (uint8[] memory _leaderboard, uint256[] memory _delegations) = chamber.getLeaderboard();
+        (uint256[] memory _leaderboard, uint256[] memory _delegations) = chamber.getLeaderboard();
         assertEq(_leaderboard[0], 5);
         assertEq(_leaderboard[1], 4);
         assertEq(_leaderboard[2], 3);
@@ -283,7 +283,7 @@ contract ChamberTest is Test {
 
         chamber.demote(5_000 ether, 5);
 
-        (uint8[] memory _leaderboard2, uint256[] memory _delegations2) = chamber.getLeaderboard();
+        (uint256[] memory _leaderboard2, uint256[] memory _delegations2) = chamber.getLeaderboard();
 
 		// The totalDelegation of tokenId 5 demote to 0
 		// but the position did not changed
@@ -314,7 +314,7 @@ contract ChamberTest is Test {
         mERC20.approve(address(chamber),15_000 ether );
         chamber.promote(4_000 ether, 4);
         
-        (uint8[] memory _leaderboard, uint256[] memory _delegations) = chamber.getLeaderboard();
+        (uint256[] memory _leaderboard, uint256[] memory _delegations) = chamber.getLeaderboard();
 
         assertEq(_leaderboard[0], 4);
         assertEq(_leaderboard[1], 5);

--- a/test/Proxy.t.sol
+++ b/test/Proxy.t.sol
@@ -49,11 +49,11 @@ contract ProxyUpgradeTest is Test {
         chamberProxy.getImplementation();
         mERC20.approve(address(chamberProxy), 1000);
         chamber.promote(1, 1);
-        (uint8[] memory leaders, uint256[] memory amounts) = chamber.getLeaderboard();
+        (uint256[] memory leaders, uint256[] memory amounts) = chamber.getLeaderboard();
         Chamber chamberV2 = new Chamber();
 
         chamberProxy.upgradeTo(address(chamberV2));
-        (uint8[] memory newLeaders, uint256[] memory newAmounts) = chamber.getLeaderboard();
+        (uint256[] memory newLeaders, uint256[] memory newAmounts) = chamber.getLeaderboard();
         assertEq(newLeaders[0], leaders[0]);
         assertEq(newAmounts[0], amounts[0]); 
         assertEq(chamberProxy.getImplementation(), address(chamberV2));

--- a/test/lifecycle/ProposalCycle.t.sol
+++ b/test/lifecycle/ProposalCycle.t.sol
@@ -64,15 +64,15 @@ contract ProposalCycleTest is Test {
 
     }
 
-    event Log(uint8[], uint256[]);
+    event Log(uint256[], uint256[]);
 
     function helperLogger() public {
         // for logging out the leaderboard
-        (uint8[] memory leaders, uint256[] memory delegation) = chamber.getLeaderboard();
+        (uint256[] memory leaders, uint256[] memory delegation) = chamber.getLeaderboard();
         emit Log(leaders, delegation);
     }
 
-    function getSignature(uint8 _proposalId, uint8 _tokenId, uint256 _privateKey)public view returns(bytes memory){
+    function getSignature(uint256 _proposalId, uint256 _tokenId, uint256 _privateKey)public view returns(bytes memory){
         bytes32 digest = chamber.constructMessageHash(_proposalId,_tokenId);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v); 
@@ -84,7 +84,7 @@ contract ProposalCycleTest is Test {
         
         // setup the chamber with delegations of 33k
         // from each of the team members above
-        for (uint8 i = 0; i <= lorians.length - 1; i++) {
+        for (uint256 i = 0; i <= lorians.length - 1; i++) {
             vm.deal(lorians[i], 100 ether);
             vm.prank(vm.addr(100));
             LORE.transfer(lorians[i], 33333 ether);
@@ -221,7 +221,7 @@ contract ProposalCycleTest is Test {
         assertTrue(state == IChamber.State.Executed);
 
         // Lorians should now have the amount of LORE
-        for (uint8 i = 0; i <= lorians.length - 1; i++) {
+        for (uint256 i = 0; i <= lorians.length - 1; i++) {
             assertEq(LORE.balanceOf(lorians[i]), amount);
         }
 

--- a/test/performance/ChamberPerf.t.sol
+++ b/test/performance/ChamberPerf.t.sol
@@ -66,7 +66,7 @@ contract ChamberPerfTest is Test {
     }
 
     // Test the performance of the promote function
-    function test_Chamber_perf_promote_one(uint8 tokenId, uint256 amount) public {
+    function test_Chamber_perf_promote_one(uint256 tokenId, uint256 amount) public {
 
         vm.assume(amount > 0);
         vm.assume(tokenId > 0);
@@ -81,8 +81,8 @@ contract ChamberPerfTest is Test {
 
         vm.assume(amount > 0);
 
-        uint8 runs = 50;
-        for (uint8 i = 1; i <= runs; i++) {
+        uint256 runs = 50;
+        for (uint256 i = 1; i <= runs; i++) {
             vm.startPrank(bones);
             deal(address(LORE), bones, amount);
             LORE.approve(address(chamber), amount);


### PR DESCRIPTION
# Upgrade: Mitigating Future Integer Storage Limitations

Upgraded all `uint8` to `uint256` to proactively address potential future issues related to limited integer storage. For instance, when the Proposal ID reaches 256, it would result in an error due to the previous limitation set to `uint8`. Similarly, the `tokenID` (NFT ID) has been updated to accommodate potential tokens with IDs exceeding 255, preventing any arising problems.
