### PR TITLE
fix(registry): cap unbounded index getters (L-01)

### DIFF
--- a/contracts/src/Registry.sol
+++ b/contracts/src/Registry.sol
@@ -20,6 +20,11 @@ contract Registry is AccessControl, Initializable, IRegistry {
     /// @notice Role for managing the registry configuration
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
+    /// @notice Maximum addresses a single registry getter may return
+    /// @dev Unbounded copies of `chambers` / by-asset / child / asset indexes can OOG.
+    ///      Paginated getters are the supported API; convenience getters return this first page.
+    uint256 public constant MAX_PAGE_SIZE = 256;
+
     /**
      * @notice ERC-7201 namespaced storage layout for Registry
      * @dev Address fields (20 bytes each) cannot be packed together in the same 32-byte slot.
@@ -172,11 +177,12 @@ contract Registry is AccessControl, Initializable, IRegistry {
     }
 
     /**
-     * @notice Returns all deployed chambers
+     * @notice Returns the first page of deployed chambers
+     * @dev Capped at `MAX_PAGE_SIZE`. Use `getChambers(limit, skip)` to page the full index.
      * @return Array of chamber addresses
      */
     function getAllChambers() external view returns (address[] memory) {
-        return _getRegistryStorage().chambers;
+        return _page(_getRegistryStorage().chambers, MAX_PAGE_SIZE, 0);
     }
 
     /**
@@ -189,29 +195,12 @@ contract Registry is AccessControl, Initializable, IRegistry {
 
     /**
      * @notice Returns a subset of chambers for pagination
-     * @param limit The maximum number of chambers to return
+     * @param limit The maximum number of chambers to return (clamped to `MAX_PAGE_SIZE`)
      * @param skip The number of chambers to skip
      * @return Array of chamber addresses
      */
     function getChambers(uint256 limit, uint256 skip) external view returns (address[] memory) {
-        address[] storage allChambers = _getRegistryStorage().chambers;
-        uint256 total = allChambers.length;
-        if (skip >= total) {
-            return new address[](0);
-        }
-
-        uint256 remaining = total - skip;
-        uint256 count = remaining < limit ? remaining : limit;
-        address[] memory result = new address[](count);
-
-        for (uint256 i = 0; i < count;) {
-            result[i] = allChambers[skip + i];
-            unchecked {
-                ++i;
-            }
-        }
-
-        return result;
+        return _page(_getRegistryStorage().chambers, limit, skip);
     }
 
     /**
@@ -224,20 +213,64 @@ contract Registry is AccessControl, Initializable, IRegistry {
     }
 
     /**
-     * @notice Returns all chambers for a given asset
+     * @notice Returns the first page of chambers for a given asset
+     * @dev Capped at `MAX_PAGE_SIZE`. Use `getChambersByAsset(asset, limit, skip)` to page.
      * @param asset The asset address
      * @return Array of chamber addresses
      */
     function getChambersByAsset(address asset) external view returns (address[] memory) {
-        return _getRegistryStorage().chambersByAsset[asset];
+        return _page(_getRegistryStorage().chambersByAsset[asset], MAX_PAGE_SIZE, 0);
     }
 
     /**
-     * @notice Returns all unique assets (Organizations)
+     * @notice Returns a paginated list of chambers for a given asset
+     * @param asset The asset address
+     * @param limit The maximum number of chambers to return (clamped to `MAX_PAGE_SIZE`)
+     * @param skip The number of chambers to skip
+     * @return Array of chamber addresses
+     */
+    function getChambersByAsset(address asset, uint256 limit, uint256 skip)
+        external
+        view
+        returns (address[] memory)
+    {
+        return _page(_getRegistryStorage().chambersByAsset[asset], limit, skip);
+    }
+
+    /**
+     * @notice Returns the number of chambers indexed for a given asset
+     * @param asset The asset address
+     * @return The number of chambers using `asset`
+     */
+    function getChambersByAssetCount(address asset) external view returns (uint256) {
+        return _getRegistryStorage().chambersByAsset[asset].length;
+    }
+
+    /**
+     * @notice Returns the first page of unique assets (Organizations)
+     * @dev Capped at `MAX_PAGE_SIZE`. Use `getAssets(limit, skip)` to page.
      * @return Array of asset addresses
      */
     function getAssets() external view returns (address[] memory) {
-        return _getRegistryStorage().assets;
+        return _page(_getRegistryStorage().assets, MAX_PAGE_SIZE, 0);
+    }
+
+    /**
+     * @notice Returns a paginated list of unique assets
+     * @param limit The maximum number of assets to return (clamped to `MAX_PAGE_SIZE`)
+     * @param skip The number of assets to skip
+     * @return Array of asset addresses
+     */
+    function getAssets(uint256 limit, uint256 skip) external view returns (address[] memory) {
+        return _page(_getRegistryStorage().assets, limit, skip);
+    }
+
+    /**
+     * @notice Returns the number of unique assets indexed by the registry
+     * @return The number of assets
+     */
+    function getAssetCount() external view returns (uint256) {
+        return _getRegistryStorage().assets.length;
     }
 
     /**
@@ -250,12 +283,73 @@ contract Registry is AccessControl, Initializable, IRegistry {
     }
 
     /**
-     * @notice Returns all child chambers for a given parent chamber
+     * @notice Returns the first page of child chambers for a given parent chamber
+     * @dev Capped at `MAX_PAGE_SIZE`. Child links are permissionless index metadata
+     *      (anyone may create a chamber whose asset is an existing chamber share token).
+     *      Use `getChildChambers(chamber, limit, skip)` to page the full index.
      * @param chamber The parent chamber address
      * @return Array of child chamber addresses
      */
     function getChildChambers(address chamber) external view returns (address[] memory) {
-        return _getRegistryStorage().childChambers[chamber];
+        return _page(_getRegistryStorage().childChambers[chamber], MAX_PAGE_SIZE, 0);
+    }
+
+    /**
+     * @notice Returns a paginated list of child chambers for a given parent chamber
+     * @param chamber The parent chamber address
+     * @param limit The maximum number of children to return (clamped to `MAX_PAGE_SIZE`)
+     * @param skip The number of children to skip
+     * @return Array of child chamber addresses
+     */
+    function getChildChambers(address chamber, uint256 limit, uint256 skip)
+        external
+        view
+        returns (address[] memory)
+    {
+        return _page(_getRegistryStorage().childChambers[chamber], limit, skip);
+    }
+
+    /**
+     * @notice Returns the number of child chambers indexed under a parent
+     * @param chamber The parent chamber address
+     * @return The number of child index entries
+     */
+    function getChildChamberCount(address chamber) external view returns (uint256) {
+        return _getRegistryStorage().childChambers[chamber].length;
+    }
+
+    /**
+     * @notice Copies a bounded slice from a storage address array
+     * @dev `limit` of 0 returns an empty page. Limits above `MAX_PAGE_SIZE` are clamped.
+     * @param items Source storage array
+     * @param limit Requested page size
+     * @param skip Number of entries to skip
+     * @return result Memory copy of the selected slice
+     */
+    function _page(address[] storage items, uint256 limit, uint256 skip)
+        internal
+        view
+        returns (address[] memory result)
+    {
+        uint256 total = items.length;
+        if (skip >= total || limit == 0) {
+            return new address[](0);
+        }
+
+        if (limit > MAX_PAGE_SIZE) {
+            limit = MAX_PAGE_SIZE;
+        }
+
+        uint256 remaining = total - skip;
+        uint256 count = remaining < limit ? remaining : limit;
+        result = new address[](count);
+
+        for (uint256 i = 0; i < count;) {
+            result[i] = items[skip + i];
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     /**

--- a/contracts/src/Registry.sol
+++ b/contracts/src/Registry.sol
@@ -229,11 +229,7 @@ contract Registry is AccessControl, Initializable, IRegistry {
      * @param skip The number of chambers to skip
      * @return Array of chamber addresses
      */
-    function getChambersByAsset(address asset, uint256 limit, uint256 skip)
-        external
-        view
-        returns (address[] memory)
-    {
+    function getChambersByAsset(address asset, uint256 limit, uint256 skip) external view returns (address[] memory) {
         return _page(_getRegistryStorage().chambersByAsset[asset], limit, skip);
     }
 
@@ -301,11 +297,7 @@ contract Registry is AccessControl, Initializable, IRegistry {
      * @param skip The number of children to skip
      * @return Array of child chamber addresses
      */
-    function getChildChambers(address chamber, uint256 limit, uint256 skip)
-        external
-        view
-        returns (address[] memory)
-    {
+    function getChildChambers(address chamber, uint256 limit, uint256 skip) external view returns (address[] memory) {
         return _page(_getRegistryStorage().childChambers[chamber], limit, skip);
     }
 

--- a/contracts/src/interfaces/IRegistry.sol
+++ b/contracts/src/interfaces/IRegistry.sol
@@ -18,9 +18,30 @@ interface IRegistry {
     function getParentChamber(address chamber) external view returns (address parent);
 
     /**
-     * @notice Returns all child chambers registered under a parent chamber.
+     * @notice Returns a capped first page of child chambers registered under a parent.
+     * @dev Convenience wrapper. Prefer `getChildChambers(chamber, limit, skip)` plus
+     *      `getChildChamberCount` when the index may exceed the page cap.
      * @param chamber The parent chamber proxy address
-     * @return children Array of child chamber addresses (may be empty)
+     * @return children First page of child chamber addresses (may be empty)
      */
     function getChildChambers(address chamber) external view returns (address[] memory children);
+
+    /**
+     * @notice Returns a paginated slice of child chambers registered under a parent.
+     * @param chamber The parent chamber proxy address
+     * @param limit Maximum addresses to return (clamped to the registry page cap)
+     * @param skip Number of child entries to skip
+     * @return children Page of child chamber addresses (may be empty)
+     */
+    function getChildChambers(address chamber, uint256 limit, uint256 skip)
+        external
+        view
+        returns (address[] memory children);
+
+    /**
+     * @notice Returns the number of child chambers indexed under a parent.
+     * @param chamber The parent chamber proxy address
+     * @return count Length of the child index (permissionless registrations included)
+     */
+    function getChildChamberCount(address chamber) external view returns (uint256 count);
 }

--- a/contracts/test/unit/Registry.t.sol
+++ b/contracts/test/unit/Registry.t.sol
@@ -296,4 +296,142 @@ contract RegistryTest is Test {
         vm.expectRevert();
         registry.setChamberImplementation(address(newImpl));
     }
+
+    /// @dev ERC-7201 `RegistryStorage` namespace; `chambers` is field index 2.
+    bytes32 internal constant _REGISTRY_STORAGE_SLOT =
+        0xf6315592a63ddf317bd8b41aa1ba894c04251b3cfbd8a95258342cd83f2a4600;
+
+    function _chambersArraySlot() internal pure returns (bytes32) {
+        return bytes32(uint256(_REGISTRY_STORAGE_SLOT) + 2);
+    }
+
+    function _assetsArraySlot() internal pure returns (bytes32) {
+        return bytes32(uint256(_REGISTRY_STORAGE_SLOT) + 3);
+    }
+
+    function _chambersByAssetArraySlot(address asset) internal pure returns (bytes32) {
+        return keccak256(abi.encode(asset, bytes32(uint256(_REGISTRY_STORAGE_SLOT) + 6)));
+    }
+
+    function _childChambersArraySlot(address parent) internal pure returns (bytes32) {
+        return keccak256(abi.encode(parent, bytes32(uint256(_REGISTRY_STORAGE_SLOT) + 8)));
+    }
+
+    function test_Registry_GetChambers_LimitZero_Empty() public {
+        registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        address[] memory page = registry.getChambers(0, 0);
+        assertEq(page.length, 0);
+    }
+
+    function test_Registry_GetChambers_ClampsOversizedLimit() public {
+        address first = registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        vm.store(address(registry), _chambersArraySlot(), bytes32(uint256(10_000)));
+
+        address[] memory page = registry.getChambers(type(uint256).max, 0);
+        assertEq(page.length, registry.MAX_PAGE_SIZE());
+        assertEq(page[0], first);
+    }
+
+    function test_Registry_GetAllChambers_CapsAtMaxPageSize() public {
+        address first = registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        vm.store(address(registry), _chambersArraySlot(), bytes32(uint256(10_000)));
+
+        assertEq(registry.getChamberCount(), 10_000);
+
+        address[] memory page = registry.getAllChambers();
+        assertEq(page.length, registry.MAX_PAGE_SIZE());
+        assertEq(page[0], first);
+
+        address[] memory next = registry.getChambers(registry.MAX_PAGE_SIZE(), registry.MAX_PAGE_SIZE());
+        assertEq(next.length, registry.MAX_PAGE_SIZE());
+    }
+
+    function test_Registry_GetChambersByAsset_PaginationAndCap() public {
+        address chamber1 = registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        address chamber2 = registry.createChamber(address(token), address(nft), 3, "C2", "C2");
+        address chamber3 = registry.createChamber(address(token), address(nft), 4, "C3", "C3");
+
+        assertEq(registry.getChambersByAssetCount(address(token)), 3);
+
+        address[] memory page = registry.getChambersByAsset(address(token), 2, 0);
+        assertEq(page.length, 2);
+        assertEq(page[0], chamber1);
+        assertEq(page[1], chamber2);
+
+        page = registry.getChambersByAsset(address(token), 2, 2);
+        assertEq(page.length, 1);
+        assertEq(page[0], chamber3);
+
+        page = registry.getChambersByAsset(address(token), 2, 5);
+        assertEq(page.length, 0);
+
+        vm.store(address(registry), _chambersByAssetArraySlot(address(token)), bytes32(uint256(10_000)));
+        assertEq(registry.getChambersByAssetCount(address(token)), 10_000);
+        address[] memory capped = registry.getChambersByAsset(address(token));
+        assertEq(capped.length, registry.MAX_PAGE_SIZE());
+        assertEq(capped[0], chamber1);
+
+        address[] memory clamped = registry.getChambersByAsset(address(token), type(uint256).max, 0);
+        assertEq(clamped.length, registry.MAX_PAGE_SIZE());
+    }
+
+    function test_Registry_GetAssets_PaginationAndCap() public {
+        MockERC20 token2 = new MockERC20("Token2", "T2", 1e18);
+        MockERC20 token3 = new MockERC20("Token3", "T3", 1e18);
+
+        registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        registry.createChamber(address(token2), address(nft), 3, "C2", "C2");
+        registry.createChamber(address(token3), address(nft), 4, "C3", "C3");
+
+        assertEq(registry.getAssetCount(), 3);
+
+        address[] memory page = registry.getAssets(2, 0);
+        assertEq(page.length, 2);
+        assertEq(page[0], address(token));
+        assertEq(page[1], address(token2));
+
+        page = registry.getAssets(2, 2);
+        assertEq(page.length, 1);
+        assertEq(page[0], address(token3));
+
+        vm.store(address(registry), _assetsArraySlot(), bytes32(uint256(10_000)));
+        assertEq(registry.getAssetCount(), 10_000);
+        address[] memory capped = registry.getAssets();
+        assertEq(capped.length, registry.MAX_PAGE_SIZE());
+        assertEq(capped[0], address(token));
+    }
+
+    function test_Registry_GetChildChambers_PaginationAndCap() public {
+        address payable parent = registry.createChamber(address(token), address(nft), 5, "Parent", "PAR");
+        MockERC721 nft2 = new MockERC721("NFT2", "NFT2");
+        MockERC721 nft3 = new MockERC721("NFT3", "NFT3");
+        MockERC721 nft4 = new MockERC721("NFT4", "NFT4");
+
+        address child1 = registry.createChamber(parent, address(nft2), 3, "Child1", "CH1");
+        address child2 = registry.createChamber(parent, address(nft3), 3, "Child2", "CH2");
+        address child3 = registry.createChamber(parent, address(nft4), 3, "Child3", "CH3");
+
+        assertEq(registry.getChildChamberCount(parent), 3);
+
+        address[] memory page = registry.getChildChambers(parent, 2, 0);
+        assertEq(page.length, 2);
+        assertEq(page[0], child1);
+        assertEq(page[1], child2);
+
+        page = registry.getChildChambers(parent, 2, 2);
+        assertEq(page.length, 1);
+        assertEq(page[0], child3);
+
+        page = registry.getChildChambers(parent, 1, 10);
+        assertEq(page.length, 0);
+
+        vm.store(address(registry), _childChambersArraySlot(parent), bytes32(uint256(10_000)));
+        assertEq(registry.getChildChamberCount(parent), 10_000);
+        address[] memory capped = registry.getChildChambers(parent);
+        assertEq(capped.length, registry.MAX_PAGE_SIZE());
+        assertEq(capped[0], child1);
+
+        address[] memory clamped = registry.getChildChambers(parent, type(uint256).max, 0);
+        assertEq(clamped.length, registry.MAX_PAGE_SIZE());
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates security finding **L-01** on the Registry: permissionless `createChamber` appends unbounded index arrays, and several getters copied the full array.

- **Paginated getters remain the supported API.** `getChambers(limit, skip)` now clamps `limit` to `MAX_PAGE_SIZE` (256).
- **Unbounded convenience getters are capped** to the first page: `getAllChambers`, `getChambersByAsset(asset)`, `getChildChambers(chamber)`, `getAssets()`.
- **New paginated overloads + counts** for the remaining indexes: by-asset, children, and assets.
- **No creation fee, no `ADMIN_ROLE` gate, no funds taken** from existing chambers. Child links stay permissionless index metadata (using another chamber’s share token as the vault asset is still a supported sub-chamber path).

## Test plan

- [x] Foundry: `Registry` getter tests (existing pagination + new cap/page/count coverage)
- [x] `forge test --match-contract RegistryTest` — **35 passed**
- [x] `forge test --match-test 'test_Registry_Get'` — **15 passed**
- [x] `SubChamberTest` and `OffensiveReviewFindingsTest` still pass against the capped getters

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-050dca78-49ac-4938-92d3-a6031bfd2c60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-050dca78-49ac-4938-92d3-a6031bfd2c60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

