### PR TITLE
fix(chamber): close M-01 director impersonation via custom ERC-1271

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -12,7 +12,6 @@ import {
     ERC4626Upgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {ERC20Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
-import {IERC1271} from "lib/openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
 import {
     ReentrancyGuardUpgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
@@ -655,24 +654,12 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     function _isDirector(uint256 tokenId) internal view {
         if (tokenId == 0) revert IChamber.NotDirector();
 
+        // NFT owners (EOA or contract) are directors only when they submit as themselves.
+        // The previous ERC-1271 path treated `abi.encode(msg.sender)` as a signature and
+        // issued a CALL from this view helper, so a promiscuous 1271 owner could
+        // impersonate the director and reenter ungated functions.
         address owner = _getChamberStorage().nft.ownerOf(tokenId);
-
-        bool isOwner = (owner == msg.sender);
-
-        if (!isOwner && owner.code.length > 0) {
-            bytes32 hash;
-            // forge-lint: disable-next-line(asm-keccak256)
-            hash = keccak256(abi.encodePacked("DirectorAuth", address(this), tokenId, msg.sender));
-            try IERC1271(owner).isValidSignature(hash, abi.encode(msg.sender)) returns (bytes4 magicValue) {
-                if (magicValue == IERC1271.isValidSignature.selector) {
-                    isOwner = true;
-                }
-            } catch {
-                // Ignore failure, remain isOwner = false
-            }
-        }
-
-        if (!isOwner) revert IChamber.NotDirector();
+        if (owner != msg.sender) revert IChamber.NotDirector();
 
         BoardStorage storage $b = _getBoardStorage();
         uint256 current = $b.head;

--- a/contracts/test/findings/OffensiveReviewFindings.t.sol
+++ b/contracts/test/findings/OffensiveReviewFindings.t.sol
@@ -132,8 +132,8 @@ contract OffensiveReviewFindingsTest is Test {
         assertTrue(executed);
     }
 
-    /// Finding 2: permissive ERC-1271 owner contract grants director rights to any caller
-    function test_Finding2_PermissiveERC1271_AnyCallerActsAsDirector() public {
+    /// Finding 2 (M-01): a promiscuous ERC-1271 owner cannot authorize a random caller
+    function test_Finding2_PermissiveERC1271_RandomCallerIsNotDirector() public {
         PermissiveERC1271Wallet wallet = new PermissiveERC1271Wallet();
         uint256 tokenId = 99;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
@@ -149,9 +149,10 @@ contract OffensiveReviewFindingsTest is Test {
 
         address randomCaller = address(0xDEAD);
         vm.prank(randomCaller);
+        vm.expectRevert(IChamber.NotDirector.selector);
         chamber.submitTransaction(tokenId, address(0x9999), 0, "");
 
-        assertEq(chamber.getTransactionCount(), 1, "permissive ERC1271 let non-owner act as director");
+        assertEq(chamber.getTransactionCount(), 0, "promiscuous ERC1271 must not authorize a random caller");
     }
 
     /// Finding 3: anyone can spam chamber creation (griefing / indexing bloat)

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1707,6 +1707,7 @@ contract ChamberTest is Test {
         token.approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
         chamber.submitTransaction(tokenId, address(0x3), 0, "");
         vm.stopPrank();
 

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -32,13 +32,6 @@ contract MockERC1271Wallet {
     }
 }
 
-/// @dev A contract that always reverts on isValidSignature
-contract RevertingERC1271 {
-    function isValidSignature(bytes32, bytes memory) external pure returns (bytes4) {
-        revert("always reverts");
-    }
-}
-
 /// @dev A minimal Chamber contract that implements IERC1271 for testing
 contract MockChamberERC1271 {
     address public authorizedAddress;
@@ -1702,38 +1695,44 @@ contract ChamberTest is Test {
         chamber.submitBatchTransactions(1, targets, values, data);
     }
 
-    // ─── _isDirector: ERC-1271 contract-owner authorisation ───────────
+    // ─── _isDirector: only the NFT owner (msg.sender == owner) ───────────
 
-    function test_Chamber_IsDirector_ERC1271_Valid() public {
-        // user1 owns the ERC1271 wallet; user1 can act as director via ERC-1271
-        address authorized = address(0xABCD);
-        MockERC1271Wallet wallet = new MockERC1271Wallet(authorized);
+    function test_Chamber_IsDirector_EOAOwner_Works() public {
+        uint256 tokenId = 1;
+        uint256 amount = 1 ether;
+        MockERC721(address(nft)).mintWithTokenId(user1, tokenId);
+        MockERC20(address(token)).mint(user1, amount);
 
-        // Mint NFT to the wallet (contract)
+        vm.startPrank(user1);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user1);
+        chamber.delegate(tokenId, 1);
+        chamber.submitTransaction(tokenId, address(0x3), 0, "");
+        vm.stopPrank();
+
+        assertEq(chamber.getTransactionCount(), 1);
+    }
+
+    function test_Chamber_IsDirector_ContractOwnerCallingAsItself_Works() public {
+        MockERC1271Wallet wallet = new MockERC1271Wallet(address(0xABCD));
         uint256 tokenId = 10;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
 
-        // Mint tokens and deposit so the tokenId enters the board
         MockERC20(address(token)).mint(address(this), 1 ether);
         token.approve(address(chamber), 1 ether);
         chamber.deposit(1 ether, address(this));
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        // authorized address submits a transaction using the contract's tokenId
-        // _isDirector: owner=wallet (contract), msg.sender=authorized ≠ wallet
-        //              → ERC1271 check → magic value → isOwner=true
-        vm.prank(authorized);
+        vm.prank(address(wallet));
         chamber.submitTransaction(tokenId, address(0x9999), 0, "");
 
         assertEq(chamber.getTransactionCount(), 1);
     }
 
-    function test_Chamber_IsDirector_ERC1271_Reverts_Unauthorized() public {
-        address authorized = address(0xABCD);
-        address unauthorized = address(0xDEAD);
-        MockERC1271Wallet wallet = new MockERC1271Wallet(authorized);
-
+    function test_Chamber_IsDirector_Promiscuous1271_CannotAuthorizeRandomCaller() public {
+        // Wallet would accept any encoded caller as a 1271 "signature"; Chamber must not consult it.
+        MockERC1271Wallet wallet = new MockERC1271Wallet(address(0xDEAD));
         uint256 tokenId = 11;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
 
@@ -1742,27 +1741,11 @@ contract ChamberTest is Test {
         chamber.deposit(1 ether, address(this));
         chamber.delegate(tokenId, 1 ether);
 
-        // unauthorized address → ERC1271 returns 0xffffffff → NotDirector
-        vm.prank(unauthorized);
+        vm.prank(address(0xDEAD));
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.submitTransaction(tokenId, address(0x9999), 0, "");
-    }
 
-    function test_Chamber_IsDirector_ERC1271_CatchesRevert() public {
-        // When isValidSignature reverts, the catch block is hit → isOwner stays false
-        RevertingERC1271 revertingWallet = new RevertingERC1271();
-
-        uint256 tokenId = 12;
-        MockERC721(address(nft)).mintWithTokenId(address(revertingWallet), tokenId);
-
-        MockERC20(address(token)).mint(address(this), 1 ether);
-        token.approve(address(chamber), 1 ether);
-        chamber.deposit(1 ether, address(this));
-        chamber.delegate(tokenId, 1 ether);
-
-        vm.prank(address(0xCAFE));
-        vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.submitTransaction(tokenId, address(0x9999), 0, "");
+        assertEq(chamber.getTransactionCount(), 0);
     }
 
     function test_ChamberAsDirector_ExecutesTransactionToAnotherChamber() public {
@@ -1814,9 +1797,9 @@ contract ChamberTest is Test {
         chamberB.delegate(tokenId2, 500e18);
         vm.roll(block.number + 1);
 
-        // 4. Chamber A (via authorizedAddress) submits a transaction on Chamber B
-        // This simulates Chamber A acting as director
+        // 4. Chamber A submits a transaction on Chamber B by calling as itself
         bytes memory testData = abi.encodeWithSignature("testFunction()");
+        vm.prank(address(chamberA));
         chamberB.submitTransaction(tokenId, address(0x1234), 0, testData);
 
         // Verify transaction was submitted
@@ -1827,6 +1810,7 @@ contract ChamberTest is Test {
         chamberB.confirmTransaction(tokenId2, 0);
 
         // 6. Chamber A executes the transaction
+        vm.prank(address(chamberA));
         chamberB.executeTransaction(tokenId, 0, testData);
 
         // Verify transaction executed
@@ -1902,11 +1886,11 @@ contract ChamberTest is Test {
         chamberB.delegate(tokenId3, 400e18);
         vm.roll(block.number + 1);
 
-        // 5. Chamber A (via authorizedAddress) submits a transaction on Chamber B
+        // 5. Chamber A submits a transaction on Chamber B by calling as itself
         // This transaction will transfer tokens from Chamber B to Chamber C
         bytes memory transferData = abi.encodeWithSelector(IERC20.transfer.selector, address(chamberC), transferAmount);
 
-        // Submit transaction to transfer tokens from Chamber B to Chamber C
+        vm.prank(address(chamberA));
         chamberB.submitTransaction(tokenId, address(token), 0, transferData);
 
         // Verify transaction was submitted
@@ -1925,6 +1909,7 @@ contract ChamberTest is Test {
         uint256 chamberCBalanceBefore = token.balanceOf(address(chamberC));
 
         // 8. Chamber A executes the transaction (transfer from Chamber B to Chamber C)
+        vm.prank(address(chamberA));
         chamberB.executeTransaction(tokenId, 0, transferData);
 
         // 9. Verify balances after execution


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes **M-01** on `_isDirector`. The previous custom ERC-1271 path hashed `DirectorAuth` + caller and treated `abi.encode(msg.sender)` as the signature. A promiscuous `isValidSignature` implementation could let any address act as that director, and the check used a normal CALL from a view helper used by state-changing modifiers.

**Fix (smallest safe option):** treat an NFT owner as a director only when `msg.sender == owner`. Contract wallets must submit themselves. No new operator marketplace, no remaining 1271 CALL.

Rebased onto current `main` (includes H-02 seating delay). `_isDirector` is owner-only + top seats + `_isSeatingMature`. Director tests roll one block after first seating so newly seated tokenIds are mature.

## Tests

- EOA owner still works
- Contract owner calling as itself works
- A promiscuous 1271 owner cannot authorize a random caller

M-02 and other findings are intentionally untouched.

## Test plan

- [x] `forge test` director-auth cases in `Chamber.t.sol` and `OffensiveReviewFindings.t.sol`
- [x] Confirm no remaining `DirectorAuth` / `IERC1271` usage in `Chamber.sol`
- [x] Full `forge test` locally on the original revision: 277 passed
- [ ] CI on rebased branch (Forge + Halmos)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70396544-8d38-43eb-9fe0-3a79685e336c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70396544-8d38-43eb-9fe0-3a79685e336c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

