### PR TITLE
fix(M-05): use AccessControlUpgradeable for Registry roles

### DIFF
--- a/contracts/src/Registry.sol
+++ b/contracts/src/Registry.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {AccessControl} from "lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
-import {Initializable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {
+    AccessControlUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 import {
     TransparentUpgradeableProxy
 } from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -14,9 +15,26 @@ import {IRegistry} from "./interfaces/IRegistry.sol";
  * @title Registry
  * @author xhad, Loreum DAO LLC
  * @notice Central registry for deploying and managing Chamber instances
- * @dev Uses OpenZeppelin `TransparentUpgradeableProxy`; registry is proxy admin until `ProxyAdmin` ownership is transferred to each chamber.
+ * @dev Uses OpenZeppelin `TransparentUpgradeableProxy`; registry is proxy admin until
+ *      `ProxyAdmin` ownership is transferred to each chamber.
+ *
+ *      Roles use OpenZeppelin 5.1.0 `AccessControlUpgradeable` (ERC-7201 namespace
+ *      `openzeppelin.storage.AccessControl`). Registry application state is separately
+ *      namespaced at `erc7201:loreum.ChamberRegistry`.
+ *
+ *      Upgrade constraint: a live Registry proxy initialized against non-upgradeable
+ *      `AccessControl` stores `_roles` at sequential slot 0. This implementation reads
+ *      roles from the ERC-7201 namespace, so those proxies must not be upgraded in-place
+ *      without an explicit role migration. Prefer a new Registry proxy (fresh
+ *      `initialize`) over copying slot-0 mappings. Chamber instances stay isolated:
+ *      each owns its own `ProxyAdmin` after `createChamber`.
+ *
+ *      `AccessControlDefaultAdminRules` was not adopted: it changes
+ *      `grantRole`/`revokeRole` for `DEFAULT_ADMIN_ROLE`, needs a product delay, and
+ *      does not change TransparentUpgradeableProxy admin (still a separate EOA-owned
+ *      `ProxyAdmin`).
  */
-contract Registry is AccessControl, Initializable, IRegistry {
+contract Registry is AccessControlUpgradeable, IRegistry {
     /// @notice Role for managing the registry configuration
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
@@ -104,6 +122,7 @@ contract Registry is AccessControl, Initializable, IRegistry {
         if (admin == address(0) || _implementation == address(0)) {
             revert ZeroAddress();
         }
+        __AccessControl_init();
         RegistryStorage storage $ = _getRegistryStorage();
         $.implementation = _implementation;
         $.proxyAdmin = admin;

--- a/contracts/test/unit/Registry.t.sol
+++ b/contracts/test/unit/Registry.t.sol
@@ -9,9 +9,11 @@ import {IChamber} from "src/interfaces/IChamber.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
 import {MockERC721} from "test/mock/MockERC721.sol";
 import {DeployRegistry} from "test/utils/DeployRegistry.sol";
+import {IAccessControl} from "lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
 import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import {Clones} from "lib/openzeppelin-contracts/contracts/proxy/Clones.sol";
 import {
+    ITransparentUpgradeableProxy,
     TransparentUpgradeableProxy
 } from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
@@ -293,7 +295,11 @@ contract RegistryTest is Test {
         address stranger = makeAddr("stranger");
 
         vm.prank(stranger);
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, registry.ADMIN_ROLE()
+            )
+        );
         registry.setChamberImplementation(address(newImpl));
     }
 
@@ -375,32 +381,6 @@ contract RegistryTest is Test {
         assertEq(clamped.length, registry.MAX_PAGE_SIZE());
     }
 
-    function test_Registry_GetAssets_PaginationAndCap() public {
-        MockERC20 token2 = new MockERC20("Token2", "T2", 1e18);
-        MockERC20 token3 = new MockERC20("Token3", "T3", 1e18);
-
-        registry.createChamber(address(token), address(nft), 5, "C1", "C1");
-        registry.createChamber(address(token2), address(nft), 3, "C2", "C2");
-        registry.createChamber(address(token3), address(nft), 4, "C3", "C3");
-
-        assertEq(registry.getAssetCount(), 3);
-
-        address[] memory page = registry.getAssets(2, 0);
-        assertEq(page.length, 2);
-        assertEq(page[0], address(token));
-        assertEq(page[1], address(token2));
-
-        page = registry.getAssets(2, 2);
-        assertEq(page.length, 1);
-        assertEq(page[0], address(token3));
-
-        vm.store(address(registry), _assetsArraySlot(), bytes32(uint256(10_000)));
-        assertEq(registry.getAssetCount(), 10_000);
-        address[] memory capped = registry.getAssets();
-        assertEq(capped.length, registry.MAX_PAGE_SIZE());
-        assertEq(capped[0], address(token));
-    }
-
     function test_Registry_GetChildChambers_PaginationAndCap() public {
         address payable parent = registry.createChamber(address(token), address(nft), 5, "Parent", "PAR");
         MockERC721 nft2 = new MockERC721("NFT2", "NFT2");
@@ -433,5 +413,134 @@ contract RegistryTest is Test {
 
         address[] memory clamped = registry.getChildChambers(parent, type(uint256).max, 0);
         assertEq(clamped.length, registry.MAX_PAGE_SIZE());
+    }
+
+    function test_Registry_GetAssets_PaginationAndCap() public {
+        MockERC20 token2 = new MockERC20("Token2", "T2", 1e18);
+        MockERC20 token3 = new MockERC20("Token3", "T3", 1e18);
+
+        registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        registry.createChamber(address(token2), address(nft), 3, "C2", "C2");
+        registry.createChamber(address(token3), address(nft), 4, "C3", "C3");
+
+        assertEq(registry.getAssetCount(), 3);
+
+        address[] memory page = registry.getAssets(2, 0);
+        assertEq(page.length, 2);
+        assertEq(page[0], address(token));
+        assertEq(page[1], address(token2));
+
+        page = registry.getAssets(2, 2);
+        assertEq(page.length, 1);
+        assertEq(page[0], address(token3));
+
+        vm.store(address(registry), _assetsArraySlot(), bytes32(uint256(10_000)));
+        assertEq(registry.getAssetCount(), 10_000);
+        address[] memory capped = registry.getAssets();
+        assertEq(capped.length, registry.MAX_PAGE_SIZE());
+        assertEq(capped[0], address(token));
+    }
+
+    /// @dev OZ 5.1.0 `AccessControlUpgradeable` ERC-7201 slot (`openzeppelin.storage.AccessControl`).
+    bytes32 internal constant _ACCESS_CONTROL_STORAGE =
+        0x02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800;
+
+    /// @dev ERC-1967 admin slot (OpenZeppelin `ERC1967Utils.ADMIN_SLOT`)
+    bytes32 internal constant _ERC1967_ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    function _roleMemberSlot(bytes32 namespace, bytes32 role, address account) internal pure returns (bytes32) {
+        bytes32 roleDataSlot = keccak256(abi.encode(role, namespace));
+        return keccak256(abi.encode(account, roleDataSlot));
+    }
+
+    function _registryProxyAdmin() internal view returns (ProxyAdmin) {
+        return ProxyAdmin(address(uint160(uint256(vm.load(address(registry), _ERC1967_ADMIN_SLOT)))));
+    }
+
+    function test_Registry_AccessControlUsesErc7201Namespace() public view {
+        bytes32 defaultAdminRole = registry.DEFAULT_ADMIN_ROLE();
+        bytes32 adminRole = registry.ADMIN_ROLE();
+
+        assertEq(
+            uint256(vm.load(address(registry), _roleMemberSlot(_ACCESS_CONTROL_STORAGE, defaultAdminRole, admin))), 1
+        );
+        assertEq(uint256(vm.load(address(registry), _roleMemberSlot(_ACCESS_CONTROL_STORAGE, adminRole, admin))), 1);
+
+        // Legacy non-upgradeable AccessControl stored `_roles` at sequential slot 0.
+        assertEq(uint256(vm.load(address(registry), _roleMemberSlot(bytes32(0), defaultAdminRole, admin))), 0);
+        assertEq(uint256(vm.load(address(registry), _roleMemberSlot(bytes32(0), adminRole, admin))), 0);
+    }
+
+    function test_Registry_GrantAndRevokeAdminRole() public {
+        address operator = makeAddr("operator");
+        bytes32 adminRole = registry.ADMIN_ROLE();
+        Chamber newImpl = new Chamber();
+
+        vm.prank(admin);
+        registry.grantRole(adminRole, operator);
+        assertTrue(registry.hasRole(adminRole, operator));
+
+        vm.prank(operator);
+        registry.setChamberImplementation(address(newImpl));
+        assertEq(registry.implementation(), address(newImpl));
+
+        vm.prank(admin);
+        registry.revokeRole(adminRole, operator);
+        assertFalse(registry.hasRole(adminRole, operator));
+
+        vm.prank(operator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, operator, adminRole)
+        );
+        registry.setChamberImplementation(address(implementation));
+    }
+
+    function test_Registry_NonAdminCannotGrantRole() public {
+        address stranger = makeAddr("stranger");
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, registry.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        registry.grantRole(registry.ADMIN_ROLE(), stranger);
+    }
+
+    function test_Registry_InitializeCannotBeCalledTwice() public {
+        vm.expectRevert();
+        registry.initialize(address(implementation), admin);
+    }
+
+    function test_Registry_UpgradePreservesRolesCreateChamberAndChamberIsolation() public {
+        address chamberBefore = registry.createChamber(address(token), address(nft), 5, "C1", "C1");
+        address chamberProxyAdmin = IChamber(chamberBefore).getProxyAdmin();
+        assertEq(ProxyAdmin(chamberProxyAdmin).owner(), chamberBefore);
+        assertNotEq(ProxyAdmin(chamberProxyAdmin).owner(), address(registry));
+
+        Registry newRegistryImpl = new Registry();
+        ProxyAdmin registryProxyAdmin = _registryProxyAdmin();
+        assertEq(registryProxyAdmin.owner(), admin);
+
+        vm.prank(admin);
+        registryProxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(registry)), address(newRegistryImpl), "");
+
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(registry.hasRole(registry.ADMIN_ROLE(), admin));
+        assertEq(registry.getChamberCount(), 1);
+        assertTrue(registry.isChamber(chamberBefore));
+        assertEq(registry.implementation(), address(implementation));
+
+        // Existing chamber still owns its ProxyAdmin after a Registry implementation upgrade.
+        assertEq(ProxyAdmin(chamberProxyAdmin).owner(), chamberBefore);
+        assertEq(IChamber(chamberBefore).getProxyAdmin(), chamberProxyAdmin);
+
+        address chamberAfter = registry.createChamber(address(token), address(nft), 3, "C2", "C2");
+        assertTrue(registry.isChamber(chamberAfter));
+        assertEq(registry.getChamberCount(), 2);
+
+        address afterProxyAdmin = IChamber(chamberAfter).getProxyAdmin();
+        assertEq(ProxyAdmin(afterProxyAdmin).owner(), chamberAfter);
+        assertNotEq(afterProxyAdmin, chamberProxyAdmin);
     }
 }

