### PR TITLE
fix(wallet): snapshot execution quorum at submit (M-04)

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -417,7 +417,9 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         Transaction storage transaction = $w.transactions[transactionId];
         if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
         if ($w.cancelled[transactionId]) revert IWallet.TransactionAlreadyCancelled();
-        if (transaction.confirmations < getQuorum()) revert IChamber.NotEnoughConfirmations();
+        if (transaction.confirmations < _requiredConfirmations(transactionId)) {
+            revert IChamber.NotEnoughConfirmations();
+        }
 
         _executeTransaction(tokenId, transactionId, data);
         emit IChamber.TransactionExecuted(transactionId, msg.sender);
@@ -506,6 +508,22 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         }
     }
 
+    /// @dev Snapshot live quorum onto each newly submitted wallet transaction (M-04).
+    function _submitQuorum() internal view override returns (uint256) {
+        return _getQuorum();
+    }
+
+    /**
+     * @notice Confirmations required to execute a submitted transaction
+     * @dev `max(submitQuorum, liveQuorum)` so a later seat decrease cannot revive an
+     *      under-quorum nonce, and a later seat increase cannot weaken the live bar.
+     */
+    function _requiredConfirmations(uint256 nonce) internal view returns (uint256) {
+        uint256 submitQuorum = _getWalletStorage().transactionRequiredQuorum[nonce];
+        uint256 liveQuorum = _getQuorum();
+        return submitQuorum > liveQuorum ? submitQuorum : liveQuorum;
+    }
+
     function _validateTransaction(address target, uint256 value, bytes memory data) internal view {
         if (target == address(0)) revert IChamber.ZeroAddress();
 
@@ -555,11 +573,10 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
     /**
      * @notice Executes multiple transactions in a single call if they have enough confirmations
-     * @dev _getQuorum() is cached once before the loop, saving one SLOAD per extra transaction
-     *      in the batch (Optimization 7).
-     *      Caller must re-supply original calldata for each hash-only transaction in the same
-     *      order as transactionIds. Self-call / upgrade entries may be empty and use the
-     *      onchain store. Each payload is verified against its stored keccak256 hash.
+     * @dev Each nonce must meet `max(submitQuorum, liveQuorum)` (M-04). Caller must re-supply
+     *      original calldata for each hash-only transaction in the same order as transactionIds.
+     *      Self-call / upgrade entries may be empty and use the onchain store (L-04). Each
+     *      payload is verified against its stored keccak256 hash.
      * @param tokenId The tokenId executing the transactions
      * @param transactionIds The array of transaction IDs to execute
      * @param data The array of original calldata for each transaction (same order as transactionIds)
@@ -573,8 +590,6 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         if (transactionIds.length == 0) revert IChamber.ZeroAmount();
         if (transactionIds.length != data.length) revert IChamber.ArrayLengthsMustMatch();
 
-        uint256 quorum = _getQuorum();
-
         WalletStorage storage $w = _getWalletStorage();
         for (uint256 i = 0; i < transactionIds.length;) {
             uint256 transactionId = transactionIds[i];
@@ -582,7 +597,9 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
             Transaction storage transaction = $w.transactions[transactionId];
 
             if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
-            if (transaction.confirmations < quorum) revert IChamber.NotEnoughConfirmations();
+            if (transaction.confirmations < _requiredConfirmations(transactionId)) {
+                revert IChamber.NotEnoughConfirmations();
+            }
 
             _executeTransaction(tokenId, transactionId, data[i]);
             emit IChamber.TransactionExecuted(transactionId, msg.sender);
@@ -851,6 +868,11 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     /// @inheritdoc IWallet
     function getTransactionCalldata(uint256 nonce) public view override(IWallet, Wallet) returns (bytes memory) {
         return super.getTransactionCalldata(nonce);
+    }
+
+    /// @inheritdoc IWallet
+    function getTransactionRequiredQuorum(uint256 nonce) public view override(IWallet, Wallet) returns (uint256) {
+        return super.getTransactionRequiredQuorum(nonce);
     }
 
     /**

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -61,6 +61,8 @@ abstract contract Wallet {
         mapping(uint256 nonce => mapping(uint256 tokenId => bool)) isCancelConfirmed;
         /// @dev Full calldata for self-calls only (L-04). Empty for ordinary hash-only txs.
         mapping(uint256 nonce => bytes storedCalldata) transactionCalldata;
+        /// @dev Quorum at submit time (M-04). Appended mapping is upgrade-safe; does not resize Transaction[].
+        mapping(uint256 nonce => uint256 requiredQuorum) transactionRequiredQuorum;
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Wallet")) - 1)) & ~bytes32(uint256(0xff))
@@ -150,12 +152,22 @@ abstract contract Wallet {
         if (target == address(this)) {
             $.transactionCalldata[nonce] = data;
         }
+        $.transactionRequiredQuorum[nonce] = _submitQuorum();
         if (bytes(metadataURI).length != 0) {
             $.transactionMetadataURI[nonce] = metadataURI;
             emit IWallet.ProposalMetadataSet(nonce, metadataURI);
         }
         _confirmTransaction(tokenId, nonce);
         emit IWallet.SubmitTransaction(tokenId, nonce, target, value, data);
+    }
+
+    /**
+     * @notice Quorum snapshotted onto a newly submitted transaction
+     * @dev Chamber overrides this to return live `getQuorum()`. Default 0 leaves
+     *      execution thresholds to the caller (e.g. MockWallet unit tests).
+     */
+    function _submitQuorum() internal view virtual returns (uint256) {
+        return 0;
     }
 
     /**
@@ -337,6 +349,15 @@ abstract contract Wallet {
      */
     function getTransactionCalldata(uint256 nonce) public view virtual txExists(nonce) returns (bytes memory) {
         return _getWalletStorage().transactionCalldata[nonce];
+    }
+
+    /**
+     * @notice Returns the quorum snapshotted when the transaction was submitted
+     * @param nonce The index of the transaction
+     * @return The required quorum recorded at submit time (0 if unset / legacy)
+     */
+    function getTransactionRequiredQuorum(uint256 nonce) public view virtual txExists(nonce) returns (uint256) {
+        return _getWalletStorage().transactionRequiredQuorum[nonce];
     }
 
     /**

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -133,6 +133,13 @@ interface IWallet {
     function getTransactionCalldata(uint256 nonce) external view returns (bytes memory storedCalldata);
 
     /**
+     * @notice Returns the quorum snapshotted when the transaction was submitted
+     * @param nonce The index of the transaction to retrieve
+     * @return requiredQuorum Quorum recorded at submit time (0 if unset / legacy)
+     */
+    function getTransactionRequiredQuorum(uint256 nonce) external view returns (uint256 requiredQuorum);
+
+    /**
      * @notice Checks if a transaction is confirmed by a specific director
      * @param tokenId The tokenId of the director to check confirmation for
      * @param nonce The index of the transaction to check

--- a/contracts/test/findings/FindingM04_QuorumSnapshot.t.sol
+++ b/contracts/test/findings/FindingM04_QuorumSnapshot.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {IWallet} from "src/interfaces/IWallet.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+
+/**
+ * @title M-04: Wallet execution quorum snapshot
+ * @notice A transaction submitted under a higher quorum must not become
+ *         executable solely because seats (and live `getQuorum()`) later decrease.
+ * @dev Confirmations are not revalidated against the current director set (H-01).
+ *      Cancel still uses live quorum (M-06).
+ */
+contract FindingM04QuorumSnapshotTest is Test {
+    Chamber public chamber;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public admin = address(0x9);
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), 5, "vERC20", "Vault Token", admin);
+
+        _setupDirector(user1, 1, 1 ether);
+        _setupDirector(user2, 2, 1 ether);
+        _setupDirector(user3, 3, 1 ether);
+        vm.roll(block.number + 1);
+
+        // 5 seats → quorum = 1 + (5 * 51) / 100 = 3
+        assertEq(chamber.getSeats(), 5);
+        assertEq(chamber.getQuorum(), 3);
+    }
+
+    function test_SeatDecreaseDoesNotMakeUnderQuorumTxExecutable() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x1234), 0, "");
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        (, uint8 confirmations,,,) = chamber.getTransaction(0);
+        assertEq(confirmations, 2, "two confirmations, below submit-time quorum of 3");
+        assertEq(chamber.getTransactionRequiredQuorum(0), 3);
+
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(1, 0, "");
+
+        _decreaseSeatsTo(3);
+
+        assertEq(chamber.getSeats(), 3);
+        assertEq(chamber.getQuorum(), 2, "live quorum dropped");
+        assertEq(chamber.getTransactionRequiredQuorum(0), 3, "submit snapshot unchanged");
+
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(1, 0, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        bytes[] memory batchData = new bytes[](1);
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeBatchTransactions(1, ids, batchData);
+    }
+
+    function test_TxBecomesExecutableAfterReachingSnapshottedQuorum() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x1234), 0, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        _decreaseSeatsTo(3);
+
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, "");
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+    }
+
+    function test_TxSubmittedAfterSeatDecreaseUsesLiveQuorum() public {
+        _decreaseSeatsTo(3);
+        assertEq(chamber.getQuorum(), 2);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x1234), 0, "");
+        assertEq(chamber.getTransactionRequiredQuorum(0), 2);
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, "");
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+    }
+
+    function test_GetTransactionRequiredQuorum_UnknownNonceReverts() public {
+        vm.expectRevert(IWallet.TransactionDoesNotExist.selector);
+        chamber.getTransactionRequiredQuorum(0);
+    }
+
+    function _decreaseSeatsTo(uint256 newSeats) internal {
+        vm.prank(user1);
+        chamber.updateSeats(1, newSeats);
+        vm.prank(user2);
+        chamber.updateSeats(2, newSeats);
+        vm.prank(user3);
+        chamber.updateSeats(3, newSeats);
+
+        vm.warp(block.timestamp + 7 days + 1);
+
+        vm.prank(user1);
+        chamber.executeSeatsUpdate(1);
+    }
+
+    function _setupDirector(address user, uint256 tokenId, uint256 amount) internal {
+        token.mint(user, amount);
+        nft.mintWithTokenId(user, tokenId);
+
+        vm.startPrank(user);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, 1);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/unit/Wallet.t.sol
+++ b/contracts/test/unit/Wallet.t.sol
@@ -247,6 +247,11 @@ contract WalletTest is Test {
         assertEq(wallet.pings(), 0);
     }
 
