### PR TITLE
docs: document exact integer quorum formula (I-02)

### DIFF
--- a/app/src/docs/introduction/founder-exit.md
+++ b/app/src/docs/introduction/founder-exit.md
@@ -54,7 +54,7 @@ Three onchain components separate **capital ownership** from **operational contr
 flowchart LR
   V[Vault<br/>ERC-4626 treasury<br/>Shares = ownership]
   B[Board<br/>Dynamic directors<br/>Top N delegators]
-  Q[Tx queue<br/>Submit → confirm → execute<br/>Quorum: 1 + seats × 51%]
+  Q[Tx queue<br/>Submit → confirm → execute<br/>Quorum: 1 + (seats × 51) / 100]
 
   V -.->|Proposes| B
   B -->|Approves| Q
@@ -170,7 +170,7 @@ The founder keeps economic stake but no longer controls operations. The communit
 
 **Director capability** — New directors may lack founder expertise. Plan onboarding and a transition period.
 
-**Quorum friction** — Getting `1 + (seats × 51%)` approvals may slow decisions initially. Community engagement is required.
+**Quorum friction** — Getting `1 + (seats × 51) / 100` approvals may slow decisions initially. Community engagement is required. One- and two-seat chambers require all seats.
 
 **Price volatility** — Exit announcements may move markets. Mitigate with clear communication.
 

--- a/app/src/docs/protocol/design-notes.md
+++ b/app/src/docs/protocol/design-notes.md
@@ -30,7 +30,7 @@ Calls where `target == Chamber` are limited to **`upgradeImplementation`** selec
 
 ## Quorum formula
 
-`getQuorum() = 1 + (getSeats() * 51) / 100` — integer math in Solidity.
+`getQuorum() = 1 + (getSeats() * 51) / 100` — integer math in Solidity. One- and two-seat chambers require all seats.
 
 ## Seat update timelock
 

--- a/app/src/docs/protocol/governance.md
+++ b/app/src/docs/protocol/governance.md
@@ -37,16 +37,20 @@ If delegation shifts and token 42 drops out of the top five, that wallet is **no
 
 Spending uses the **transaction queue**. Each proposal needs enough **confirmations** from directors.
 
-Quorum is **not** “half of directors.” It is computed as:
+Quorum is **not** “half of directors” and is **not** a real-number “51% of seats + 1.” It is computed as:
 
 \[
 \text{quorum} = 1 + \lfloor \text{seats} \times 51 / 100 \rfloor
 \]
 
+This is the Solidity integer formula `1 + (seats * 51) / 100`. For many seat counts the result is about 55–67% of seats. One- and two-seat chambers require 100% of seats.
+
 Examples:
 
 | Seats | Confirmations needed |
 |------:|---------------------:|
+| 1 | 1 |
+| 2 | 2 |
 | 3 | 2 |
 | 5 | 3 |
 | 7 | 4 |

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -71,7 +71,7 @@ Public ETH / NFT receive: **`receive`**, **`fallback`**, **`onERC721Received`**.
 | **`getMember(tokenId)`** | Node tuple (`tokenId`, `amount`, `next`, `prev`). |
 | **`getTop(uint256 count)`** | Token IDs + amounts, descending. |
 | **`getSize()`** | Linked-list node count. |
-| **`getQuorum()`** | `1 + (seats * 51) / 100`. |
+| **`getQuorum()`** | `1 + (seats * 51) / 100`. One- and two-seat chambers require all seats. |
 | **`getSeats()`** | Seat count. |
 | **`getDirectors()`** | **`ownerOf`** for each top **`getSeats()`** token ID; `address(0)` on failure. |
 | **`updateSeats(uint256 tokenId, uint256 numOfSeats)`** | Director-only seat proposal / support. |

