### PR TITLE
fix(H-01): ignore stale director confirmations at wallet execute

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -447,10 +447,12 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     }
 
     /**
-     * @notice Executes a transaction if it has enough confirmations
+     * @notice Executes a transaction if current directors still meet the required quorum
      * @dev Caller must re-supply the original calldata unless this nonce stored it (self-call /
      *      `upgradeImplementation`). Empty `data` uses the stored bytes. Payload is always
      *      verified against the stored keccak256 hash.
+     *      Counts live top-seat flags (H-01) against `max(submitQuorum, liveQuorum)` (M-04).
+     *      Deadline `0` is unset and is not expired (M-06).
      * @param tokenId The tokenId executing the transaction
      * @param transactionId The ID of the transaction to execute
      * @param data The original calldata, or empty to use stored self-call bytes
@@ -467,7 +469,7 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
         if ($w.cancelled[transactionId]) revert IWallet.TransactionAlreadyCancelled();
         _notExpired(transactionId);
-        if (transaction.confirmations < _requiredConfirmations(transactionId)) {
+        if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
             revert IChamber.NotEnoughConfirmations();
         }
 
@@ -477,20 +479,18 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
 
     /**
      * @notice Revokes a confirmation for a transaction
+     * @dev Token owner may revoke after leaving the top-seat set, so outgoing approvals can be
+     *      withdrawn. Authorization is owner-only (M-01). Execute already ignores those flags.
      * @param tokenId The tokenId revoking the confirmation
      * @param transactionId The ID of the transaction to revoke confirmation for
      */