+    function test_Wallet_GetTransactionRequiredQuorum_Unset() public {
+        wallet.submitTransaction(1, address(0x3), 0, "");
+        assertEq(wallet.getTransactionRequiredQuorum(0), 0);
+    }
+
     function test_Wallet_ConfirmTransaction_AlreadyExecuted_Reverts() public {
         address target = address(0x3);
         bytes memory data = "";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **M-04**: wallet execution used live `getQuorum()`, so a completed seat decrease could make an older transaction executable once its confirmation count met the new, lower bar. Confirmations never decay, and seat updates already snapshot `requiredQuorum` — wallet txs did not.

## Change

- On submit, snapshot the then-current quorum onto the nonce (`Wallet.transactionRequiredQuorum`).
- `executeTransaction` / `executeBatchTransactions` require `max(submitQuorum, liveQuorum)` confirmations.
- Lowering seats cannot revive an under-quorum tx. Raising seats cannot weaken the live bar either.
- Storage is an appended ERC-7201 mapping (does not resize `Transaction[]`).
- New getter: `getTransactionRequiredQuorum(nonce)`.

**Out of scope (intentionally):**

- H-01 confirmer revalidation (stale confirmations from directors who left the board).
- M-06 cancel-path quorum behavior (cancel still uses live `getQuorum()`).

## Tests

`contracts/test/findings/FindingM04_QuorumSnapshot.t.sol`:

- A tx submitted under 5 seats (quorum 3) with 2 confirmations does **not** become executable after seats drop to 3 (live quorum 2).
- The same tx executes only after confirmations reach the snapshotted threshold.
- A tx submitted *after* the decrease uses the new live quorum.

## Verification

Foundry tests for this finding (and Wallet unit coverage of the new getter) are in this PR. No exploit PoCs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcd2907f-f667-47db-a5f4-b208735adda6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcd2907f-f667-47db-a5f4-b208735adda6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