--- a/contracts/test/unit/Registry.t.sol
+++ b/contracts/test/unit/Registry.t.sol
@@ -293,12 +293,11 @@ contract RegistryTest is Test {
     function test_Registry_SetChamberImplementation_NotAdmin_Reverts() public {
         Chamber newImpl = new Chamber();
         address stranger = makeAddr("stranger");
+        bytes32 adminRole = registry.ADMIN_ROLE();
 
         vm.prank(stranger);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, registry.ADMIN_ROLE()
-            )
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, adminRole)
         );
         registry.setChamberImplementation(address(newImpl));
     }
@@ -497,14 +496,14 @@ contract RegistryTest is Test {
 
     function test_Registry_NonAdminCannotGrantRole() public {
         address stranger = makeAddr("stranger");
+        bytes32 adminRole = registry.ADMIN_ROLE();
+        bytes32 defaultAdminRole = registry.DEFAULT_ADMIN_ROLE();
 
         vm.prank(stranger);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, registry.DEFAULT_ADMIN_ROLE()
-            )
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, defaultAdminRole)
         );
-        registry.grantRole(registry.ADMIN_ROLE(), stranger);
+        registry.grantRole(adminRole, stranger);
     }
 
     function test_Registry_InitializeCannotBeCalledTwice() public {
@@ -518,6 +517,7 @@ contract RegistryTest is Test {
         assertEq(ProxyAdmin(chamberProxyAdmin).owner(), chamberBefore);
         assertNotEq(ProxyAdmin(chamberProxyAdmin).owner(), address(registry));
 
+        address chamberImpl = registry.implementation();
         Registry newRegistryImpl = new Registry();
         ProxyAdmin registryProxyAdmin = _registryProxyAdmin();
         assertEq(registryProxyAdmin.owner(), admin);
@@ -529,7 +529,7 @@ contract RegistryTest is Test {
         assertTrue(registry.hasRole(registry.ADMIN_ROLE(), admin));
         assertEq(registry.getChamberCount(), 1);
         assertTrue(registry.isChamber(chamberBefore));
-        assertEq(registry.implementation(), address(implementation));
+        assertEq(registry.implementation(), chamberImpl);
 
         // Existing chamber still owns its ProxyAdmin after a Registry implementation upgrade.
         assertEq(ProxyAdmin(chamberProxyAdmin).owner(), chamberBefore);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **M-05**: `Registry` is a `TransparentUpgradeableProxy` + `Initializable` contract, but it inherited non-upgradeable OpenZeppelin 5.1.0 `AccessControl`, which stores `_roles` at sequential slot 0.

This PR switches `Registry` to `AccessControlUpgradeable` so roles live in the ERC-7201 namespace `openzeppelin.storage.AccessControl`. Application state remains in `erc7201:loreum.ChamberRegistry`. `initialize`, `onlyRole` gates, and `createChamber` are unchanged.

`AccessControlDefaultAdminRules` was considered and not adopted: it would change `grantRole`/`revokeRole` for `DEFAULT_ADMIN_ROLE`, requires a product delay, and does not change TransparentUpgradeableProxy admin (still a separate EOA-owned `ProxyAdmin`).

## Upgrade constraint

A live Registry proxy that was initialized against non-upgradeable `AccessControl` (roles at sequential slot 0) **must not** be upgraded in-place to this implementation without an explicit role migration. After such an upgrade, `hasRole` would read the empty ERC-7201 namespace.

Safe path: deploy a new Registry proxy and call `initialize` (new namespace). Do not copy slot-0 mappings.

Chamber instances stay isolated: each owns its own `ProxyAdmin` after `createChamber`. A Registry implementation change does not move chamber upgrade authority.

## Tests

Verified locally with Foundry:

- `forge test --match-contract RegistryTest` — 34 passed
- `forge test --match-contract ChamberUpgradeTest` — 12 passed
- `forge inspect Registry storage` — empty sequential layout (roles are ERC-7201 only)

Coverage includes initialize, role grant/revoke/`onlyRole` gates, `createChamber` after a Registry implementation upgrade, ERC-7201 vs sequential-slot-0 layout, and chamber `ProxyAdmin` isolation.

## Out of scope

Does not address L-02 or other findings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45876ed5-707f-48a6-9a5c-b91b8ce64ccc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45876ed5-707f-48a6-9a5c-b91b8ce64ccc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

