### PR TITLE
docs: document ERC-721 custody and absent ERC-1155 intake (I-04)

### DIFF
--- a/app/src/docs/protocol/design-notes.md
+++ b/app/src/docs/protocol/design-notes.md
@@ -40,6 +40,13 @@ Calls where `target == Chamber` are limited to **`upgradeImplementation`** selec
 
 `_update` enforces that share transfers cannot strand delegated weight (see **[Vault](./vaults.md)**).
 
+## NFT intake
+
+- `onERC721Received` accepts **any** ERC-721 collection. This is intentional treasury custody, not a membership gate. Receiving an NFT does not mint shares or affect delegation.
+- Directors transfer received ERC-721s out via the wallet (`executeTransaction` targeting the collection).
+- Chamber does **not** implement `IERC1155Receiver`. ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` to the Chamber revert.
+- `test_Chamber_ReceiveERC721` sends a **non-membership** collection to the Chamber to lock this intent.
+
 ## Further reading
 
 - **[API reference](../reference/api-reference.md)**  

--- a/app/src/docs/protocol/multisig.md
+++ b/app/src/docs/protocol/multisig.md
@@ -58,6 +58,10 @@ A proposal may target **the Chamber itself** only for **`upgradeImplementation`*
 
 Directors can submit, confirm, or execute **many proposals in one transaction** to save gas. If any step in a batch fails, the **whole batch** reverts.
 
+## Assets the queue can move
+
+The Chamber can hold **ETH**, the **vault ERC-20**, and **any ERC-721** received via `safeTransferFrom`. Directors move those assets by targeting the token contract (or an ETH recipient) in a queued call. **ERC-1155 cannot be received** via `safeTransferFrom` (no receiver hook). See **[Vault](./vaults.md)**.
+
 ## Safety
 
 External entrypoints use **reentrancy guards**. Execution follows **checks-effects-interactions**: mark executed, then call out; revert and roll back if the call fails.

--- a/app/src/docs/protocol/vaults.md
+++ b/app/src/docs/protocol/vaults.md
@@ -28,8 +28,11 @@ The contract blocks transfers that would leave you with **fewer free shares than
 
 ## ETH and NFTs sent to the Chamber
 
-- **ETH** sent to the Chamber address is accepted (useful for gas or donations).  
-- **ERC‑721 membership NFTs** can be received via `safeTransferFrom`; that is **not** a vault deposit — it does not mint shares.
+These paths are **not** vault deposits — they do not mint shares or change board seats.
+
+- **ETH** sent to the Chamber address is accepted (`receive` / payable `fallback`) for donations or gas.
+- **Any ERC‑721** can be received via `safeTransferFrom`. `onERC721Received` does **not** whitelist the membership collection. Chamber is meant to **custody arbitrary ERC‑721s** the same way a Safe holds NFTs. Directors move them out through the **proposal queue** (wallet `executeTransaction`).
+- **ERC‑1155 is not accepted.** There is no `onERC1155Received` / `onERC1155BatchReceived`. An ERC‑1155 `safeTransferFrom` to the Chamber **reverts**.
 
 ## Safety note (first depositor attacks)
 

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -54,6 +54,8 @@ Standard **`deposit` / `mint` / `withdraw` / `redeem`** with OpenZeppelin ERC‑
 
 Public ETH / NFT receive: **`receive`**, **`fallback`**, **`onERC721Received`**.
 
+`onERC721Received` accepts **any** ERC-721 collection (treasury custody; not a membership whitelist). Receipt does not mint shares. There is **no** `onERC1155Received` — ERC-1155 `safeTransferFrom` to Chamber reverts. Directors transfer received ERC-721s out via the wallet queue.
+
 ### Delegation
 
 | Function | Role |

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -597,8 +597,11 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         }
     }
 
-    /// @notice Accepts ERC721 tokens via safeTransferFrom
-    /// @dev Returns the magic value required by IERC721Receiver
+    /// @notice Accepts any ERC-721 via `safeTransferFrom` for treasury custody.
+    /// @dev Not limited to the membership collection (`nft()`). Receipt does not mint
+    ///      shares or change board seats. Directors can transfer received tokens out
+    ///      through the wallet. There is no `onERC1155Received`; ERC-1155
+    ///      `safeTransferFrom` to this contract reverts.
     function onERC721Received(address, address from, uint256 tokenId, bytes calldata)
         external
         override

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -161,10 +161,12 @@ interface IChamber is IERC4626, IBoard, IWallet {
     event Received(address indexed sender, uint256 amount);
 
     /**
-     * @notice Emitted when the contract receives an ERC721 token via safeTransferFrom
-     * @param token The ERC721 contract address
-     * @param from The address that sent the token
+     * @notice Emitted when the contract receives an ERC-721 via `safeTransferFrom`.
+     * @param token The ERC-721 collection (`msg.sender`); any collection is accepted
+     * @param from The previous owner
      * @param tokenId The token ID received
+     * @dev Receipt is treasury custody, not a membership or vault deposit. ERC-1155
+     *      intake is not implemented.
      */
     event ReceivedERC721(address indexed token, address indexed from, uint256 indexed tokenId);
 

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1264,7 +1264,7 @@ contract ChamberTest is Test {
     }
 
     function test_Chamber_ReceiveERC721() public {
-        // Use a separate ERC721 (not the governance NFT) to send to Chamber
+        // Intended: Chamber custodies arbitrary ERC-721s, not only the membership collection.
         MockERC721 otherNft = new MockERC721("Other NFT", "ONFT");
         uint256 tokenId = otherNft.mint(user1);
 

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -288,9 +288,10 @@ Batch functions reduce transaction overhead:
 
 ### Chamber Limitations
 
-- **Single NFT Contract**: One ERC721 per Chamber
-- **Single Asset**: One ERC20 asset per Chamber
-- **No Multi-Asset**: Cannot hold multiple ERC20 tokens
+- **Single NFT Contract**: One ERC721 per Chamber for **membership / director identity**
+- **Single Asset**: One ERC20 asset per Chamber as the **ERC-4626 vault underlying**
+- **No Multi-Asset vault**: The vault cannot hold multiple ERC20 tokens as the share-accounting asset
+- **NFT custody**: `onERC721Received` accepts any ERC-721 for treasury custody (not limited to the membership NFT). There is no ERC-1155 receiver; ERC-1155 `safeTransferFrom` reverts.
 
 ## Future Enhancements
 

--- a/docs/protocol/multisig.md
+++ b/docs/protocol/multisig.md
@@ -26,6 +26,10 @@ To improve efficiency and gas costs, the Wallet supports batch operations:
 - `confirmBatchTransactions`: Confirm multiple pending transactions.
 - `executeBatchTransactions`: Execute a series of authorized transactions.
 
+## Assets the queue can move
+
+The Chamber can hold **ETH**, the vault ERC-20, and **any ERC-721** received via `safeTransferFrom`. Directors move those assets by targeting the token contract (or an ETH recipient) in a queued call. **ERC-1155 cannot be received** via `safeTransferFrom` (no `onERC1155Received`). See **[Vaults](./vaults.md)**.
+
 ## Security Features
 - **Non-Reentrant**: All execution functions are protected by a reentrancy guard.
 - **Access Control**: Only Directors can interact with the wallet functions.

--- a/docs/protocol/vaults.md
+++ b/docs/protocol/vaults.md
@@ -26,3 +26,11 @@ Since the Chamber follows the ERC4626 standard:
 - It can be integrated into yield aggregators.
 - Shares can be used as collateral in lending protocols.
 - It provides a standardized interface for `deposit`, `withdraw`, `mint`, and `redeem` operations.
+
+## ETH and NFT intake (not vault deposits)
+
+These paths do **not** mint shares or change board seats.
+
+- **ETH** sent to the Chamber is accepted (`receive` / payable `fallback`).
+- **Any ERC-721** is accepted via `onERC721Received`. The hook does **not** restrict `msg.sender` to the membership collection (`nft()`). Chamber is intended to custody arbitrary ERC-721s; directors transfer them out through the wallet (`executeTransaction`).
+- **ERC-1155 intake is absent.** There is no `onERC1155Received` / `onERC1155BatchReceived`. ERC-1155 `safeTransferFrom` to the Chamber reverts.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -453,6 +453,25 @@ Returns next transaction ID.
 
 ---
 
+### Receive functions
+
+#### `receive()`
+Accepts native ETH with empty calldata. Emits `Received`.
+
+#### `fallback()`
+Accepts native ETH sent with calldata. Emits `Received` when `msg.value > 0`. Unknown selectors do not dispatch privileged logic.
+
+#### `onERC721Received(address operator, address from, uint256 tokenId, bytes data) → bytes4`
+ERC-721 receiver hook. Accepts **any** collection (`msg.sender` is not checked against `nft()`). Receipt is treasury custody: it does not mint shares or change board seats. Directors transfer received ERC-721s out via the wallet.
+
+**Returns**: `IERC721Receiver.onERC721Received.selector`
+
+**Events**: `ReceivedERC721(token, from, tokenId)` where `token` is the collection (`msg.sender`)
+
+**Not implemented**: `onERC1155Received` / `onERC1155BatchReceived`. ERC-1155 `safeTransferFrom` to Chamber reverts.
+
+---
+
 ### ERC4626 Functions
 
 #### `deposit(uint256 assets, address receiver) → uint256`
@@ -567,6 +586,7 @@ Transfers tokens from another address.
 - `TransactionConfirmed(uint256 indexed transactionId, address indexed confirmer)`
 - `TransactionExecuted(uint256 indexed transactionId, address indexed executor)`
 - `Received(address indexed sender, uint256 amount)`
+- `ReceivedERC721(address indexed token, address indexed from, uint256 indexed tokenId)` — any ERC-721 collection; not limited to the membership NFT
 
 ### Board Events
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remediation for informational finding **I-04** from the `contracts/src` security review (PR #115): `onERC721Received` accepts any collection, there is no `onERC1155Received`, directors can move received ERC-721s out via the wallet, and ERC-1155 `safeTransferFrom` to Chamber reverts.

## Investigation

Product intent was checked in code, tests, and docs **before** changing receiver behavior:

- `test_Chamber_ReceiveERC721` already sends a **non-membership** ERC-721 into Chamber and asserts ownership. That is a lock on arbitrary NFT custody, not a membership-only gate.
- Chamber is a Safe-like treasury: directors execute arbitrary wallet calls, including transfers of held NFTs.
- App vault docs previously said only “membership NFTs” could be received — that wording was wrong relative to the hook and the unit test.

Because membership-only was **not** the intended product flow, this PR does **not** whitelist `nft()` in `onERC721Received` and does **not** add an ERC-1155 receiver.

## What changed

- NatSpec on `Chamber.onERC721Received` and `IChamber.ReceivedERC721` records the intended surface.
- Protocol / app docs now state: any ERC-721 is accepted for treasury custody; receipt does not mint shares; directors move NFTs out via the wallet; ERC-1155 `safeTransferFrom` reverts.
- The existing receive test comment was aligned with that intent.

No bytecode / ABI change. Receiver behavior is unchanged.

## Scope

Touches only I-04. No exploit PoCs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4252f6bf-3969-4f80-a616-b613c28476c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4252f6bf-3969-4f80-a616-b613c28476c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

