### PR TITLE
Harden Chamber vault deposits against fee-on-transfer assets (M-07)

### DIFF
--- a/app/src/docs/protocol/vaults.md
+++ b/app/src/docs/protocol/vaults.md
@@ -8,7 +8,7 @@ If you only know multisigs: a Safe **holds** tokens but does not issue **shares*
 
 | Action | What happens |
 |--------|----------------|
-| **Deposit** | You send the Chamber’s **underlying ERC‑20** (for example USDC) into the contract. You receive **Chamber share tokens**. |
+| **Deposit** | You send the Chamber’s **underlying standard ERC‑20** (for example USDC) into the contract. You receive **Chamber share tokens**. |
 | **Withdraw / Redeem** | You burn shares and receive underlying back (subject to vault liquidity). |
 
 Share price follows ERC‑4626 math: as the vault earns or holds more underlying per share, each share represents a larger claim.
@@ -30,6 +30,10 @@ The contract blocks transfers that would leave you with **fewer free shares than
 
 - **ETH** sent to the Chamber address is accepted (useful for gas or donations).  
 - **ERC‑721 membership NFTs** can be received via `safeTransferFrom`; that is **not** a vault deposit — it does not mint shares.
+
+## Supported assets
+
+Use a **standard ERC‑20** as the vault asset (USDC-style tokens that transfer the exact amount). Fee-on-transfer and rebasing tokens are **not** supported. Deposits revert if the Chamber does not receive the full requested amount, so those tokens cannot mint shares for value the vault never got.
 
 ## Safety note (first depositor attacks)
 

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -14,7 +14,7 @@ Upgradeable registry behind a **`TransparentUpgradeableProxy`** in the productio
 |---------|--------|
 | **`initialize(address _implementation, address admin)`** | One-time; stores implementation address and `admin`; reverts `ZeroAddress`. |
 | **`setChamberImplementation(address newImplementation)`** | **`ADMIN_ROLE` only**; updates pointer for **future** `createChamber` only. |
-| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, registers listing, transfers **ProxyAdmin ownership to `chamber`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). If `isChamber(erc20Token)`, sets **parent** / **child** links. |
+| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, registers listing, transfers **ProxyAdmin ownership to `chamber`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). If `isChamber(erc20Token)`, sets **parent** / **child** links. `erc20Token` must be a **standard ERC-20** (no factory allowlist; fee-on-transfer / rebasing unsupported). |
 
 ### Read
 
@@ -50,7 +50,7 @@ Single proxy instance per organization. **`VERSION`** is a public **`bytes32`** 
 
 ### ERC‑4626 / ERC‑20 (high level)
 
-Standard **`deposit` / `mint` / `withdraw` / `redeem`** with OpenZeppelin ERC‑4626 behavior. Transfers and withdrawals enforce **non-underflow vs `totalHolderDelegations`** (**`ExceedsDelegatedAmount`**). ERC‑20 **`transfer`/`transferFrom`** disallow zero amount and zero **to** (**`ZeroAmount`**, **`TransferToZeroAddress`**).
+Standard **`deposit` / `mint` / `withdraw` / `redeem`** with OpenZeppelin ERC‑4626 behavior. Vault assets must be **standard ERC‑20**; `deposit`/`mint` revert **`AssetAmountMismatch`** if the observed `balanceOf` delta is not the requested amount (fee-on-transfer). Transfers and withdrawals enforce **non-underflow vs `totalHolderDelegations`** (**`ExceedsDelegatedAmount`**). ERC‑20 **`transfer`/`transferFrom`** disallow zero amount and zero **to** (**`ZeroAmount`**, **`TransferToZeroAddress`**).
 
 Public ETH / NFT receive: **`receive`**, **`fallback`**, **`onERC721Received`**.
 
