### PR TITLE
Store self-call calldata for upgrade liveness (L-04)

### DIFF
--- a/app/src/docs/protocol/multisig.md
+++ b/app/src/docs/protocol/multisig.md
@@ -52,7 +52,7 @@ Directors can vote to **cancel** before execution. Enough cancel votes (quorum) 
 
 ## Upgrades (special case)
 
-A proposal may target **the Chamber itself** only for **`upgradeImplementation`** — the controlled path to upgrade the contract logic via **ProxyAdmin**. Random self-calls are blocked.
+A proposal may target **the Chamber itself** only for **`upgradeImplementation`** — the controlled path to upgrade the contract logic via **ProxyAdmin**. Random self-calls are blocked. Those self-calls persist calldata onchain so a confirmed upgrade can still be executed if event logs are unavailable. Ordinary treasury calls stay hash-only.
 
 ## Batching
 

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -84,11 +84,11 @@ All director-gated with **`isDirector(tokenId)`** and **`nonReentrant`** where m
 
 | Function | Role |
 |---------|------|
-| **`submitTransaction(tokenId, target, value, data)`** | Validates target/value (see below); stores **`keccak256(data)`**; auto-confirms submitter. |
+| **`submitTransaction(tokenId, target, value, data)`** | Validates target/value (see below); stores **`keccak256(data)`**; also stores full bytes for self-calls (`upgradeImplementation`); auto-confirms submitter. |
 | **`submitTransactionWithMetadata(..., string metadataURI)`** | Same + optional durable URI / hash string. |
 | **`confirmTransaction(tokenId, transactionId)`** | Increments confirmations if not cancelled / executed / duplicate. |
 | **`revokeConfirmation(tokenId, transactionId)`** | Removes this director’s confirmation when allowed. |
-| **`executeTransaction(tokenId, transactionId, bytes calldata data)`** | Requires quorum; verifies hash; external call. |
+| **`executeTransaction(tokenId, transactionId, bytes calldata data)`** | Requires quorum; verifies hash; empty `data` uses stored self-call bytes. |
 | **`cancelTransaction(tokenId, transactionId)`** | Cancels after quorum cancel votes. |
 | **`submitBatchTransactions(tokenId, targets[], values[], data[])`** | Same constraints per row; **`Σ values ≤ address(this).balance`** check for ETH. |
 | **`confirmBatchTransactions(tokenId, transactionIds[])`** | Batched confirms. |
@@ -96,7 +96,7 @@ All director-gated with **`isDirector(tokenId)`** and **`nonReentrant`** where m
 
 Transaction validation (single and batch): **`target != address(0)`**. If **`target == address(this)`**, calldata selector must be **`upgradeImplementation(address,bytes)`**. **`value`** cannot exceed native balance.
 
-Read helpers: **`getTransactionCount`**, **`getNextTransactionId`**, **`getTransaction(nonce)`** → **`(..., dataHash)`**, **`getTransactionMetadata`**, **`getConfirmation`**, **`getCancelled`**, **`getCancelConfirmation`**, **`getCancelConfirmations`**.
+Read helpers: **`getTransactionCount`**, **`getNextTransactionId`**, **`getTransaction(nonce)`** → **`(..., dataHash)`**, **`getTransactionMetadata`**, **`getTransactionCalldata`**, **`getConfirmation`**, **`getCancelled`**, **`getCancelConfirmation`**, **`getCancelConfirmations`**.
 
 ### Proxy upgrades
 

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -395,10 +395,12 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
     /**
      * @notice Executes a transaction if it has enough confirmations
-     * @dev Caller must re-supply the original calldata; it is verified against the stored keccak256 hash.
+     * @dev Caller must re-supply the original calldata unless this nonce stored it (self-call /
+     *      `upgradeImplementation`). Empty `data` uses the stored bytes. Payload is always
+     *      verified against the stored keccak256 hash.
      * @param tokenId The tokenId executing the transaction
      * @param transactionId The ID of the transaction to execute
-     * @param data The original calldata supplied at submission time
+     * @param data The original calldata, or empty to use stored self-call bytes
      */
     function executeTransaction(uint256 tokenId, uint256 transactionId, bytes calldata data)
         public
@@ -551,8 +553,9 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      * @notice Executes multiple transactions in a single call if they have enough confirmations
      * @dev _getQuorum() is cached once before the loop, saving one SLOAD per extra transaction
      *      in the batch (Optimization 7).
