### PR TITLE
fix: EIP-191 Compliance for Message Hash

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -276,7 +276,8 @@ contract Chamber is IChamber, Common {
         bytes memory signature
     ) public view returns (bool) {
         bytes32 messageHash = constructMessageHash(proposalId, tokenId);
-        address signer = ECDSA.recover(messageHash, signature);
+        bytes32 digest = toEthSignedMessageHash(messageHash);
+        address signer = ECDSA.recover(digest, signature);
         return signer == IERC721(memberToken).ownerOf(tokenId);
     }
 

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -35,4 +35,14 @@ abstract contract Common is Initializable, ReentrancyGuard, Context, ERC721Holde
 
     // Function signature for the cancelProposal function.
     bytes4 internal constant CANCEL_PROPOSAL_SELECTOR = bytes4(abi.encodeWithSignature("cancel(uint256)"));
+
+    // Function to get the signature of a message hash. (EIP-191)
+    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
+            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
+            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
+        }
+    }
 }

--- a/test/Chamber.t.sol
+++ b/test/Chamber.t.sol
@@ -22,9 +22,18 @@ contract ChamberTest is Test {
     address registryProxyAddr;
     address chamberProxyAddr;
 
+    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
+            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
+            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
+        }
+    }
+
     function getSignature(uint256 _proposalId, uint256 _tokenId, uint256 _privateKey)public view returns(bytes memory){
         bytes32 digest = chamber.constructMessageHash(_proposalId,_tokenId);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, toEthSignedMessageHash(digest));
         bytes memory signature = abi.encodePacked(r, s, v); 
         return signature;
     }

--- a/test/lifecycle/ProposalCycle.t.sol
+++ b/test/lifecycle/ProposalCycle.t.sol
@@ -72,9 +72,18 @@ contract ProposalCycleTest is Test {
         emit Log(leaders, delegation);
     }
 
+    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
+            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
+            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
+        }
+    }
+
     function getSignature(uint256 _proposalId, uint256 _tokenId, uint256 _privateKey)public view returns(bytes memory){
         bytes32 digest = chamber.constructMessageHash(_proposalId,_tokenId);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, toEthSignedMessageHash(digest));
         bytes memory signature = abi.encodePacked(r, s, v); 
         return signature;
     }


### PR DESCRIPTION
# EIP-191 Compliance for Message Hash

To recover the signer address from a signature, we need to provide the message hash and signature, both of which must comply with the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) standard. In the previous version, the message hash was not compliant with EIP-191. After this change, the message hash is constructed as follows:

```solidity
bytes32 messageHash = constructMessageHash(proposalId, tokenId);
bytes32 digest = toEthSignedMessageHash(messageHash);
address signer = ECDSA.recover(digest, signature);
```

The `toEthSignedMessageHash` function is introduced to make the message hash EIP-191 compliant:

```solidity
function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {
    /// @solidity memory-safe-assembly
    assembly {
        mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
        mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
        digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
    }
}
```
This change ensures that the message hash used for signature recovery is EIP-191 compliant, improving security and compatibility with the Ethereum ecosystem.