### PR TITLE
docs: I-03 token-weighted quorum is a single-actor treasury

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The Chamber represents a novel smart account architecture that fundamentally rei
 
 ### Wallet System
 - Multi-signature transaction management
-- Quorum-based approval system
+- Quorum-based approval system (token-weighted: confirmations are per membership NFT, not per address)
+- One address holding `quorum` top-seat membership NFTs is a single-actor treasury
 - Batch transaction support
 - Revocable transaction confirmations
 

--- a/app/src/docs/protocol/design-notes.md
+++ b/app/src/docs/protocol/design-notes.md
@@ -32,6 +32,8 @@ Calls where `target == Chamber` are limited to **`upgradeImplementation`** selec
 
 `getQuorum() = 1 + (getSeats() * 51) / 100` — integer math in Solidity. One- and two-seat chambers require all seats.
 
+That count is **token-weighted** (distinct director `tokenId`s). One address holding `quorum` top-seat membership NFTs can satisfy quorum alone — a single-actor treasury. Confirmations are not capped per owner.
+
 ## Seat update timelock
 
 `executeSeatsUpdate` requires **7 days** and enough supporters who are **still directors** at execution time.

--- a/app/src/docs/protocol/governance.md
+++ b/app/src/docs/protocol/governance.md
@@ -58,6 +58,8 @@ Examples:
 
 Each director **token ID** may confirm **once** per proposal. The **submitter** auto-confirms their own vote when they submit.
 
+Quorum is **token-weighted**, not 1-address-1-vote. `isDirector` and confirmations are per membership NFT. One address that holds `quorum` distinct top-seat membership NFTs can submit, self-confirm, and execute — a **single-actor treasury**. Confirmations are not capped per owner.
+
 ## Changing the number of seats
 
 After launch, directors can propose a new **seat count** (still capped at **20**):

--- a/app/src/docs/protocol/multisig.md
+++ b/app/src/docs/protocol/multisig.md
@@ -21,7 +21,7 @@ sequenceDiagram
 ```
 
 1. **Submit** — a director proposes: send ETH to an address, or call another contract with calldata.  
-2. **Confirm** — other directors add confirmations until **quorum** is met.  
+2. **Confirm** — directors add confirmations until **quorum** is met. Confirmations are per membership NFT, so one address holding `quorum` top-seat NFTs is a **single-actor treasury**.  
 3. **Execute** — someone submits the **exact calldata** again; the contract verifies it matches the stored **hash**, then runs the call.
 
 If calldata does not match, execution **reverts** (`DataHashMismatch`).

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -71,7 +71,7 @@ Public ETH / NFT receive: **`receive`**, **`fallback`**, **`onERC721Received`**.
 | **`getMember(tokenId)`** | Node tuple (`tokenId`, `amount`, `next`, `prev`). |
 | **`getTop(uint256 count)`** | Token IDs + amounts, descending. |
 | **`getSize()`** | Linked-list node count. |
-| **`getQuorum()`** | `1 + (seats * 51) / 100`. One- and two-seat chambers require all seats. |
+| **`getQuorum()`** | `1 + (seats * 51) / 100` distinct director `tokenId`s (token-weighted, not 1-address-1-vote). One- and two-seat chambers require all seats. |
 | **`getSeats()`** | Seat count. |
 | **`getDirectors()`** | **`ownerOf`** for each top **`getSeats()`** token ID; `address(0)` on failure. |
 | **`updateSeats(uint256 tokenId, uint256 numOfSeats)`** | Director-only seat proposal / support. |
@@ -80,7 +80,7 @@ Public ETH / NFT receive: **`receive`**, **`fallback`**, **`onERC721Received`**.
 
 ### Wallet multisig
 
-All director-gated with **`isDirector(tokenId)`** and **`nonReentrant`** where marked on `Chamber`.
+All director-gated with **`isDirector(tokenId)`** and **`nonReentrant`** where marked on `Chamber`. Directorship and confirmations are **per membership token**, so one address holding **`quorum`** top-seat NFTs is a **single-actor treasury**.
 
 | Function | Role |
 |---------|------|

--- a/app/src/docs/security/security-review.md
+++ b/app/src/docs/security/security-review.md
@@ -23,6 +23,7 @@ Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Chamber`
 |--------|----------------|
 | Delegation vs share transfers | Prevent double-use of voting weight |
 | Quorum on execute | Confirmations must match live director policy |
+| Token-weighted quorum (I-03) | `isDirector` and confirmations are per `tokenId`. One address holding `quorum` top-seat NFTs is a single-actor treasury — intended, not 1-address-1-vote. |
 | Calldata hashing | Execution must not accept mismatched payloads |
 | Seat updates | Timelock + still-director supporters |
 | Upgrade self-calls | Only sanctioned upgrade selector to Chamber |

