### PR TITLE
fix: block revokeConfirmation after transaction cancel

### DIFF
--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -170,10 +170,16 @@ abstract contract Wallet {
 
     /**
      * @notice Revokes a previously given confirmation
+     * @dev Reverts via `notCancelled` after cancellation (consistent with {_confirmTransaction}).
      * @param tokenId The token ID revoking the confirmation
      * @param nonce The transaction index to revoke confirmation for
      */
-    function _revokeConfirmation(uint256 tokenId, uint256 nonce) internal txExists(nonce) notExecuted(nonce) {
+    function _revokeConfirmation(uint256 tokenId, uint256 nonce)
+        internal
+        txExists(nonce)
+        notExecuted(nonce)
+        notCancelled(nonce)
+    {
         WalletStorage storage $ = _getWalletStorage();
         if (!$.isConfirmed[nonce][tokenId]) revert IWallet.TransactionNotConfirmed();
 

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1338,6 +1338,28 @@ contract ChamberTest is Test {
         chamber.confirmTransaction(2, 0);
     }
 
+    function test_Chamber_RevokeConfirmation_AfterCancel_Reverts() public {
+        addDirectors();
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        vm.prank(user1);
+        chamber.cancelTransaction(1, 0);
+        vm.prank(user2);
+        chamber.cancelTransaction(2, 0);
+        vm.prank(user3);
+        chamber.cancelTransaction(3, 0);
+        assertTrue(chamber.getCancelled(0));
+
+        vm.prank(user2);
+        vm.expectRevert(IWallet.TransactionAlreadyCancelled.selector);
+        chamber.revokeConfirmation(2, 0);
+    }
+
     function test_Chamber_CancelTransaction_DoubleVote_Reverts() public {
         addDirectors();
 


### PR DESCRIPTION
## Summary

- Apply the `notCancelled` modifier to `Wallet._revokeConfirmation`, matching `_confirmTransaction` so cancelled multisig proposals cannot have their confirmation count decremented afterward.
- Add `test_Chamber_RevokeConfirmation_AfterCancel_Reverts` to lock in the behaviour.

This removes misleading on-chain multisig counters for explorers and UIs once a proposal has been cancelled (execution was already forbidden).

## Test plan

- [x] `forge test --match-test test_Chamber_RevokeConfirmation_AfterCancel_Reverts`
- [ ] `forge test` (full contracts suite)


Made with [Cursor](https://cursor.com)