### PR TITLE
Align BoardTypes and WalletTypes with on-chain packed storage (L-05)

### DIFF
--- a/contracts/src/types/BoardTypes.sol
+++ b/contracts/src/types/BoardTypes.sol
@@ -4,23 +4,27 @@ pragma solidity ^0.8.30;
 /**
  * @title BoardTypes
  * @author xhad, Loreum DAO LLC
- * @notice Legacy reference structs for documentation and offchain tooling.
- * @dev Canonical onchain layout is `Board.Node` (packed `uint128` links) and `Board.SeatUpdate`; do not assume byte-for-byte equivalence.
+ * @notice Shared structs matching on-chain `Board` storage layouts.
+ * @dev `Node.next` / `Node.prev` are `uint128` and pack into one slot, matching `Board.Node`.
+ *      `IBoard.getMember` ABI-widens those links to `uint256`; this library describes storage,
+ *      not that getter ABI.
  */
 library BoardTypes {
     /**
      * @notice Node structure for the doubly linked list
-     * @dev Each node represents a token delegation with links to maintain sorted order
+     * @dev Each node represents a token delegation with links to maintain sorted order.
+     *      next and prev are uint128, packed into one storage slot.
+     *      tokenIds > type(uint128).max are rejected at insertion time.
      * @param tokenId Unique identifier for the token
      * @param amount Total amount of tokens delegated to this node
      * @param next TokenId of the next node in the sorted list (0 if none)
      * @param prev TokenId of the previous node in the sorted list (0 if none)
      */
     struct Node {
-        uint256 tokenId;
-        uint256 amount;
-        uint256 next;
-        uint256 prev;
+        uint256 tokenId; // slot 0
+        uint256 amount; // slot 1
+        uint128 next; // slot 2 lower 128 bits
+        uint128 prev; // slot 2 upper 128 bits
     }
 
     /**

--- a/contracts/src/types/WalletTypes.sol
+++ b/contracts/src/types/WalletTypes.sol
@@ -4,23 +4,27 @@ pragma solidity ^0.8.30;
 /**
  * @title WalletTypes
  * @author xhad, Loreum DAO LLC
- * @notice Legacy reference struct for documentation and offchain tooling.
- * @dev Canonical onchain layout is `Wallet.Transaction` with `bytes32 dataHash`, not inline `bytes data`.
+ * @notice Shared struct matching on-chain `Wallet.Transaction` storage.
+ * @dev Uses `bytes32 dataHash` (keccak256 of calldata), not inline `bytes data`.
+ *      Matches `Wallet.Transaction` and `IWallet.getTransaction`.
  */
 library WalletTypes {
     /**
      * @notice Structure representing a transaction in the wallet
+     * @dev Slot packing: executed (bool, 1 byte) + confirmations (uint8, 1 byte) +
+     *      target (address, 20 bytes) = 22 bytes in slot 0. value fills slot 1.
+     *      dataHash (bytes32) fills slot 2 — hash-only calldata storage.
      * @param executed Whether the transaction has been executed
      * @param confirmations Number of confirmations received for this transaction
      * @param target The destination address for the transaction
      * @param value The amount of ETH to send with the transaction
-     * @param data The calldata to be executed
+     * @param dataHash keccak256 of the original calldata; verified at execution time
      */
     struct Transaction {
         bool executed;
         uint8 confirmations;
         address target;
         uint256 value;
-        bytes data;
+        bytes32 dataHash;
     }
 }

--- a/contracts/test/unit/TypesLayout.t.sol
+++ b/contracts/test/unit/TypesLayout.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "lib/forge-std/src/Test.sol";
+import {BoardTypes} from "src/types/BoardTypes.sol";
+import {WalletTypes} from "src/types/WalletTypes.sol";
+import {MockBoard} from "test/mock/MockBoard.sol";
+import {MockWallet} from "test/mock/MockWallet.sol";
+
+/// @dev Stores a `BoardTypes.Node` so tests can inspect packed slot layout.
+contract BoardTypesStorageProbe {
+    BoardTypes.Node public node;
+
+    function write(uint256 tokenId, uint256 amount, uint128 next, uint128 prev) external {
+        node = BoardTypes.Node({tokenId: tokenId, amount: amount, next: next, prev: prev});
+    }
+}
+
+/// @dev Stores a `WalletTypes.Transaction` so tests can inspect hash-only slot layout.
+contract WalletTypesStorageProbe {
+    WalletTypes.Transaction public transaction;
+
+    function write(bool executed, uint8 confirmations, address target, uint256 value, bytes32 dataHash) external {
+        transaction = WalletTypes.Transaction({
+            executed: executed,
+            confirmations: confirmations,
+            target: target,
+            value: value,
+            dataHash: dataHash
+        });
+    }
+}
+
+/**
+ * @notice Compile + layout checks that helper types match on-chain Board/Wallet storage.
+ * @dev Assigning helper fields into `MockBoard.Node` / `MockWallet.Transaction` fails to
+ *      compile if `next`/`prev` are still `uint256` or if `data` is still dynamic `bytes`.
+ */
+contract TypesLayoutTest is Test {
+    function test_BoardTypesNodeAssignableToOnchainNode() public pure {
+        BoardTypes.Node memory helper = BoardTypes.Node({tokenId: 1, amount: 2, next: uint128(3), prev: uint128(4)});
+        MockBoard.Node memory onchain = _copyBoardNodeToOnchain(helper);
+        assertEq(onchain.tokenId, 1);
+        assertEq(onchain.amount, 2);
+        assertEq(onchain.next, 3);
+        assertEq(onchain.prev, 4);
+    }
+
+    function test_BoardTypesSeatUpdateAssignableToOnchainSeatUpdate() public pure {
+        uint256[] memory supporters = new uint256[](1);
+        supporters[0] = 7;
+        BoardTypes.SeatUpdate memory helper =
+            BoardTypes.SeatUpdate({proposedSeats: 5, timestamp: 11, requiredQuorum: 3, supporters: supporters});
+        MockBoard.SeatUpdate memory onchain = _copySeatUpdateToOnchain(helper);
+        assertEq(onchain.proposedSeats, 5);
+        assertEq(onchain.timestamp, 11);
+        assertEq(onchain.requiredQuorum, 3);
+        assertEq(onchain.supporters.length, 1);
+        assertEq(onchain.supporters[0], 7);
+    }
+
+    function test_WalletTypesTransactionAssignableToOnchainTransaction() public pure {
+        bytes32 dataHash = keccak256("calldata");
+        WalletTypes.Transaction memory helper = WalletTypes.Transaction({
+            executed: true,
+            confirmations: 2,
+            target: address(0xBEEF),
+            value: 99,
+            dataHash: dataHash
+        });
+        MockWallet.Transaction memory onchain = _copyWalletTransactionToOnchain(helper);
+        assertTrue(onchain.executed);
+        assertEq(onchain.confirmations, 2);
+        assertEq(onchain.target, address(0xBEEF));
+        assertEq(onchain.value, 99);
+        assertEq(onchain.dataHash, dataHash);
+    }
+
+    function test_BoardTypesNodePacksNextPrevInOneSlot() public {
+        BoardTypesStorageProbe probe = new BoardTypesStorageProbe();
+        probe.write(1, 2, uint128(3), uint128(4));
+
+        assertEq(uint256(vm.load(address(probe), bytes32(uint256(0)))), 1);
+        assertEq(uint256(vm.load(address(probe), bytes32(uint256(1)))), 2);
+
+        uint256 packed = uint256(vm.load(address(probe), bytes32(uint256(2))));
+        assertEq(uint256(uint128(packed)), 3);
+        assertEq(packed >> 128, 4);
+    }
+
+    function test_WalletTypesTransactionStoresDataHashInSlot2() public {
+        WalletTypesStorageProbe probe = new WalletTypesStorageProbe();
+        bytes32 dataHash = keccak256("calldata");
+        address target = address(0xBEEF);
+        probe.write(true, 2, target, 99, dataHash);
+
+        uint256 slot0 = uint256(vm.load(address(probe), bytes32(uint256(0))));
+        assertEq(slot0 & 0xff, 1);
+        assertEq((slot0 >> 8) & 0xff, 2);
+        assertEq(address(uint160(slot0 >> 16)), target);
+
+        assertEq(uint256(vm.load(address(probe), bytes32(uint256(1)))), 99);
+        assertEq(vm.load(address(probe), bytes32(uint256(2))), dataHash);
+    }
+
+    /// @dev uint256 helper.next/prev would not implicitly assign into packed uint128 on-chain fields.
+    function _copyBoardNodeToOnchain(BoardTypes.Node memory helper) private pure returns (MockBoard.Node memory onchain) {
+        onchain = MockBoard.Node({tokenId: helper.tokenId, amount: helper.amount, next: helper.next, prev: helper.prev});
+    }
+
+    function _copySeatUpdateToOnchain(BoardTypes.SeatUpdate memory helper)
+        private
+        pure
+        returns (MockBoard.SeatUpdate memory onchain)
+    {
+        onchain = MockBoard.SeatUpdate({
+            proposedSeats: helper.proposedSeats,
+            timestamp: helper.timestamp,
+            requiredQuorum: helper.requiredQuorum,
+            supporters: helper.supporters
+        });
+    }
+
+    /// @dev A leftover `bytes data` field would not populate `dataHash` here.
+    function _copyWalletTransactionToOnchain(WalletTypes.Transaction memory helper)
+        private
+        pure
+        returns (MockWallet.Transaction memory onchain)
+    {
+        onchain = MockWallet.Transaction({
+            executed: helper.executed,
+            confirmations: helper.confirmations,
+            target: helper.target,
+            value: helper.value,
+            dataHash: helper.dataHash
+        });
+    }
+}

--- a/contracts/test/unit/TypesLayout.t.sol
+++ b/contracts/test/unit/TypesLayout.t.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.30;
 
 import {Test} from "lib/forge-std/src/Test.sol";
+import {Board} from "src/Board.sol";
+import {Wallet} from "src/Wallet.sol";
 import {BoardTypes} from "src/types/BoardTypes.sol";
 import {WalletTypes} from "src/types/WalletTypes.sol";
-import {MockBoard} from "test/mock/MockBoard.sol";
-import {MockWallet} from "test/mock/MockWallet.sol";
 
 /// @dev Stores a `BoardTypes.Node` so tests can inspect packed slot layout.
 contract BoardTypesStorageProbe {
@@ -33,13 +33,13 @@ contract WalletTypesStorageProbe {
 
 /**
  * @notice Compile + layout checks that helper types match on-chain Board/Wallet storage.
- * @dev Assigning helper fields into `MockBoard.Node` / `MockWallet.Transaction` fails to
- *      compile if `next`/`prev` are still `uint256` or if `data` is still dynamic `bytes`.
+ * @dev Assigning helper fields into `Board.Node` / `Wallet.Transaction` fails to compile
+ *      if `next`/`prev` are still `uint256` or if `data` is still dynamic `bytes`.
  */
 contract TypesLayoutTest is Test {
     function test_BoardTypesNodeAssignableToOnchainNode() public pure {
         BoardTypes.Node memory helper = BoardTypes.Node({tokenId: 1, amount: 2, next: uint128(3), prev: uint128(4)});
-        MockBoard.Node memory onchain = _copyBoardNodeToOnchain(helper);
+        Board.Node memory onchain = _copyBoardNodeToOnchain(helper);
         assertEq(onchain.tokenId, 1);
         assertEq(onchain.amount, 2);
         assertEq(onchain.next, 3);
@@ -51,7 +51,7 @@ contract TypesLayoutTest is Test {
         supporters[0] = 7;
         BoardTypes.SeatUpdate memory helper =
             BoardTypes.SeatUpdate({proposedSeats: 5, timestamp: 11, requiredQuorum: 3, supporters: supporters});
-        MockBoard.SeatUpdate memory onchain = _copySeatUpdateToOnchain(helper);
+        Board.SeatUpdate memory onchain = _copySeatUpdateToOnchain(helper);
         assertEq(onchain.proposedSeats, 5);
         assertEq(onchain.timestamp, 11);
         assertEq(onchain.requiredQuorum, 3);
@@ -68,7 +68,7 @@ contract TypesLayoutTest is Test {
             value: 99,
             dataHash: dataHash
         });
-        MockWallet.Transaction memory onchain = _copyWalletTransactionToOnchain(helper);
+        Wallet.Transaction memory onchain = _copyWalletTransactionToOnchain(helper);
         assertTrue(onchain.executed);
         assertEq(onchain.confirmations, 2);
         assertEq(onchain.target, address(0xBEEF));
@@ -84,6 +84,8 @@ contract TypesLayoutTest is Test {
         assertEq(uint256(vm.load(address(probe), bytes32(uint256(1)))), 2);
 
         uint256 packed = uint256(vm.load(address(probe), bytes32(uint256(2))));
+        // Low 128 bits are `next`; the downcast discards only `prev`.
+        // forge-lint: disable-next-line(unsafe-typecast)
         assertEq(uint256(uint128(packed)), 3);
         assertEq(packed >> 128, 4);
     }
@@ -97,6 +99,8 @@ contract TypesLayoutTest is Test {
         uint256 slot0 = uint256(vm.load(address(probe), bytes32(uint256(0))));
         assertEq(slot0 & 0xff, 1);
         assertEq((slot0 >> 8) & 0xff, 2);
+        // Target occupies the high 160 bits of the packed header slot.
+        // forge-lint: disable-next-line(unsafe-typecast)
         assertEq(address(uint160(slot0 >> 16)), target);
 
         assertEq(uint256(vm.load(address(probe), bytes32(uint256(1)))), 99);
@@ -104,16 +108,16 @@ contract TypesLayoutTest is Test {
     }
 
     /// @dev uint256 helper.next/prev would not implicitly assign into packed uint128 on-chain fields.
-    function _copyBoardNodeToOnchain(BoardTypes.Node memory helper) private pure returns (MockBoard.Node memory onchain) {
-        onchain = MockBoard.Node({tokenId: helper.tokenId, amount: helper.amount, next: helper.next, prev: helper.prev});
+    function _copyBoardNodeToOnchain(BoardTypes.Node memory helper) private pure returns (Board.Node memory onchain) {
+        onchain = Board.Node({tokenId: helper.tokenId, amount: helper.amount, next: helper.next, prev: helper.prev});
     }
 
     function _copySeatUpdateToOnchain(BoardTypes.SeatUpdate memory helper)
         private
         pure
-        returns (MockBoard.SeatUpdate memory onchain)
+        returns (Board.SeatUpdate memory onchain)
     {
-        onchain = MockBoard.SeatUpdate({
+        onchain = Board.SeatUpdate({
             proposedSeats: helper.proposedSeats,
             timestamp: helper.timestamp,
             requiredQuorum: helper.requiredQuorum,
@@ -125,9 +129,9 @@ contract TypesLayoutTest is Test {
     function _copyWalletTransactionToOnchain(WalletTypes.Transaction memory helper)
         private
         pure
-        returns (MockWallet.Transaction memory onchain)
+        returns (Wallet.Transaction memory onchain)
     {
-        onchain = MockWallet.Transaction({
+        onchain = Wallet.Transaction({
             executed: helper.executed,
             confirmations: helper.confirmations,
             target: helper.target,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates security finding **L-05**: `BoardTypes` and `WalletTypes` were leftover helper structs that no longer matched on-chain storage, so off-chain/tooling consumers could treat them as ABI or storage types.

Verified in code:
- `Board.Node` packs `uint128 next` / `uint128 prev` into one slot; `BoardTypes.Node` still used `uint256` links.
- `Wallet.Transaction` stores `bytes32 dataHash`; `WalletTypes.Transaction` still had inline `bytes data`.

## Change

- Update `BoardTypes.Node` to the packed `uint128` link layout used by `Board.Node`.
- Update `WalletTypes.Transaction` to hash-only `bytes32 dataHash`, matching `Wallet.Transaction`.
- Refresh NatSpec so the libraries are documented as on-chain storage shapes (and note that `IBoard.getMember` ABI-widens links to `uint256`).
- Add `contracts/test/unit/TypesLayout.t.sol`, which imports both libraries and asserts assignability plus slot packing.

`Chamber` / `Board` / `Wallet` storage is unchanged.

## Test plan

- [x] `forge build` in `contracts/`
- [x] `forge test --match-path test/unit/TypesLayout.t.sol` (5 passed)
- [x] `forge test --match-path test/unit/{Board,Wallet,Chamber}.t.sol` (161 passed)
- [x] GitHub CI (Forge Tests + Halmos) passed on `083e0b1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2474aa72-bcf1-4f07-9f01-43bb2837a71c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2474aa72-bcf1-4f07-9f01-43bb2837a71c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