-    function revokeConfirmation(uint256 tokenId, uint256 transactionId)
-        public
-        override
-        nonReentrant
-        isDirector(tokenId)
-    {
+    function revokeConfirmation(uint256 tokenId, uint256 transactionId) public override nonReentrant {
+        _requireTokenAuthorized(tokenId);
         _revokeConfirmation(tokenId, transactionId);
     }
 
     /**
-     * @notice Records a director's vote to cancel a transaction. Requires quorum of directors to cancel.
+     * @notice Records a director's vote to cancel a transaction. Requires quorum of current directors.
      * @param tokenId The tokenId voting to cancel
      * @param transactionId The ID of the transaction to cancel
      */
@@ -505,8 +505,12 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         Transaction storage transaction = $w.transactions[transactionId];
         if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
 
-        _recordCancelVote(tokenId, transactionId, getQuorum());
+        _recordCancelVote(tokenId, transactionId);
         emit IChamber.TransactionCancelVoted(transactionId, msg.sender);
+
+        if (_countCurrentDirectorFlags($w.isCancelConfirmed, transactionId) >= getQuorum()) {
+            _cancelTransaction(transactionId);
+        }
     }
 
     /**
@@ -622,11 +626,12 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     }
 
     /**
-     * @notice Executes multiple transactions in a single call if they have enough confirmations
-     * @dev Each nonce must meet `max(submitQuorum, liveQuorum)` (M-04). Caller must re-supply
-     *      original calldata for each hash-only transaction in the same order as transactionIds.
-     *      Self-call / upgrade entries may be empty and use the onchain store (L-04). Each
-     *      payload is verified against its stored keccak256 hash.
+     * @notice Executes multiple transactions in a single call if they have enough current-director confirmations
+     * @dev Each nonce must meet live top-seat flags >= `max(submitQuorum, liveQuorum)` (H-01, M-04)
+     *      and must not be expired (deadline `0` is unset). Caller must re-supply original calldata
+     *      for each hash-only transaction in the same order as transactionIds. Self-call / upgrade
+     *      entries may be empty and use the onchain store (L-04). Each payload is verified against
+     *      its stored keccak256 hash.
      * @param tokenId The tokenId executing the transactions
      * @param transactionIds The array of transaction IDs to execute
      * @param data The array of original calldata for each transaction (same order as transactionIds)
@@ -647,7 +652,8 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
             Transaction storage transaction = $w.transactions[transactionId];
 
             if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
-            if (transaction.confirmations < _requiredConfirmations(transactionId)) {
+            _notExpired(transactionId);
+            if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
                 revert IChamber.NotEnoughConfirmations();
             }
 
@@ -700,28 +706,58 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     /// @dev Authorization is per token, not per address. See {isDirector} for the token-weighted
     ///      quorum assumption (one owner of `quorum` top-seat NFTs is a single-actor treasury).
     function _isDirector(uint256 tokenId) internal view {
+        _requireTokenAuthorized(tokenId);
+        if (!_isInTopSeats(tokenId)) revert IChamber.NotDirector();
+        if (!_isSeatingMature(tokenId)) revert IChamber.DirectorNotSeated();
+    }
+
+    /// @dev NFT owner of `tokenId` (directorship not required). Owner-only; no ERC-1271 (M-01).
+    function _requireTokenAuthorized(uint256 tokenId) internal view {
         if (tokenId == 0) revert IChamber.NotDirector();
 
-        // NFT owners (EOA or contract) are directors only when they submit as themselves.
-        // The previous ERC-1271 path treated `abi.encode(msg.sender)` as a signature and
-        // issued a CALL from this view helper, so a promiscuous 1271 owner could
-        // impersonate the director and reenter ungated functions.
+        // NFT owners (EOA or contract) act only as themselves. The previous ERC-1271 path
+        // treated `abi.encode(msg.sender)` as a signature and issued a CALL from this view
+        // helper, so a promiscuous 1271 owner could impersonate the director.
         address owner = _getChamberStorage().nft.ownerOf(tokenId);
         if (owner != msg.sender) revert IChamber.NotDirector();
+    }
 
+    /// @dev True when `tokenId` is among the current top `_getSeats()` nodes.
+    function _isInTopSeats(uint256 tokenId) internal view returns (bool) {
         BoardStorage storage $b = _getBoardStorage();
         uint256 current = $b.head;
         uint256 remaining = _getSeats();
 
         while (current != 0 && remaining > 0) {
             if (current == tokenId) {
-                if (!_isSeatingMature(tokenId)) revert IChamber.DirectorNotSeated();
-                return;
+                return true;
             }
             current = $b.nodes[current].next;
             remaining--;
         }
-        revert IChamber.NotDirector();
+        return false;
+    }
+
+    /**
+     * @notice Counts flags set by tokenIds that are still in the top-seat set.
+     * @dev Mirrors {_executeSeatsUpdate}: one O(seats) walk; evicted tokenIds are ignored.
+     */
+    function _countCurrentDirectorFlags(
+        mapping(uint256 nonce => mapping(uint256 tokenId => bool)) storage flags,
+        uint256 nonce
+    ) internal view returns (uint256 count) {
+        BoardStorage storage $b = _getBoardStorage();
+        uint256 current = $b.head;
+        uint256 remaining = _getSeats();
+        unchecked {
+            while (current != 0 && remaining > 0) {
+                if (flags[nonce][current]) {
+                    ++count;
+                }
+                current = uint256($b.nodes[current].next);
+                --remaining;
+            }
+        }
     }
 
     /**

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -292,12 +292,13 @@ abstract contract Wallet {
     }
 
     /**
-     * @notice Records a director's vote to cancel a transaction. When quorum directors have voted, the transaction is cancelled.
+     * @notice Records a director's vote to cancel a transaction.
+     * @dev Does not apply cancellation. Caller must invoke {_cancelTransaction} after counting
+     *      votes that are still from current directors (same live-set check as execute).
      * @param tokenId The token ID voting to cancel
      * @param nonce The transaction index to cancel
-     * @param quorum The number of cancel votes required to cancel
      */
-    function _recordCancelVote(uint256 tokenId, uint256 nonce, uint256 quorum)
+    function _recordCancelVote(uint256 tokenId, uint256 nonce)
         internal
         txExists(nonce)
         notExecuted(nonce)
@@ -310,11 +311,15 @@ abstract contract Wallet {
         $.cancelConfirmations[nonce] += 1;
 
         emit IWallet.CancelTransaction(tokenId, nonce);
+    }
 