--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -414,7 +414,10 @@ abstract contract Board {
      * @dev Exact integer formula: `1 + (seats * 51) / 100` (Solidity truncating division).
      *      This is not a real-number "51% of seats + 1". For many seat counts the result
      *      is about 55–67% of seats. One- and two-seat chambers require 100% of seats
-     *      (`quorum == seats`).
+     *      (`quorum == seats`). Quorum is token-weighted: it counts distinct director
+     *      `tokenId` confirmations, not unique addresses. One address holding `quorum`
+     *      top-seat membership NFTs can satisfy quorum alone (a single-actor treasury).
+     *      Confirmations are not capped per owner.
      * @return The number of confirmations required for quorum
      */
     function _getQuorum() internal view returns (uint256) {

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -201,8 +201,11 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     }
 
     /**
-     * @notice Retrieves the current quorum
+     * @notice Retrieves the current quorum (minimum distinct director-token confirmations to execute)
      * @dev Integer formula `1 + (seats * 51) / 100`. One- and two-seat chambers require all seats.
+     *      Quorum is token-weighted: it counts distinct top-seat `tokenId`s, not unique addresses.
+     *      One owner of `quorum` membership NFTs in the top seats can submit, self-confirm, and
+     *      execute — a single-actor treasury. Confirmations are not capped per owner.
      * @return The current quorum value
      */
     function getQuorum() public view override returns (uint256) {
@@ -615,12 +618,20 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    /// @notice Modifier to restrict access to only directors
+    /// @notice Restricts the call to a director acting with a specific membership `tokenId`.
+    /// @dev Directorship and confirmations are token-weighted (per `tokenId`), not 1-address-1-vote.
+    ///      `msg.sender` must control `tokenId` and `tokenId` must be in the current top seats.
+    ///      Each top-seat token may confirm once per proposal. An address that holds `quorum`
+    ///      distinct top-seat membership NFTs can submit, self-confirm, and execute — a
+    ///      single-actor treasury. This is intended; confirmations are not capped per owner.
     modifier isDirector(uint256 tokenId) {
         _isDirector(tokenId);
         _;
     }
 
+    /// @notice Verifies `msg.sender` controls `tokenId` and that `tokenId` is a current director seat.
+    /// @dev Authorization is per token, not per address. See {isDirector} for the token-weighted
+    ///      quorum assumption (one owner of `quorum` top-seat NFTs is a single-actor treasury).
     function _isDirector(uint256 tokenId) internal view {
         if (tokenId == 0) revert IChamber.NotDirector();
 

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -36,8 +36,10 @@ interface IBoard {
     function getSize() external view returns (uint256 size);
 
     /**
-     * @notice Wallet multisig confirmation threshold: `1 + (seats * 51) / 100`.
+     * @notice Wallet confirmation threshold: `1 + (seats * 51) / 100` distinct director tokens.
      * @dev Integer (truncating) division. One- and two-seat chambers require all seats.
+     *      Quorum is token-weighted (per membership `tokenId`), not 1-address-1-vote.
+     *      One address holding `quorum` top-seat NFTs is a single-actor treasury.
      * @return quorum Minimum confirmations required to execute a transaction
      */
     function getQuorum() external view returns (uint256 quorum);

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -9,6 +9,9 @@ pragma solidity ^0.8.30;
  *      Self-calls (`target == address(this)`, Chamber: `upgradeImplementation`) also persist the
  *      original bytes onchain so a confirmed upgrade remains executable if logs are unavailable.
  *      Confirmation and execution require a quorum of distinct director token IDs as enforced by `Chamber`.
+ *      That quorum is token-weighted: one address that holds `quorum` top-seat membership NFTs
+ *      can submit, self-confirm, and execute (a single-actor treasury). Confirmations are not
+ *      capped per owner.
  */
 interface IWallet {
     /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,8 @@ one- and two-seat chambers require 100% of seats. For example:
 - 5 seats → quorum = 1 + (5 * 51) / 100 = 3
 - 7 seats → quorum = 1 + (7 * 51) / 100 = 4
 
+Quorum is **token-weighted**, not 1-address-1-vote. `isDirector` and confirmations are per membership `tokenId`. An address that holds `quorum` distinct top-seat membership NFTs can submit, self-confirm, and execute — a **single-actor treasury**. Confirmations are not capped per owner.
+
 ### Transactions
 
 Transactions require:

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -74,7 +74,7 @@ struct SeatUpdate {
 - **Sorted Linked List**: Maintains nodes sorted by delegation amount (descending)
 - **Circuit Breaker**: Prevents reentrancy during repositioning
 - **Seat Management**: Dynamic seat updates with timelock and quorum
-- **Quorum Calculation**: `1 + (seats * 51) / 100` (integer division; one- and two-seat chambers require all seats)
+- **Quorum Calculation**: `1 + (seats * 51) / 100` distinct director `tokenId`s (integer division; one- and two-seat chambers require all seats; token-weighted — one owner of `quorum` top-seat NFTs is a single-actor treasury)
 
 **Operations**:
 - `_delegate()`: Add/update delegation, maintain sorted order

--- a/docs/protocol/governance.md
+++ b/docs/protocol/governance.md
@@ -36,3 +36,5 @@ Quorum is the integer formula `1 + (seats * 51) / 100` (Solidity truncating divi
 This is not a simple majority and is not "51% of seats + 1" as a real-number percentage.
 For many seat counts the result is about 55–67% of seats. One- and two-seat chambers
 require 100% of seats (quorum equals seats).
+
+That threshold is a count of distinct director **token IDs**, not unique addresses. `isDirector` and confirmations are per membership NFT. One address holding `quorum` top-seat membership NFTs can submit, self-confirm, and execute — a **single-actor treasury**. This is intended (token-weighted quorum); confirmations are not capped per owner.

--- a/docs/protocol/multisig.md
+++ b/docs/protocol/multisig.md
@@ -12,6 +12,7 @@ Any current Director can submit a transaction.
 ### 2. Confirmation
 Other Directors must confirm the transaction.
 - Only current Directors (those in the top seats) can confirm.
+- Confirmations are per membership `tokenId` (token-weighted), not per address. One owner of `quorum` top-seat NFTs can self-confirm to threshold — a single-actor treasury.
 - Confirmations can be revoked as long as the transaction hasn't been executed.
 
 ### 3. Execution

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -207,6 +207,8 @@ Returns current quorum requirement.
 
 **Returns**: Quorum value (`1 + (seats * 51) / 100`). One- and two-seat chambers require all seats.
 
+**Note**: Quorum is token-weighted. It counts distinct director `tokenId` confirmations, not unique addresses. One owner of `quorum` top-seat membership NFTs is a single-actor treasury.
+
 ---
 
 #### `getSeats() → uint256`

--- a/docs/security/i-03-token-weighted-quorum.md
+++ b/docs/security/i-03-token-weighted-quorum.md
@@ -1,0 +1,19 @@
+# I-03 — Token-weighted quorum (accepted)
+
+**Severity**: Informational  
+**Status**: Accepted (documentation only; no voting-math change)  
+**Location**: `Chamber.isDirector` / `_isDirector`; `Wallet` confirmations keyed by `tokenId`; `Board._getQuorum` / `getQuorum`
+
+## Finding
+
+`isDirector` and transaction confirmations are per membership `tokenId`, not per owner address. A single address that holds `quorum` distinct top-seat membership NFTs can submit, self-confirm (once per NFT), and execute.
+
+This can look like a 1-of-1 treasury if NFT ownership is concentrated.
+
+## Disposition
+
+This is the intended model: quorum is **token-weighted** (NFT-weighted), not 1-address-1-vote. Voting math is unchanged and confirmations are **not** capped per owner.
+
+An address holding `quorum` top-seat membership NFTs is a **single-actor treasury**. Deployers and members should treat concentrated NFT ownership as equivalent to a single signer.
+
+NatSpec on `isDirector` and `getQuorum` records the same assumption next to the code.

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -109,6 +109,7 @@ For each contract, systematically check:
 - [ ] Delegation edge cases
 - [ ] Quorum/threshold bypasses
 - [ ] Flash loan governance attacks
+- [ ] Token-weighted quorum assumption (I-03): `isDirector` and confirmations are per `tokenId`, not per address — one owner of `quorum` top-seat NFTs is a single-actor treasury. See [I-03](./i-03-token-weighted-quorum.md).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents informational finding I-03. No bytecode or voting-math change.

## Finding

`isDirector` and confirmations are per membership `tokenId`. A single owner of `quorum` top-seat membership NFTs can submit, self-confirm, and execute.

This is intended: quorum is **token-weighted** (NFT-weighted), not 1-address-1-vote. Confirmations are not capped per owner.

## What changed

- NatSpec next to `isDirector` / `_isDirector` and `getQuorum` / `_getQuorum`
- README, governance, and security docs state that one address holding `quorum` NFTs is a **single-actor treasury**
- Accepted finding note: `docs/security/i-03-token-weighted-quorum.md`

Voting math and confirmation counting are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92cefca3-5751-42fe-bd0b-d6ed9f9c381b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92cefca3-5751-42fe-bd0b-d6ed9f9c381b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