-     *      Caller must re-supply original calldata for each transaction in the same order as
-     *      transactionIds; each entry is verified against its stored keccak256 hash.
+     *      Caller must re-supply original calldata for each hash-only transaction in the same
+     *      order as transactionIds. Self-call / upgrade entries may be empty and use the
+     *      onchain store. Each payload is verified against its stored keccak256 hash.
      * @param tokenId The tokenId executing the transactions
      * @param transactionIds The array of transaction IDs to execute
      * @param data The array of original calldata for each transaction (same order as transactionIds)
@@ -813,6 +816,11 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     /// @inheritdoc IWallet
     function getTransactionMetadata(uint256 nonce) public view override(IWallet, Wallet) returns (string memory) {
         return super.getTransactionMetadata(nonce);
+    }
+
+    /// @inheritdoc IWallet
+    function getTransactionCalldata(uint256 nonce) public view override(IWallet, Wallet) returns (bytes memory) {
+        return super.getTransactionCalldata(nonce);
     }
 
     /**

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -10,16 +10,22 @@ import {IWallet} from "./interfaces/IWallet.sol";
  * @dev Provides core functionality for submitting, confirming, and executing transactions
  *      with configurable quorum requirements.
  *
- * Gas optimization — hash-only calldata storage:
+ * Gas optimization — hash-only calldata storage for ordinary calls:
  *   Transaction.data (formerly dynamic `bytes`) is replaced with `bytes32 dataHash`.
  *   At submission the keccak256 of the calldata is stored (fixed 1 slot vs. 20k per 32 bytes
  *   of raw calldata). At execution the caller re-supplies the original bytes; the contract
  *   verifies keccak256(data) == dataHash before forwarding to the target.
  *   This matches the pattern used by Gnosis Safe.
  *
- * BREAKING: executeTransaction and executeBatchTransactions now require a `data` / `data[]`
- *           parameter at call time. Callers must persist the original calldata (e.g. via the
- *           SubmitTransaction event or offchain storage) and re-supply it at execution.
+ * L-04 liveness exception — self-calls store full calldata onchain:
+ *   Calls whose `target == address(this)` (Chamber: `upgradeImplementation` only) persist
+ *   the original bytes in `transactionCalldata`. Execution may pass empty `data` and the
+ *   stored payload is used, so a confirmed upgrade remains executable if event logs or
+ *   `metadataURI` archives are unavailable. Ordinary treasury calls stay hash-only.
+ *
+ * BREAKING: executeTransaction and executeBatchTransactions require a `data` / `data[]`
+ *           parameter at call time. For non-self-calls, callers must persist the original
+ *           calldata (e.g. via the SubmitTransaction event) and re-supply it at execution.
  */
 abstract contract Wallet {
     /**
@@ -53,6 +59,8 @@ abstract contract Wallet {
         mapping(uint256 nonce => bool) cancelled;
         mapping(uint256 nonce => uint8) cancelConfirmations;
         mapping(uint256 nonce => mapping(uint256 tokenId => bool)) isCancelConfirmed;
+        /// @dev Full calldata for self-calls only (L-04). Empty for ordinary hash-only txs.
+        mapping(uint256 nonce => bytes storedCalldata) transactionCalldata;
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Wallet")) - 1)) & ~bytes32(uint256(0xff))
@@ -111,7 +119,7 @@ abstract contract Wallet {
      * @param tokenId The token ID submitting the transaction
      * @param target The destination address for the transaction
      * @param value The amount of ETH to send
-     * @param data The calldata to execute (stored as keccak256 hash only)
+     * @param data The calldata to execute (hash stored always; full bytes stored for self-calls)
      */
     function _submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data) internal {
         _submitTransactionWithMetadata(tokenId, target, value, data, "");
@@ -122,7 +130,7 @@ abstract contract Wallet {
      * @param tokenId The token ID submitting the transaction
      * @param target The destination address for the transaction
      * @param value The amount of ETH to send
-     * @param data The calldata to execute (stored as keccak256 hash only)
+     * @param data The calldata to execute (hash stored always; full bytes stored for self-calls)
      * @param metadataURI URI or content hash describing the proposal rationale and risk context
      */
     function _submitTransactionWithMetadata(
@@ -138,6 +146,10 @@ abstract contract Wallet {
         bytes32 dataHash = keccak256(data);
         $.transactions
             .push(Transaction({target: target, value: value, dataHash: dataHash, executed: false, confirmations: 0}));
+        // L-04: persist upgrade/self-call bytes so execution does not depend on logs.
+        if (target == address(this)) {
+            $.transactionCalldata[nonce] = data;
+        }
         if (bytes(metadataURI).length != 0) {
             $.transactionMetadataURI[nonce] = metadataURI;
             emit IWallet.ProposalMetadataSet(nonce, metadataURI);
@@ -223,10 +235,11 @@ abstract contract Wallet {
     /**
      * @notice Executes a confirmed transaction
      * @dev Uses CEI pattern — state updated before external call.
-     *      Verifies keccak256(data) == stored dataHash before forwarding.
+     *      Verifies keccak256(payload) == stored dataHash before forwarding.
+     *      Self-calls use onchain-stored calldata when the caller passes empty `data`.
      * @param tokenId The token ID executing the transaction
      * @param nonce The transaction index to execute
-     * @param data The original calldata (must match the stored keccak256 hash)
+     * @param data The original calldata, or empty to use stored self-call bytes
      */
     function _executeTransaction(uint256 tokenId, uint256 nonce, bytes calldata data)
         internal
@@ -238,7 +251,8 @@ abstract contract Wallet {
         Transaction storage transaction = $.transactions[nonce];
 
         if (transaction.target == address(0)) revert IWallet.InvalidTarget();
-        if (keccak256(data) != transaction.dataHash) revert IWallet.DataHashMismatch();
+
+        bytes memory payload = _resolveExecutionCalldata(nonce, transaction, data);
 
         address target = transaction.target;
         uint256 value = transaction.value;
@@ -246,13 +260,33 @@ abstract contract Wallet {
         // CEI pattern: Update state BEFORE external call to prevent reentrancy
         transaction.executed = true;
 
-        (bool success, bytes memory returnData) = target.call{value: value}(data);
+        (bool success, bytes memory returnData) = target.call{value: value}(payload);
         if (!success) {
             transaction.executed = false;
             revert IWallet.TransactionFailed(returnData);
         }
 
         emit IWallet.ExecuteTransaction(tokenId, nonce);
+    }
+
+    /**
+     * @notice Resolves calldata for execution: stored self-call bytes, else caller-supplied.
+     * @dev If this nonce stored calldata (self-call / upgrade), empty `data` uses the store.
+     *      Any non-empty caller `data` must still match `dataHash`.
+     */
+    function _resolveExecutionCalldata(uint256 nonce, Transaction storage transaction, bytes calldata data)
+        private
+        view
+        returns (bytes memory payload)
+    {
+        bytes memory stored = _getWalletStorage().transactionCalldata[nonce];
+        if (stored.length != 0 || transaction.target == address(this)) {
+            payload = stored;
+            if (data.length != 0 && keccak256(data) != transaction.dataHash) revert IWallet.DataHashMismatch();
+        } else {
+            payload = data;
+        }
+        if (keccak256(payload) != transaction.dataHash) revert IWallet.DataHashMismatch();
     }
 
     /**
@@ -295,6 +329,14 @@ abstract contract Wallet {
      */
     function getTransactionMetadata(uint256 nonce) public view virtual txExists(nonce) returns (string memory) {
         return _getWalletStorage().transactionMetadataURI[nonce];
+    }
+
+    /**
+     * @notice Returns onchain-stored calldata for a self-call, or empty bytes for hash-only txs
+     * @param nonce The index of the transaction to retrieve stored calldata for
+     */
+    function getTransactionCalldata(uint256 nonce) public view virtual txExists(nonce) returns (bytes memory) {
+        return _getWalletStorage().transactionCalldata[nonce];
     }
 
     /**

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.8.30;
  * @title IWallet
  * @author xhad, Loreum DAO LLC
  * @notice Director-gated multisig: submit, confirm, execute, revoke, and cancel transaction flows.
- * @dev Only `keccak256(calldata)` is stored onchain; callers must retain full calldata to execute.
+ * @dev Ordinary calls store only `keccak256(calldata)`; callers must retain full calldata to execute.
+ *      Self-calls (`target == address(this)`, Chamber: `upgradeImplementation`) also persist the
+ *      original bytes onchain so a confirmed upgrade remains executable if logs are unavailable.
  *      Confirmation and execution require a quorum of distinct director token IDs as enforced by `Chamber`.
  */
 interface IWallet {
@@ -14,7 +16,7 @@ interface IWallet {
      * @param tokenId The tokenId submitting the transaction
      * @param target The address to send the transaction to
      * @param value The amount of Ether to send
-     * @param data The calldata (stored onchain as keccak256 hash only)
+     * @param data The calldata (hash stored always; full bytes stored when `target` is this wallet)
      */
     function submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data) external;
 
@@ -23,7 +25,7 @@ interface IWallet {
      * @param tokenId The tokenId submitting the transaction
      * @param target The address to send the transaction to
      * @param value The amount of Ether to send
-     * @param data The calldata (stored onchain as keccak256 hash only)
+     * @param data The calldata (hash stored always; full bytes stored when `target` is this wallet)
      * @param metadataURI URI or content hash describing the proposal rationale and risk context
      */
     function submitTransactionWithMetadata(
@@ -42,10 +44,12 @@ interface IWallet {
 
     /**
      * @notice Executes a transaction if it has enough confirmations
-     * @dev Caller must supply the original calldata; the contract verifies keccak256(data) == stored hash.
+     * @dev Caller must supply the original calldata unless it was stored onchain for a self-call
+     *      (Chamber: `upgradeImplementation`). Empty `data` then uses the stored bytes.
+     *      The contract always verifies keccak256(payload) == stored hash.
      * @param tokenId The tokenId executing the transaction
      * @param transactionId The ID of the transaction to execute
-     * @param data The original calldata supplied at submission time
+     * @param data The original calldata, or empty to use stored self-call bytes
      */
     function executeTransaction(uint256 tokenId, uint256 transactionId, bytes calldata data) external;
 
@@ -68,7 +72,7 @@ interface IWallet {
      * @param tokenId The tokenId submitting the transactions
      * @param targets The array of addresses to send the transactions to
      * @param values The array of amounts of Ether to send
-     * @param data The array of calldata (each stored as keccak256 hash only)
+     * @param data The array of calldata (hash stored always; full bytes stored for self-calls)
      */
     function submitBatchTransactions(
         uint256 tokenId,
@@ -86,10 +90,11 @@ interface IWallet {
 
     /**
      * @notice Executes multiple transactions in a single call if they have enough confirmations
-     * @dev Caller must supply the original calldata for each transaction in the same order as transactionIds.
+     * @dev Caller must supply the original calldata for each hash-only transaction, in the same
+     *      order as transactionIds. Self-call entries may be empty and use the onchain store.
      * @param tokenId The tokenId executing the transactions
      * @param transactionIds The array of transaction IDs to execute
-     * @param data The array of original calldata for each transaction
+     * @param data The array of original calldata for each transaction (empty allowed for stored self-calls)
      */
     function executeBatchTransactions(uint256 tokenId, uint256[] memory transactionIds, bytes[] calldata data) external;
 
@@ -106,7 +111,7 @@ interface IWallet {
      * @return confirmations Number of confirmations
      * @return target The target address
      * @return value The ETH value
-     * @return dataHash keccak256 of the original calldata (re-supply at execution time)
+     * @return dataHash keccak256 of the original calldata (re-supply at execution unless stored)
      */
     function getTransaction(uint256 nonce)
         external
@@ -119,6 +124,13 @@ interface IWallet {
      * @return metadataURI URI or content hash supplied at proposal creation
      */
     function getTransactionMetadata(uint256 nonce) external view returns (string memory metadataURI);
+
+    /**
+     * @notice Returns onchain-stored calldata for a self-call / upgrade, or empty bytes for hash-only txs
+     * @param nonce The index of the transaction to retrieve stored calldata for
+     * @return storedCalldata Original bytes if this nonce targeted the wallet itself; otherwise empty
+     */
+    function getTransactionCalldata(uint256 nonce) external view returns (bytes memory storedCalldata);
 
     /**
      * @notice Checks if a transaction is confirmed by a specific director
@@ -163,7 +175,7 @@ interface IWallet {
      * @param nonce The unique identifier for the transaction
      * @param to The target address for the transaction
      * @param value The amount of ETH to send
-     * @param data The original calldata (emitted for offchain persistence; only hash stored onchain)
+     * @param data The original calldata (emitted for offchain persistence; also stored onchain for self-calls)
      */
     event SubmitTransaction(
         uint256 indexed tokenId, uint256 indexed nonce, address indexed to, uint256 value, bytes data

--- a/contracts/test/findings/FindingL04_UpgradeCalldataLiveness.t.sol
+++ b/contracts/test/findings/FindingL04_UpgradeCalldataLiveness.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Registry} from "src/Registry.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {IWallet} from "src/interfaces/IWallet.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployRegistry} from "test/utils/DeployRegistry.sol";
+
+/// @notice L-04: self-call / upgrade calldata is stored onchain so execution does not depend on logs.
+contract FindingL04UpgradeCalldataLivenessTest is Test {
+    Registry public registry;
+    Chamber public newImplementation;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public admin = makeAddr("admin");
+    address public user1 = makeAddr("user1");
+    address public user2 = makeAddr("user2");
+    address public user3 = makeAddr("user3");
+
+    IChamber public chamber;
+    address public chamberAddress;
+
+    function setUp() public {
+        token = new MockERC20("Test Token", "TEST", 1000000e18);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        newImplementation = new Chamber();
+        registry = DeployRegistry.deploy(admin);
+
+        chamberAddress = registry.createChamber(address(token), address(nft), 5, "Chamber Token", "CHMB");
+        chamber = IChamber(chamberAddress);
+
+        _setupDirectors();
+    }
+
+    function _setupDirectors() internal {
+        nft.mintWithTokenId(user1, 1);
+        nft.mintWithTokenId(user2, 2);
+        nft.mintWithTokenId(user3, 3);
+
+        uint256 amount = 1000e18;
+        token.mint(user1, amount);
+        token.mint(user2, amount);
+        token.mint(user3, amount);
+
+        vm.startPrank(user1);
+        token.approve(chamberAddress, amount);
+        chamber.deposit(amount, user1);
+        chamber.delegate(1, amount);
+        vm.stopPrank();
+
+        vm.startPrank(user2);
+        token.approve(chamberAddress, amount);
+        chamber.deposit(amount, user2);
+        chamber.delegate(2, amount);
+        vm.stopPrank();
+
+        vm.startPrank(user3);
+        token.approve(chamberAddress, amount);
+        chamber.deposit(amount, user3);
+        chamber.delegate(3, amount);
+        vm.stopPrank();
+    }
+
+    function _reachQuorum(uint256 txId) internal {
+        vm.prank(user2);
+        chamber.confirmTransaction(2, txId);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, txId);
+    }
+
+    function test_L04_UpgradeExecutesWithoutResuppliedCalldata() public {
+        bytes32 implSlot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address currentImpl = address(uint160(uint256(vm.load(chamberAddress, implSlot))));
+
+        bytes memory upgradeData =
+            abi.encodeWithSelector(IChamber.upgradeImplementation.selector, address(newImplementation), "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, chamberAddress, 0, upgradeData);
+        uint256 txId = chamber.getTransactionCount() - 1;
+
+        assertEq(chamber.getTransactionCalldata(txId), upgradeData);
+        (,,,, bytes32 dataHash) = chamber.getTransaction(txId);
+        assertEq(dataHash, keccak256(upgradeData));
+
+        _reachQuorum(txId);
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, txId, "");
+
+        address upgraded = address(uint160(uint256(vm.load(chamberAddress, implSlot))));
+        assertEq(upgraded, address(newImplementation));
+        assertNotEq(upgraded, currentImpl);
+    }
+
+    function test_L04_BatchUpgradeExecutesWithoutResuppliedCalldata() public {
+        Chamber impl1 = new Chamber();
+        bytes[] memory upgradeDataArray = new bytes[](1);
+        upgradeDataArray[0] = abi.encodeWithSelector(IChamber.upgradeImplementation.selector, address(impl1), "");
+
+        address[] memory targets = new address[](1);
+        targets[0] = chamberAddress;
+        uint256[] memory values = new uint256[](1);
+
+        vm.prank(user1);
+        chamber.submitBatchTransactions(1, targets, values, upgradeDataArray);
+
+        uint256 txId = chamber.getTransactionCount() - 1;
+        assertEq(chamber.getTransactionCalldata(txId), upgradeDataArray[0]);
+        _reachQuorum(txId);
+
+        uint256[] memory txIds = new uint256[](1);
+        txIds[0] = txId;
+        bytes[] memory emptyData = new bytes[](1);
+
+        vm.prank(user1);
+        chamber.executeBatchTransactions(1, txIds, emptyData);
+
+        bytes32 implSlot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address upgraded = address(uint160(uint256(vm.load(chamberAddress, implSlot))));
+        assertEq(upgraded, address(impl1));
+    }
+
+    function test_L04_NormalTreasuryTxStillHashChecks() public {
+        address recipient = address(0x1234);
+        bytes memory transferData = abi.encodeWithSignature("transfer(address,uint256)", recipient, 1e18);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(token), 0, transferData);
+        uint256 txId = chamber.getTransactionCount() - 1;
+
+        assertEq(chamber.getTransactionCalldata(txId).length, 0);
+        _reachQuorum(txId);
+
+        vm.prank(user1);
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        chamber.executeTransaction(1, txId, "");
+
+        vm.prank(user1);
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        chamber.executeTransaction(1, txId, hex"cafebabe");
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, txId, transferData);
+
+        (bool executed,,,,) = chamber.getTransaction(txId);
+        assertTrue(executed);
+        assertEq(token.balanceOf(recipient), 1e18);
+    }
+}

--- a/contracts/test/mock/MockWallet.sol
+++ b/contracts/test/mock/MockWallet.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.30;
 import {Wallet} from "src/Wallet.sol";
 
 contract MockWallet is Wallet {
+    uint256 public pings;
+
+    /// @notice Target for Wallet self-call liveness tests (L-04)
+    function ping() external {
+        pings += 1;
+    }
+
     function submitTransaction(uint256 tokenId, address to, uint256 value, bytes memory data) public {
         _submitTransaction(tokenId, to, value, data);
     }

--- a/contracts/test/unit/ChamberUpgrade.t.sol
+++ b/contracts/test/unit/ChamberUpgrade.t.sol
@@ -139,6 +139,55 @@ contract ChamberUpgradeTest is Test {
         assertNotEq(newImpl, currentImpl);
     }
 
+    function test_Chamber_UpgradeViaTransaction_ForgottenCalldata_UsesStored() public {
+        bytes32 implSlot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address currentImpl = address(uint160(uint256(vm.load(chamberAddress, implSlot))));
+
+        bytes memory upgradeData =
+            abi.encodeWithSelector(IChamber.upgradeImplementation.selector, address(newImplementation), "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, chamberAddress, 0, upgradeData);
+
+        uint256 txId = chamber.getTransactionCount() - 1;
+        assertEq(chamber.getTransactionCalldata(txId), upgradeData);
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, txId);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, txId);
+
+        // Execute without re-supplying the original bytes (logs / archives unavailable).
+        vm.prank(user1);
+        chamber.executeTransaction(1, txId, "");
+
+        address newImpl = address(uint160(uint256(vm.load(chamberAddress, implSlot))));
+        assertEq(newImpl, address(newImplementation));
+        assertNotEq(newImpl, currentImpl);
+    }
+
+    function test_Chamber_UpgradeViaTransaction_WrongCalldata_Reverts() public {
+        bytes memory upgradeData =
+            abi.encodeWithSelector(IChamber.upgradeImplementation.selector, address(newImplementation), "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, chamberAddress, 0, upgradeData);
+
+        uint256 txId = chamber.getTransactionCount() - 1;
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, txId);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, txId);
+
+        bytes memory wrongData =
+            abi.encodeWithSelector(IChamber.upgradeImplementation.selector, address(implementation), "");
+
+        vm.prank(user1);
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        chamber.executeTransaction(1, txId, wrongData);
+    }
+
     function test_Chamber_UpgradeViaTransaction_WithInitialization() public {
         // Create a new implementation with a different version
         Chamber v2Implementation = new Chamber();

--- a/contracts/test/unit/Wallet.t.sol
+++ b/contracts/test/unit/Wallet.t.sol
@@ -204,6 +204,49 @@ contract WalletTest is Test {
         assertEq(wallet.getNextTransactionId(), 2);
     }
 
+    function test_Wallet_ExecuteTransaction_DataHashMismatch_Reverts() public {
+        bytes memory data = hex"deadbeef";
+        wallet.submitTransaction(1, address(0x3), 0, data);
+
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        wallet.executeTransaction(1, 0, hex"cafebabe");
+    }
+
+    function test_Wallet_ExecuteTransaction_ForgottenCalldata_HashOnly_Reverts() public {
+        bytes memory data = hex"deadbeef";
+        wallet.submitTransaction(1, address(0x3), 0, data);
+
+        assertEq(wallet.getTransactionCalldata(0).length, 0);
+
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        wallet.executeTransaction(1, 0, "");
+    }
+
+    function test_Wallet_SelfCall_StoresCalldata_AndExecutesWithoutResupply() public {
+        bytes memory data = abi.encodeWithSignature("ping()");
+
+        wallet.submitTransaction(1, address(wallet), 0, data);
+
+        assertEq(wallet.getTransactionCalldata(0), data);
+        (,,,, bytes32 dataHash) = wallet.getTransaction(0);
+        assertEq(dataHash, keccak256(data));
+
+        wallet.executeTransaction(1, 0, "");
+
+        (bool executed,,,,) = wallet.getTransaction(0);
+        assertTrue(executed);
+        assertEq(wallet.pings(), 1);
+    }
+
+    function test_Wallet_SelfCall_WrongCalldata_Reverts() public {
+        bytes memory data = abi.encodeWithSignature("ping()");
+        wallet.submitTransaction(1, address(wallet), 0, data);
+
+        vm.expectRevert(IWallet.DataHashMismatch.selector);
+        wallet.executeTransaction(1, 0, hex"cafebabe");
+        assertEq(wallet.pings(), 0);
+    }
+
     function test_Wallet_ConfirmTransaction_AlreadyExecuted_Reverts() public {
         address target = address(0x3);
         bytes memory data = "";

--- a/docs/protocol/multisig.md
+++ b/docs/protocol/multisig.md
@@ -18,6 +18,8 @@ Other Directors must confirm the transaction.
 Once the number of confirmations reaches the **Quorum**, any Director can execute the transaction.
 - The Chamber uses the **Checks-Effects-Interactions (CEI)** pattern to prevent reentrancy during execution.
 - If a Director who confirmed a transaction is unseated before execution, their confirmation still counts (as the action was authorized while they were a Director).
+- Ordinary calls store only `keccak256(calldata)`; the executor must re-supply the original bytes (typically recovered from the `SubmitTransaction` event).
+- Self-calls (`target == Chamber`, restricted to `upgradeImplementation`) also persist the original bytes onchain. Execution may pass empty `data` and the stored payload is used, so a confirmed upgrade remains executable if logs are unavailable.
 
 ## Batch Operations
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **L-04** (liveness, not theft): Wallet stored only `keccak256(data)`, so `executeTransaction` required the original bytes from `SubmitTransaction` logs / `metadataURI`. If those archives are unavailable, a fully confirmed upgrade cannot be executed.

This change keeps hash-only storage for ordinary treasury calls (gas) and persists full calldata **only** for self-calls (`target == address(this)`). On Chamber that path is already restricted to `upgradeImplementation`.

## Behavior

- Submit of a self-call / upgrade stores original bytes in `WalletStorage.transactionCalldata` (appended ERC-7201 mapping).
- `executeTransaction` / `executeBatchTransactions` may pass empty `data` for those nonces; the stored payload is used.
- Any non-empty caller `data` is still hash-checked.
- Ordinary txs stay hash-only: forgotten or mismatched bytes revert `DataHashMismatch`.
- New reader: `getTransactionCalldata(nonce)`.

Does **not** address H-01 / M-06.

## Tests

Foundry (286 unit/fuzz/e2e/findings tests) passed, including:

- `FindingL04UpgradeCalldataLivenessTest` — upgrade and batch upgrade execute without re-supplied bytes; normal ERC-20 transfer still hash-checks.
- Wallet unit tests for self-call store + forgotten-bytes execute, and hash-only mismatch.
- Chamber upgrade unit tests for forgotten / wrong calldata.

## Docs

Notes the on-chain upgrade store in `docs/protocol/multisig.md` and the app protocol/API copies.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23523043-894e-455a-921f-d6d939e52cdd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23523043-894e-455a-921f-d6d939e52cdd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