-        if ($.cancelConfirmations[nonce] >= quorum) {
-            $.cancelled[nonce] = true;
-            emit IWallet.TransactionCancelled(nonce);
-        }
+    /**
+     * @notice Marks a transaction cancelled after live director quorum is met
+     * @param nonce The transaction index to cancel
+     */
+    function _cancelTransaction(uint256 nonce) internal {
+        _getWalletStorage().cancelled[nonce] = true;
+        emit IWallet.TransactionCancelled(nonce);
     }
 
     /**

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -78,10 +78,12 @@ interface IWallet {
     function confirmTransaction(uint256 tokenId, uint256 transactionId) external;
 
     /**
-     * @notice Executes a transaction if it has enough confirmations
+     * @notice Executes a transaction if current directors still meet the required quorum
      * @dev Caller must supply the original calldata unless it was stored onchain for a self-call
      *      (Chamber: `upgradeImplementation`). Empty `data` then uses the stored bytes.
      *      The contract always verifies keccak256(payload) == stored hash.
+     *      Chamber counts only tokenIds still in the top-seat set, against
+     *      `max(submitQuorum, liveQuorum)`. Deadline `0` is unset and is not expired.
      * @param tokenId The tokenId executing the transaction
      * @param transactionId The ID of the transaction to execute
      * @param data The original calldata, or empty to use stored self-call bytes
@@ -90,6 +92,7 @@ interface IWallet {
 
     /**
      * @notice Revokes a confirmation for a transaction
+     * @dev Chamber allows the token owner to revoke after leaving the board (owner-only, no ERC-1271).
      * @param tokenId The tokenId revoking the confirmation
      * @param transactionId The ID of the transaction to revoke confirmation for
      */
