### PR TITLE
fix(L-03): replace Board circuitBreaker with OZ ReentrancyGuardTransient

### DIFF
--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IBoard} from "./interfaces/IBoard.sol";
+import {ReentrancyGuardTransient} from "lib/openzeppelin-contracts/contracts/utils/ReentrancyGuardTransient.sol";
 
 /**
  * @title Board
@@ -9,9 +10,11 @@ import {IBoard} from "./interfaces/IBoard.sol";
  * @notice Manages a sorted linked list of nodes representing token delegations and board seats
  * @dev Abstract contract that implements core board functionality including delegation tracking
  *      and seat management. Uses a doubly linked list to maintain sorted order of delegations.
+ *      Reentrancy on `_delegate` / `_undelegate` is enforced by OpenZeppelin's
+ *      {ReentrancyGuardTransient} (`nonReentrant`, EIP-1153).
  *
  */
-abstract contract Board {
+abstract contract Board is ReentrancyGuardTransient {
     /**
      * @notice Node structure for the doubly linked list
      * @dev next and prev are uint128, packed into one storage slot.
@@ -45,7 +48,7 @@ abstract contract Board {
     /**
      * @notice ERC-7201 namespaced storage layout for Board
      * @dev size and seats are uint32, sharing one 32-byte slot (max values 50 and 20 fit
-     *      comfortably). locked has been removed; reentrancy is handled via transient storage.
+     *      comfortably). locked has been removed; reentrancy uses {ReentrancyGuardTransient}.
      * @custom:storage-location erc7201:loreum.Board
      */
     struct BoardStorage {
@@ -60,14 +63,6 @@ abstract contract Board {
     /// @notice Maximum number of nodes allowed in the linked list
     uint256 internal constant MAX_NODES = 50;
 
-    /**
-     * @dev Transient storage slot used for the circuit-breaker reentrancy lock.
-     *      Uses a domain-separated value to avoid collisions with other contracts that
-     *      might also use transient storage in the same call chain.
-     *      Value: uint256(keccak256("loreum.Board.circuitBreaker"))
-     */
-    uint256 private constant _TRANSIENT_LOCK_SLOT = 0x63a9d87af1ca3d71f80fefdfe0f7c45cfede4a17e7c60e4bd0c022a28e82e0c;
-
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Board")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant _BOARD_STORAGE_SLOT = 0xae916af301d5dc481b59b170e7db23e36b830da7017e456f99549768499c8800;
 
@@ -78,38 +73,6 @@ abstract contract Board {
     }
 
     /// @dev Events and errors are defined in IBoard interface
-
-    /// MODIFIERS ///
-
-    /**
-     * @notice Circuit-breaker modifier using EIP-1153 transient storage.
-     * @dev Sets a transient lock on entry; clears it after body executes.
-     *      TSTORE/TLOAD cost ~100 gas each vs. ~20k/2.1k for SSTORE/SLOAD on a cold slot.
-     */
-    modifier circuitBreaker() {
-        _circuitBreakerBefore();
-        _;
-        _circuitBreakerAfter();
-    }
-
-    function _circuitBreakerBefore() internal {
-        bool locked;
-        uint256 slot = _TRANSIENT_LOCK_SLOT;
-        assembly {
-            locked := tload(slot)
-        }
-        if (locked) revert IBoard.CircuitBreakerActive();
-        assembly {
-            tstore(slot, 1)
-        }
-    }
-
-    function _circuitBreakerAfter() internal {
-        uint256 slot = _TRANSIENT_LOCK_SLOT;
-        assembly {
-            tstore(slot, 0)
-        }
-    }
 
     /// FUNCTIONS ///
 
@@ -125,11 +88,11 @@ abstract contract Board {
     /**
      * @notice Handles token delegation to a specific tokenId
      * @dev Updates or creates a node and maintains sorted order.
-     *      The circuitBreaker modifier locks transient storage for the full operation.
+     *      {ReentrancyGuardTransient.nonReentrant} locks transient storage for the full operation.
      * @param tokenId The token ID to delegate to
      * @param amount The amount of tokens to delegate
      */
-    function _delegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+    function _delegate(uint256 tokenId, uint256 amount) internal nonReentrant {
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
         if (node.tokenId == tokenId) {
@@ -144,11 +107,11 @@ abstract contract Board {
     /**
      * @notice Handles token undelegation from a specific tokenId
      * @dev Reduces delegation amount or removes node if amount becomes zero.
-     *      The circuitBreaker modifier locks transient storage for the full operation.
+     *      {ReentrancyGuardTransient.nonReentrant} locks transient storage for the full operation.
      * @param tokenId The token ID to undelegate from
      * @param amount The amount of tokens to undelegate
      */
-    function _undelegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+    function _undelegate(uint256 tokenId, uint256 amount) internal nonReentrant {
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
         if (node.tokenId != tokenId) revert IBoard.NodeDoesNotExist();
@@ -171,7 +134,7 @@ abstract contract Board {
      *      Compared to the previous remove+re-insert approach, this avoids a full `delete`
      *      (4-slot zero write + SSTORE refund complexity) and a fresh cold-slot insert scan.
      *      Worst case is still O(N), but the common single-step move costs ~6 SSTOREs vs ~14+.
-     *      Called only from within a circuitBreaker-locked context (_delegate / _undelegate).
+     *      Called only from within a nonReentrant-locked context (_delegate / _undelegate).
      * @param tokenId The token ID to reposition
      */
     function _reposition(uint256 tokenId) internal {

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -13,9 +13,6 @@ import {
 } from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {ERC20Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import {IERC1271} from "lib/openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
-import {
-    ReentrancyGuardUpgradeable
-} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import {
     ITransparentUpgradeableProxy
@@ -26,8 +23,10 @@ import {StorageSlot} from "lib/openzeppelin-contracts/contracts/utils/StorageSlo
  * @title Chamber Contract
  * @notice This contract is a smart vault for managing assets with a board of directors
  * @author xhad, Loreum DAO LLC
+ * @dev Wallet `nonReentrant` modifiers come from {Board}'s {ReentrancyGuardTransient}
+ *      (replaces the previous {ReentrancyGuardUpgradeable} parent).
  */
-contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Wallet, IChamber, IERC721Receiver {
+contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver {
     /**
      * @notice ERC-7201 namespaced storage layout for Chamber
      * @dev Packing: `nft` (address, 20 bytes) sits alone in its slot; remaining fields are
@@ -100,7 +99,6 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
         __ERC4626_init(IERC20(erc20Token));
         __ERC20_init(_name, _symbol);
-        __ReentrancyGuard_init();
 
         ChamberStorage storage $ = _getChamberStorage();
         $.nft = IERC721(erc721Token);

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -131,7 +131,8 @@ interface IBoard {
     /// @notice Thrown when the linked list has reached its maximum size
     error MaxNodesReached();
 
-    /// @notice Thrown when circuit breaker is active
+    /// @notice Reserved error (not reverted by current Board source); kept for ABI compatibility.
+    /// @dev Board now reverts with OpenZeppelin `ReentrancyGuardReentrantCall` on reentrancy.
     error CircuitBreakerActive();
 
     /// @notice Thrown when a non-proposer attempts to cancel a seat update proposal (Fix Finding 14)

--- a/contracts/test/mock/MockBoard.sol
+++ b/contracts/test/mock/MockBoard.sol
@@ -62,20 +62,17 @@ contract MockBoard is Board {
     }
 
     /**
-     * @notice Sets the transient circuit-breaker lock and immediately tries to delegate again
+     * @notice Holds the OZ transient reentrancy lock and immediately tries to delegate again
      *         in the same call — simulates reentrancy to verify the guard fires.
      */
-    function lockAndDelegate(uint256 tokenId, uint256 amount) public {
-        _circuitBreakerBefore();
-        _delegate(tokenId, amount); // Should revert with CircuitBreakerActive
+    function lockAndDelegate(uint256 tokenId, uint256 amount) public nonReentrant {
+        _delegate(tokenId, amount); // Should revert with ReentrancyGuardReentrantCall
     }
 
     /**
-     * @notice Locks the board and tries to reposition within the same call
-     *         (used to test that reposition is guarded when called from a locked context).
+     * @notice Holds the OZ transient reentrancy lock and tries to reposition in the same call.
      */
-    function lockAndReposition(uint256 tokenId) public {
-        _circuitBreakerBefore();
-        _reposition(tokenId); // NodeDoesNotExist if not inserted; CircuitBreakerActive path via _delegate
+    function lockAndReposition(uint256 tokenId) public nonReentrant {
+        _reposition(tokenId);
     }
 }

--- a/contracts/test/unit/Board.t.sol
+++ b/contracts/test/unit/Board.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {Test} from "lib/forge-std/src/Test.sol";
 import {MockBoard} from "test/mock/MockBoard.sol";
 import {IBoard} from "src/interfaces/IBoard.sol";
+import {ReentrancyGuardTransient} from "lib/openzeppelin-contracts/contracts/utils/ReentrancyGuardTransient.sol";
 
 contract BoardTest is Test {
     MockBoard board;
@@ -414,16 +415,16 @@ contract BoardTest is Test {
     // ─── Circuit breaker ───────────────────────────────────────────────
 
     function test_Board_CircuitBreakerActive_Delegate_Reverts() public {
-        // lockAndDelegate acquires the transient lock then immediately calls _delegate in the
-        // same transaction, simulating reentrancy. The second _delegate should revert.
-        vm.expectRevert(IBoard.CircuitBreakerActive.selector);
+        // lockAndDelegate holds the OZ transient lock then immediately calls _delegate in the
+        // same transaction, simulating reentrancy. The nested _delegate should revert.
+        vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         board.lockAndDelegate(1, 100);
     }
 
     function test_Board_CircuitBreakerActive_Undelegate_Reverts() public {
         board.exposed_delegate(1, 100);
 
-        vm.expectRevert(IBoard.CircuitBreakerActive.selector);
+        vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         board.lockAndDelegate(1, 50);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **L-03**: Board implemented a custom EIP-1153 lock (`tload`/`tstore` on `keccak256("loreum.Board.circuitBreaker")`) even though OpenZeppelin 5.1.0 already ships `ReentrancyGuardTransient`.

- `Board` now inherits `ReentrancyGuardTransient` and applies `nonReentrant` to `_delegate` / `_undelegate` only (the functions that already used `circuitBreaker`).
- Custom assembly, `_TRANSIENT_LOCK_SLOT`, and the `circuitBreaker` modifier are removed. OZ is imported, not vendored.
- `Chamber` drops `ReentrancyGuardUpgradeable`. Solidity cannot inherit both guards (`nonReentrant` / `_reentrancyGuardEntered` / `ReentrancyGuardReentrantCall` collide, and neither is `virtual`). Wallet functions that already used `nonReentrant` now use the inherited transient modifier. Seat/vault surfaces that were ungated stay ungated (out of scope for L-03 / not an M-02 sweep).
- Existing Board reentrancy tests still cover the lock; they now expect `ReentrancyGuardReentrantCall`. `IBoard.CircuitBreakerActive` is kept as a reserved ABI error.

## Test plan

Local Foundry (`solc 0.8.30`, Cancun):

- [x] `forge test --match-contract BoardTest` — **44 passed**, including both lock tests
- [x] `forge test --match-path test/unit/Chamber.t.sol` — **99 passed**
- [x] `test/findings/Finding9_WalletReentrancy.t.sol` — **passed** (wallet `nonReentrant` still blocks reentrant submit)
- [x] `test/unit/Vault.t.sol` — **16 passed**
- [x] `test/unit/ChamberUpgrade.t.sol` — **12 passed**
- [x] Confirmed no new `nonReentrant` on `updateSeats` / `executeSeatsUpdate` / vault deposit paths

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b8ada18-13eb-4e7c-9bec-00e802e29bb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b8ada18-13eb-4e7c-9bec-00e802e29bb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