--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -395,7 +395,10 @@ abstract contract Board {
 
     /**
      * @notice Calculates the current quorum requirement
-     * @dev Quorum is 51% of seats + 1
+     * @dev Exact integer formula: `1 + (seats * 51) / 100` (Solidity truncating division).
+     *      This is not a real-number "51% of seats + 1". For many seat counts the result
+     *      is about 55–67% of seats. One- and two-seat chambers require 100% of seats
+     *      (`quorum == seats`).
      * @return The number of confirmations required for quorum
      */
     function _getQuorum() internal view returns (uint256) {

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -199,6 +199,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
     /**
      * @notice Retrieves the current quorum
+     * @dev Integer formula `1 + (seats * 51) / 100`. One- and two-seat chambers require all seats.
      * @return The current quorum value
      */
     function getQuorum() public view override returns (uint256) {

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -37,6 +37,7 @@ interface IBoard {
 
     /**
      * @notice Wallet multisig confirmation threshold: `1 + (seats * 51) / 100`.
+     * @dev Integer (truncating) division. One- and two-seat chambers require all seats.
      * @return quorum Minimum confirmations required to execute a transaction
      */
     function getQuorum() external view returns (uint256 quorum);

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,10 @@ Token holders delegate their voting power to NFT token IDs. The delegation amoun
 
 ### Quorum
 
-Quorum is calculated as `1 + (seats * 51) / 100`, ensuring majority approval. For example:
+Quorum is calculated as `1 + (seats * 51) / 100` (integer division). This is not a simple majority:
+one- and two-seat chambers require 100% of seats. For example:
+- 1 seat → quorum = 1 + (1 * 51) / 100 = 1
+- 2 seats → quorum = 1 + (2 * 51) / 100 = 2
 - 5 seats → quorum = 1 + (5 * 51) / 100 = 3
 - 7 seats → quorum = 1 + (7 * 51) / 100 = 4
 

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -74,7 +74,7 @@ struct SeatUpdate {
 - **Sorted Linked List**: Maintains nodes sorted by delegation amount (descending)
 - **Circuit Breaker**: Prevents reentrancy during repositioning
 - **Seat Management**: Dynamic seat updates with timelock and quorum
-- **Quorum Calculation**: `1 + (seats * 51) / 100`
+- **Quorum Calculation**: `1 + (seats * 51) / 100` (integer division; one- and two-seat chambers require all seats)
 
 **Operations**:
 - `_delegate()`: Add/update delegation, maintain sorted order

--- a/docs/protocol/governance.md
+++ b/docs/protocol/governance.md
@@ -32,5 +32,7 @@ The number of seats on the Board can be updated through a governance proposal.
 
 ## Quorum Calculation
 
-Quorum is dynamically calculated based on the current number of seats:
-`Quorum = 1 + (seats * 51) / 100` (representing a simple majority).
+Quorum is the integer formula `1 + (seats * 51) / 100` (Solidity truncating division).
+This is not a simple majority and is not "51% of seats + 1" as a real-number percentage.
+For many seat counts the result is about 55–67% of seats. One- and two-seat chambers
+require 100% of seats (quorum equals seats).

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -205,7 +205,7 @@ Returns total number of nodes in board.
 #### `getQuorum() → uint256`
 Returns current quorum requirement.
 
-**Returns**: Quorum value (1 + (seats * 51) / 100)
+**Returns**: Quorum value (`1 + (seats * 51) / 100`). One- and two-seat chambers require all seats.
 
 ---
 

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -268,7 +268,8 @@ function Whitepaper() {
                   quorum = 1 + (seats × 51) / 100
                 </code>
                 <p className="text-gray-400 text-sm mt-2">
-                  This ensures a simple majority (51%+) of directors must approve transactions.
+                  Exact integer formula (`/` truncates). This is not a simple majority:
+                  one- and two-seat chambers require 100% of seats.
                 </p>
               </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates informational finding **I-02**: `Board._getQuorum` was documented as “51% of seats + 1” while the implementation is `1 + (seats * 51) / 100`.

The comment was attached to the correct function. This PR updates NatSpec and user-facing docs so they match the integer formula. **Governance math is unchanged.**

## What changed

- NatSpec on `Board._getQuorum`, `IBoard.getQuorum`, and `Chamber.getQuorum` now states the exact formula `1 + (seats * 51) / 100` (truncating division) and the 1–2 seat special case (100% of seats).
- Protocol/app docs and the landing whitepaper no longer describe this as a simple majority.

## What did not change

- The quorum expression `1 + (seats * 51) / 100` is identical.
- No tests, deployment scripts, or other findings.

## Formula (unchanged)

| Seats | `1 + (seats * 51) / 100` | Share of seats |
|------:|-------------------------:|---------------:|
| 1 | 1 | 100% |
| 2 | 2 | 100% |
| 5 | 3 | 60% |
| 7 | 4 | ~57% |

## Verification

- Local `make ci-test` in `contracts/`: **277 passed**, 0 failed.
- GitHub **Forge Tests** on this branch: passed.
- Quorum-specific coverage: `test_Board_GetQuorum`, `test_Chamber_GetQuorum`, `testFuzz_Quorum` (256 runs).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4f71d84-1084-46dd-9310-18bbd3e50d1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4f71d84-1084-46dd-9310-18bbd3e50d1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