@@ -124,9 +127,10 @@ interface IWallet {
     function confirmBatchTransactions(uint256 tokenId, uint256[] memory transactionIds) external;
 
     /**
-     * @notice Executes multiple transactions in a single call if they have enough confirmations
+     * @notice Executes multiple transactions in a single call if they have enough current-director confirmations
      * @dev Caller must supply the original calldata for each hash-only transaction, in the same
      *      order as transactionIds. Self-call entries may be empty and use the onchain store.
+     *      Each nonce recounts live top-seat flags against `max(submitQuorum, liveQuorum)`.
      * @param tokenId The tokenId executing the transactions
      * @param transactionIds The array of transaction IDs to execute
      * @param data The array of original calldata for each transaction (empty allowed for stored self-calls)

--- a/contracts/test/findings/OffensiveReviewFindings.t.sol
+++ b/contracts/test/findings/OffensiveReviewFindings.t.sol
@@ -68,8 +68,8 @@ contract OffensiveReviewFindingsTest is Test {
         return false;
     }
 
-    /// Finding 1: confirmations from former directors still enable execution
-    function test_Finding1_StaleConfirmations_ExecuteAfterDirectorTurnover() public {
+    /// H-01: confirmations from former directors must not satisfy execute quorum
+    function test_H01_StaleConfirmations_DoNotCountAtExecute() public {
         _setupInitialDirectors();
 
         assertTrue(_isDirectorToken(1));
@@ -93,7 +93,136 @@ contract OffensiveReviewFindingsTest is Test {
         assertFalse(executed);
         assertEq(confirmations, 3);
 
-        // New holders out-delegate and take all top seats, evicting 1/2/3
+        _evictInitialDirectors();
+
+        assertFalse(_isDirectorToken(1), "token 1 should no longer be in top seats");
+        assertFalse(_isDirectorToken(2), "token 2 should no longer be in top seats");
+        assertFalse(_isDirectorToken(3), "token 3 should no longer be in top seats");
+        assertTrue(_isDirectorToken(4), "token 4 should be current director");
+
+        uint256 attackerBefore = attacker.balance;
+
+        // Current director cannot execute on approvals from evicted tokenIds
+        vm.prank(address(0x4));
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(4, 0, "");
+
+        assertEq(attacker.balance, attackerBefore, "stale confirmations must not move funds");
+        (executed,,,,) = chamber.getTransaction(0);
+        assertFalse(executed);
+    }
+
+    /// H-01: current directors can still reach quorum and execute
+    function test_H01_CurrentDirectorsCanExecute() public {
+        _setupInitialDirectors();
+        deal(address(chamber), 1 ether);
+
+        address user4 = address(0x4);
+        address user5 = address(0x5);
+        address user6 = address(0x6);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, attacker, 1 ether, "");
+
+        _evictInitialDirectors();
+
+        uint256 attackerBefore = attacker.balance;
+
+        vm.prank(user4);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(4, 0, "");
+
+        vm.prank(user4);
+        chamber.confirmTransaction(4, 0);
+        vm.prank(user5);
+        chamber.confirmTransaction(5, 0);
+        vm.prank(user6);
+        chamber.confirmTransaction(6, 0);
+
+        vm.prank(user4);
+        chamber.executeTransaction(4, 0, "");
+
+        assertEq(attacker.balance, attackerBefore + 1 ether, "current director quorum must execute");
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+    }
+
+    /// H-01: former director may revoke their own leftover confirmation
+    function test_H01_FormerDirectorCanRevoke() public {
+        _setupInitialDirectors();
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, attacker, 0, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        _evictInitialDirectors();
+
+        assertTrue(chamber.getConfirmation(1, 0));
+        vm.prank(user1);
+        chamber.revokeConfirmation(1, 0);
+        assertFalse(chamber.getConfirmation(1, 0));
+
+        // Non-owner still cannot revoke another tokenId's confirmation
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.revokeConfirmation(2, 0);
+    }
+
+    /// H-01: cancel quorum also ignores votes from evicted tokenIds
+    function test_H01_StaleCancelVotes_DoNotCancel() public {
+        _setupInitialDirectors();
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, attacker, 0, "");
+
+        vm.prank(user1);
+        chamber.cancelTransaction(1, 0);
+        vm.prank(user2);
+        chamber.cancelTransaction(2, 0);
+        assertFalse(chamber.getCancelled(0));
+
+        _evictInitialDirectors();
+
+        vm.prank(address(0x4));
+        chamber.cancelTransaction(4, 0);
+        assertFalse(chamber.getCancelled(0), "stale cancel votes must not satisfy quorum");
+
+        vm.prank(address(0x5));
+        chamber.cancelTransaction(5, 0);
+        vm.prank(address(0x6));
+        chamber.cancelTransaction(6, 0);
+        assertTrue(chamber.getCancelled(0), "current director cancel quorum must still cancel");
+    }
+
+    /// H-01: batch execute uses the same live-director confirmation count
+    function test_H01_ExecuteBatch_StaleConfirmations_Reverts() public {
+        _setupInitialDirectors();
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, attacker, 1 ether, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        _evictInitialDirectors();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        bytes[] memory data = new bytes[](1);
+        data[0] = "";
+
+        vm.prank(address(0x4));
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeBatchTransactions(4, ids, data);
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertFalse(executed);
+    }
+
+    function _evictInitialDirectors() internal {
         address user4 = address(0x4);
         address user5 = address(0x5);
         address user6 = address(0x6);
@@ -115,21 +244,6 @@ contract OffensiveReviewFindingsTest is Test {
         // Second roll in this test: `block.number` is the test-tx start, so +2 reaches
         // the block after the new directors' seating checkpoint.
         vm.roll(block.number + 2);
-
-        assertFalse(_isDirectorToken(1), "token 1 should no longer be in top seats");
-        assertFalse(_isDirectorToken(2), "token 2 should no longer be in top seats");
-        assertFalse(_isDirectorToken(3), "token 3 should no longer be in top seats");
-        assertTrue(_isDirectorToken(4), "token 4 should be current director");
-
-        uint256 attackerBefore = attacker.balance;
-
-        // Current director executes; confirmers (1,2,3) are no longer directors
-        vm.prank(user4);
-        chamber.executeTransaction(4, 0, "");
-
-        assertEq(attacker.balance, attackerBefore + 1 ether, "stale confirmations allowed fund drain");
-        (executed,,,,) = chamber.getTransaction(0);
-        assertTrue(executed);
     }
 
     /// Finding 2 (M-01): a promiscuous ERC-1271 owner cannot authorize a random caller


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Finding

**H-01** — Wallet execute accepted stale director confirmations. Rebased onto latest `main` (M-01 owner-only auth, M-02 transient guard, L-04 calldata, M-04 snapshot quorum, M-06 deadline `0` = unset, H-03 seat cancel).

## What changed

- `executeTransaction` / `executeBatchTransactions`: live top-seat director flags `>= max(submitQuorum, liveQuorum)` **and** not expired (`deadline == 0` is unset / not expired).
- `cancelTransaction`: same live-flag recount (not the stored cancel counter).
- `revokeConfirmation`: former NFT owner can revoke leftover approvals; `_requireTokenAuthorized` is owner-only (no ERC-1271, M-01).
- Submit/confirm stay director-gated (owner + top seats + seating delay).

## Test plan

- `forge test --match-contract OffensiveReviewFindingsTest`
- `forge test --match-contract FindingM04QuorumSnapshotTest`
- `forge test --match-contract FindingM06WalletExpiryTest`
- Chamber / Wallet unit suites

All of the above passed after rebase. Ready to squash-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9d2cfb5-e0bb-4274-b2f5-f3e07d77a2b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9d2cfb5-e0bb-4274-b2f5-f3e07d77a2b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