@@ -127,7 +127,7 @@ Reserved but **not emitted** by current Chamber: **`DirectorshipChanged`**, **`Q
 | Area | Examples |
 |------|-----------|
 | Registry | `ZeroAddress`, `InvalidSeats` |
-| Chamber / IChamber | `InsufficientChamberBalance`, `ExceedsDelegatedAmount`, `NotDirector`, `NotEnoughConfirmations`, `InvalidTransaction`, `NotAuthorized`, seat / token errors |
+| Chamber / IChamber | `InsufficientChamberBalance`, `ExceedsDelegatedAmount`, `AssetAmountMismatch`, `NotDirector`, `NotEnoughConfirmations`, `InvalidTransaction`, `NotAuthorized`, seat / token errors |
 | Board | `CircuitBreakerActive`, `TokenIdTooLarge`, `MaxNodesReached`, seat proposal / timelock errors |
 | Wallet / IWallet | `TransactionDoesNotExist`, `TransactionAlreadyExecuted`, `TransactionAlreadyConfirmed`, `TransactionNotConfirmed`, `TransactionAlreadyCancelled`, `DataHashMismatch`, `TransactionFailed`, `InvalidTarget` |
 

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -79,7 +79,10 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     /**
      * @notice Initializes the Chamber contract with the given ERC20 and ERC721 tokens and sets the number of seats
      * @dev `seats` must be between 1 and `MAX_SEATS` (20) inclusive; aligns with `Registry` validation.
-     * @param erc20Token The address of the ERC20 token
+     *      `erc20Token` must be a standard ERC-20: `transfer`/`transferFrom` move exactly the requested
+     *      amount, and `balanceOf` must not rebase independently of transfers. Fee-on-transfer deposits
+     *      revert via `_deposit`. Rebasing/elastic tokens remain unsupported.
+     * @param erc20Token The address of the standard ERC-20 vault asset
      * @param erc721Token The address of the ERC721 token
      * @param seats The initial number of seats
      * @param _name The name of the chamber's ERC20 token
@@ -717,6 +720,22 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      */
     function _decimalsOffset() internal pure override returns (uint8) {
         return 3;
+    }
+
+    /**
+     * @notice Deposit/mint workflow that requires the vault to receive exactly `assets`
+     * @dev Hardens M-07: OpenZeppelin ERC-4626 mints shares from the requested amount, not the
+     *      observed `balanceOf` delta. Fee-on-transfer tokens would otherwise credit shares for
+     *      value the vault never received. Rebasing tokens remain unsupported.
+     */
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
+        IERC20 vaultAsset = IERC20(asset());
+        uint256 balanceBefore = vaultAsset.balanceOf(address(this));
+        super._deposit(caller, receiver, assets, shares);
+        uint256 balanceAfter = vaultAsset.balanceOf(address(this));
+        if (balanceAfter < balanceBefore || balanceAfter - balanceBefore != assets) {
+            revert IChamber.AssetAmountMismatch();
+        }
     }
 
     /**

--- a/contracts/src/Registry.sol
+++ b/contracts/src/Registry.sol
@@ -125,7 +125,11 @@ contract Registry is AccessControl, Initializable, IRegistry {
 
     /**
      * @notice Deploys a new Chamber instance using TransparentUpgradeableProxy
-     * @param erc20Token The ERC20 token to be used for assets
+     * @dev `erc20Token` must be a standard ERC-20. There is no factory allowlist; Chamber
+     *      deposit/mint revert with `AssetAmountMismatch` if the vault receives less (or more)
+     *      than the requested amount (fee-on-transfer). Rebasing/elastic tokens are unsupported
+     *      and are not fully detectable at deposit time.
+     * @param erc20Token Standard ERC-20 vault asset (not fee-on-transfer or rebasing)
      * @param erc721Token The ERC721 token to be used for membership
      * @param seats The initial number of board seats
      * @param name The name of the chamber's ERC20 token

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -15,7 +15,7 @@ import {IWallet} from "./IWallet.sol";
 interface IChamber is IERC4626, IBoard, IWallet {
     /**
      * @notice Initializes the proxy; callable once by the proxy during deployment.
-     * @param erc20Token Underlying ERC-20 asset for the ERC-4626 vault
+     * @param erc20Token Standard ERC-20 vault asset (no fee-on-transfer or rebasing; see Chamber natspec)
      * @param erc721Token Membership ERC-721 whose holders may be directors when in top seats
      * @param seats Initial board seat count (must be 1..20 inclusive)
      * @param name ERC-20 name for chamber share tokens
@@ -238,4 +238,8 @@ interface IChamber is IERC4626, IBoard, IWallet {
 
     /// @notice Thrown when signature is invalid
     error InvalidSignature();
+
+    /// @notice Thrown when the vault's observed asset delta does not equal the requested amount
+    /// @dev Rejects fee-on-transfer / deflating tokens on deposit and mint
+    error AssetAmountMismatch();
 }

--- a/contracts/test/mock/MockFeeOnTransferERC20.sol
+++ b/contracts/test/mock/MockFeeOnTransferERC20.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @notice Test ERC-20 that withholds a basis-point fee on every user-to-user transfer.
+ * @dev Mints and burns are fee-free so setup can fund accounts at face value.
+ */
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(string memory name_, string memory symbol_, uint256 initialSupply, uint256 feeBps_)
+        ERC20(name_, symbol_)
+    {
+        feeBps = feeBps_;
+        _mint(msg.sender, initialSupply);
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && value > 0 && feeBps > 0) {
+            uint256 fee = (value * feeBps) / 10_000;
+            super._update(from, to, value - fee);
+            if (fee > 0) {
+                super._update(from, address(0), fee);
+            }
+            return;
+        }
+        super._update(from, to, value);
+    }
+}

--- a/contracts/test/unit/Vault.t.sol
+++ b/contracts/test/unit/Vault.t.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.30;
 
 import {Test} from "lib/forge-std/src/Test.sol";
 import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {IERC721} from "lib/openzeppelin-contracts/contracts/interfaces/IERC721.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
 import {MockERC721} from "test/mock/MockERC721.sol";
+import {MockFeeOnTransferERC20} from "test/mock/MockFeeOnTransferERC20.sol";
 import {DeployChamber} from "test/utils/DeployChamber.sol";
 
 /**
@@ -230,5 +232,63 @@ contract ChamberVaultTest is Test {
         assertEq(chamber.totalAssets(), 0);
         assertEq(token.balanceOf(address(chamber)), 0);
         assertEq(token.balanceOf(user1), depositAmount);
+    }
+
+    /// @dev M-07: standard ERC-20 deposit still credits shares for the full received amount.
+    function test_Vault_StandardERC20DepositCreditsObservedAssets() public {
+        uint256 depositAmount = 100e18;
+        deal(address(token), user1, depositAmount);
+
+        vm.startPrank(user1);
+        token.approve(address(chamber), depositAmount);
+        uint256 sharesReceived = chamber.deposit(depositAmount, user1);
+        vm.stopPrank();
+
+        assertEq(sharesReceived, depositAmount * SHARE_MULTIPLIER);
+        assertEq(chamber.balanceOf(user1), depositAmount * SHARE_MULTIPLIER);
+        assertEq(token.balanceOf(address(chamber)), depositAmount);
+        assertEq(chamber.totalAssets(), depositAmount);
+    }
+
+    /// @dev M-07: fee-on-transfer cannot mint shares for value the vault did not receive.
+    function test_Vault_FeeOnTransferDepositDoesNotMintUnreceivedValue() public {
+        MockFeeOnTransferERC20 feeToken = new MockFeeOnTransferERC20("Fee Token", "FEE", 0, 1_000);
+        Chamber feeChamber = DeployChamber.deploy(address(feeToken), address(nft), seats, "vFEE", "vFEE", address(0x9));
+
+        uint256 depositAmount = 100e18;
+        feeToken.mint(user1, depositAmount);
+
+        uint256 vaultBefore = feeToken.balanceOf(address(feeChamber));
+        uint256 userSharesBefore = feeChamber.balanceOf(user1);
+
+        vm.startPrank(user1);
+        feeToken.approve(address(feeChamber), depositAmount);
+        vm.expectRevert(IChamber.AssetAmountMismatch.selector);
+        feeChamber.deposit(depositAmount, user1);
+        vm.stopPrank();
+
+        assertEq(feeChamber.balanceOf(user1), userSharesBefore);
+        assertEq(feeToken.balanceOf(address(feeChamber)), vaultBefore);
+        assertEq(feeToken.balanceOf(user1), depositAmount);
+    }
+
+    /// @dev M-07: mint() uses the same pull path and must reject fee-on-transfer assets.
+    function test_Vault_FeeOnTransferMintDoesNotMintUnreceivedValue() public {
+        MockFeeOnTransferERC20 feeToken = new MockFeeOnTransferERC20("Fee Token", "FEE", 0, 1_000);
+        Chamber feeChamber = DeployChamber.deploy(address(feeToken), address(nft), seats, "vFEE", "vFEE", address(0x9));
+
+        uint256 mintShares = 100e18 * SHARE_MULTIPLIER;
+        uint256 expectedAssets = 100e18;
+        feeToken.mint(user1, expectedAssets);
+
+        vm.startPrank(user1);
+        feeToken.approve(address(feeChamber), expectedAssets);
+        vm.expectRevert(IChamber.AssetAmountMismatch.selector);
+        feeChamber.mint(mintShares, user1);
+        vm.stopPrank();
+
+        assertEq(feeChamber.balanceOf(user1), 0);
+        assertEq(feeToken.balanceOf(address(feeChamber)), 0);
+        assertEq(feeToken.balanceOf(user1), expectedAssets);
     }
 }

--- a/docs/protocol/vaults.md
+++ b/docs/protocol/vaults.md
@@ -4,9 +4,18 @@ Chamber instances function as fully compliant **ERC4626 Tokenized Vaults**. This
 
 ## Asset Management
 
-Every Chamber is paired with an underlying **ERC20 asset**.
+Every Chamber is paired with an underlying **standard ERC-20** asset.
 - **Deposits**: Users deposit the underlying asset and receive "Chamber Shares".
 - **Withdrawals**: Users burn shares to retrieve the underlying asset.
+
+### Supported assets
+
+`Registry.createChamber` does not maintain an asset allowlist. The vault asset **must** be a standard ERC-20:
+
+- `transfer` / `transferFrom` move **exactly** the requested amount (no fee-on-transfer or deflation).
+- `balanceOf` must not change except via transfers (no rebasing or elastic supply).
+
+On `deposit` and `mint`, Chamber measures `asset.balanceOf(vault)` before and after the pull. If the observed delta is not equal to the requested amount, the call reverts with `AssetAmountMismatch`. That prevents minting shares for value the vault did not receive. Rebasing tokens remain unsupported: a later rebase is not detectable at deposit time.
 
 ## Shares and Voting Power
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -22,7 +22,7 @@ Initializes the Registry contract.
 Deploys a new Chamber instance using minimal proxy pattern.
 
 **Parameters**:
-- `erc20Token`: ERC20 token address for assets
+- `erc20Token`: Standard ERC-20 vault asset (no factory allowlist; fee-on-transfer and rebasing tokens are unsupported)
 - `erc721Token`: ERC721 token address for membership
 - `seats`: Initial number of board seats (1-20)
 - `name`: Name of chamber's ERC20 token
@@ -464,6 +464,9 @@ Deposits assets and mints shares.
 
 **Returns**: Shares minted
 
+**Reverts**:
+- `AssetAmountMismatch`: If the vault's observed `balanceOf` delta is not equal to `assets` (fee-on-transfer)
+
 **Events**: `Deposit`, `Transfer`
 
 ---
@@ -493,6 +496,9 @@ Mints shares for assets.
 - `receiver`: Address to receive shares
 
 **Returns**: Assets deposited
+
+**Reverts**:
+- `AssetAmountMismatch`: If the vault's observed `balanceOf` delta is not equal to the pulled asset amount (fee-on-transfer)
 
 **Events**: `Deposit`, `Transfer`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates security finding **M-07**: `createChamber` still accepts any ERC-20 address (no factory allowlist), but Chamber now rejects deposit/mint when the vault does not receive the requested amount.

OpenZeppelin 5.1 ERC-4626 mints shares from the requested asset amount, not the observed `balanceOf` delta. Fee-on-transfer tokens would otherwise credit shares for value the vault never received.

## Changes

- Override `Chamber._deposit` to require `balanceOf(vault)` after the pull equals `balanceOf` before plus `assets`; otherwise revert `AssetAmountMismatch`.
- Document supported assets as **standard ERC-20 only** (exact-amount transfers; no fee-on-transfer or rebasing) in NatSpec and vault docs.
- Foundry tests: standard ERC-20 deposit still works; a fee-on-transfer mock cannot mint shares for unreceived value (deposit and mint).

Out of scope: M-02 reentrancy on vault entry points; no asset-allowlist marketplace on `Registry`.

## Test plan

- [x] `forge test --match-contract ChamberVaultTest` — 19 passed
- [x] Existing vault deposit/mint/withdraw/redeem tests still pass
- [x] Fee-on-transfer deposit and mint revert with `AssetAmountMismatch` and mint no shares
- [x] `forge test --match-path 'test/unit/*'` — 223 passed
- [x] Finding 6 first-depositor tests still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61cd70e5-b5d2-451b-aab6-10e3257fb6ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61cd70e5-b5d2-451b-aab6-10e3257fb6ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

