### PR TITLE
fix(wallet): expire transactions after a 30-day deadline (M-06)

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -889,6 +889,16 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     }
 
     /// @inheritdoc IWallet
+    function getTransactionDeadline(uint256 nonce) public view override(IWallet, Wallet) returns (uint256) {
+        return super.getTransactionDeadline(nonce);
+    }
+
+    /// @inheritdoc IWallet
+    function isTransactionExpired(uint256 nonce) public view override(IWallet, Wallet) returns (bool) {
+        return super.isTransactionExpired(nonce);
+    }
+
+    /// @inheritdoc IWallet
     function getCancelConfirmation(uint256 tokenId, uint256 nonce)
         public
         view

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -360,6 +360,25 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     }
 
     /**
+     * @notice Submits a new transaction for approval with an explicit execution deadline
+     * @param tokenId The tokenId submitting the transaction
+     * @param target The address to send the transaction to
+     * @param value The amount of Ether to send
+     * @param data The data to include in the transaction
+     * @param deadline Exclusive-after unix timestamp; `0` applies the 30-day default max age
+     */
+    function submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data, uint256 deadline)
+        public
+        override
+        nonReentrant
+        isDirector(tokenId)
+    {
+        _validateTransaction(target, value, data);
+        _submitTransaction(tokenId, target, value, data, deadline);
+        emit IChamber.TransactionSubmitted(getNextTransactionId() - 1, target, value);
+    }
+
+    /**
      * @notice Submits a new transaction with durable proposal metadata for approval
      * @param tokenId The tokenId submitting the transaction
      * @param target The address to send the transaction to
@@ -376,6 +395,28 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     ) public override nonReentrant isDirector(tokenId) {
         _validateTransaction(target, value, data);
         _submitTransactionWithMetadata(tokenId, target, value, data, metadataURI);
+        emit IChamber.TransactionSubmitted(getNextTransactionId() - 1, target, value);
+    }
+
+    /**
+     * @notice Submits a new transaction with durable proposal metadata and an explicit deadline
+     * @param tokenId The tokenId submitting the transaction
+     * @param target The address to send the transaction to
+     * @param value The amount of Ether to send
+     * @param data The data to include in the transaction
+     * @param metadataURI URI or content hash describing the proposal rationale and risk context
+     * @param deadline Exclusive-after unix timestamp; `0` applies the 30-day default max age
+     */
+    function submitTransactionWithMetadata(
+        uint256 tokenId,
+        address target,
+        uint256 value,
+        bytes memory data,
+        string memory metadataURI,
+        uint256 deadline
+    ) public override nonReentrant isDirector(tokenId) {
+        _validateTransaction(target, value, data);
+        _submitTransactionWithMetadata(tokenId, target, value, data, metadataURI, deadline);
         emit IChamber.TransactionSubmitted(getNextTransactionId() - 1, target, value);
     }
 
@@ -420,6 +461,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
         Transaction storage transaction = $w.transactions[transactionId];
         if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
         if ($w.cancelled[transactionId]) revert IWallet.TransactionAlreadyCancelled();
+        _notExpired(transactionId);
         if (transaction.confirmations < _requiredConfirmations(transactionId)) {
             revert IChamber.NotEnoughConfirmations();
         }

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -8,7 +8,8 @@ import {IWallet} from "./interfaces/IWallet.sol";
  * @author xhad, Loreum DAO LLC
  * @notice Abstract contract implementing multisig transaction management
  * @dev Provides core functionality for submitting, confirming, and executing transactions
- *      with configurable quorum requirements.
+ *      with configurable quorum requirements. Submitted transactions expire after a
+ *      deadline (default 30 days) and cannot be confirmed, revoked, or executed once expired.
  *
  * Gas optimization — hash-only calldata storage for ordinary calls:
  *   Transaction.data (formerly dynamic `bytes`) is replaced with `bytes32 dataHash`.
@@ -48,6 +49,9 @@ abstract contract Wallet {
         bytes32 dataHash;
     }
 
+    /// @notice Default lifetime for a submitted transaction when no deadline is provided
+    uint256 public constant DEFAULT_TRANSACTION_MAX_AGE = 30 days;
+
     /**
      * @notice ERC-7201 namespaced storage layout for Wallet
      * @custom:storage-location erc7201:loreum.Wallet
@@ -63,6 +67,8 @@ abstract contract Wallet {
         mapping(uint256 nonce => bytes storedCalldata) transactionCalldata;
         /// @dev Quorum at submit time (M-04). Appended mapping is upgrade-safe; does not resize Transaction[].
         mapping(uint256 nonce => uint256 requiredQuorum) transactionRequiredQuorum;
+        /// @dev unix timestamp after which the nonce is treated as expired (non-executable)
+        mapping(uint256 nonce => uint256 deadline) transactionDeadline;
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Wallet")) - 1)) & ~bytes32(uint256(0xff))
@@ -106,6 +112,31 @@ abstract contract Wallet {
         if (_getWalletStorage().cancelled[nonce]) revert IWallet.TransactionAlreadyCancelled();
     }
 
+    /// @notice Modifier to check if a transaction has not passed its deadline
+    modifier notExpired(uint256 nonce) {
+        _notExpired(nonce);
+        _;
+    }
+
+    function _notExpired(uint256 nonce) internal view {
+        if (block.timestamp > _getWalletStorage().transactionDeadline[nonce]) revert IWallet.TransactionExpired();
+    }
+
+    /**
+     * @notice Resolves a submit-time deadline. Zero means the default max age.
+     * @dev Rejects timestamps that are not in the future or that exceed the 30-day max age.
+     */
+    function _resolveDeadline(uint256 deadline) internal view returns (uint256 resolved) {
+        uint256 maxDeadline = block.timestamp + DEFAULT_TRANSACTION_MAX_AGE;
+        if (deadline == 0) {
+            return maxDeadline;
+        }
+        if (deadline <= block.timestamp || deadline > maxDeadline) {
+            revert IWallet.InvalidDeadline();
+        }
+        return deadline;
+    }
+
     /// @notice Modifier to check if a transaction has not been confirmed by a specific tokenId
     modifier notConfirmed(uint256 tokenId, uint256 nonce) {
         _notConfirmed(tokenId, nonce);
@@ -124,7 +155,21 @@ abstract contract Wallet {
      * @param data The calldata to execute (hash stored always; full bytes stored for self-calls)
      */
     function _submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data) internal {
-        _submitTransactionWithMetadata(tokenId, target, value, data, "");
+        _submitTransaction(tokenId, target, value, data, 0);
+    }
+
+    /**
+     * @notice Submits a new transaction with an explicit deadline and auto-confirms for the submitter
+     * @param tokenId The token ID submitting the transaction
+     * @param target The destination address for the transaction
+     * @param value The amount of ETH to send
+     * @param data The calldata to execute (stored as keccak256 hash only)
+     * @param deadline Exclusive-after unix timestamp; `0` applies {DEFAULT_TRANSACTION_MAX_AGE}
+     */
+    function _submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data, uint256 deadline)
+        internal
+    {
+        _submitTransactionWithMetadata(tokenId, target, value, data, "", deadline);
     }
 
     /**
@@ -142,8 +187,29 @@ abstract contract Wallet {
         bytes memory data,
         string memory metadataURI
     ) internal {
+        _submitTransactionWithMetadata(tokenId, target, value, data, metadataURI, 0);
+    }
+
+    /**
+     * @notice Submits a new transaction with metadata and an explicit deadline
+     * @param tokenId The token ID submitting the transaction
+     * @param target The destination address for the transaction
+     * @param value The amount of ETH to send
+     * @param data The calldata to execute (stored as keccak256 hash only)
+     * @param metadataURI URI or content hash describing the proposal rationale and risk context
+     * @param deadline Exclusive-after unix timestamp; `0` applies {DEFAULT_TRANSACTION_MAX_AGE}
+     */
+    function _submitTransactionWithMetadata(
+        uint256 tokenId,
+        address target,
+        uint256 value,
+        bytes memory data,
+        string memory metadataURI,
+        uint256 deadline
+    ) internal {
         WalletStorage storage $ = _getWalletStorage();
         uint256 nonce = $.transactions.length;
+        uint256 resolvedDeadline = _resolveDeadline(deadline);
 
         bytes32 dataHash = keccak256(data);
         $.transactions
@@ -153,6 +219,8 @@ abstract contract Wallet {
             $.transactionCalldata[nonce] = data;
         }
         $.transactionRequiredQuorum[nonce] = _submitQuorum();
+        $.transactionDeadline[nonce] = resolvedDeadline;
+        emit IWallet.TransactionDeadlineSet(nonce, resolvedDeadline);
         if (bytes(metadataURI).length != 0) {
             $.transactionMetadataURI[nonce] = metadataURI;
             emit IWallet.ProposalMetadataSet(nonce, metadataURI);
@@ -181,6 +249,7 @@ abstract contract Wallet {
         txExists(nonce)
         notExecuted(nonce)
         notCancelled(nonce)
+        notExpired(nonce)
         notConfirmed(tokenId, nonce)
     {
         WalletStorage storage $ = _getWalletStorage();
@@ -202,6 +271,7 @@ abstract contract Wallet {
         txExists(nonce)
         notExecuted(nonce)
         notCancelled(nonce)
+        notExpired(nonce)
     {
         WalletStorage storage $ = _getWalletStorage();
         if (!$.isConfirmed[nonce][tokenId]) revert IWallet.TransactionNotConfirmed();
@@ -258,6 +328,7 @@ abstract contract Wallet {
         txExists(nonce)
         notExecuted(nonce)
         notCancelled(nonce)
+        notExpired(nonce)
     {
         WalletStorage storage $ = _getWalletStorage();
         Transaction storage transaction = $.transactions[nonce];
@@ -377,6 +448,24 @@ abstract contract Wallet {
      */
     function getCancelled(uint256 nonce) public view virtual returns (bool) {
         return _getWalletStorage().cancelled[nonce];
+    }
+
+    /**
+     * @notice Returns the exclusive-after unix timestamp after which `nonce` cannot be executed
+     * @param nonce The index of the transaction to retrieve
+     * @return deadline The stored deadline (`block.timestamp + DEFAULT_TRANSACTION_MAX_AGE` when submit used `0`)
+     */
+    function getTransactionDeadline(uint256 nonce) public view virtual txExists(nonce) returns (uint256 deadline) {
+        return _getWalletStorage().transactionDeadline[nonce];
+    }
+
+    /**
+     * @notice Returns whether a transaction has passed its deadline
+     * @param nonce The index of the transaction to check
+     * @return True if `block.timestamp` is strictly greater than the stored deadline
+     */
+    function isTransactionExpired(uint256 nonce) public view virtual txExists(nonce) returns (bool) {
+        return block.timestamp > _getWalletStorage().transactionDeadline[nonce];
     }
 
     /**

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -8,8 +8,9 @@ import {IWallet} from "./interfaces/IWallet.sol";
  * @author xhad, Loreum DAO LLC
  * @notice Abstract contract implementing multisig transaction management
  * @dev Provides core functionality for submitting, confirming, and executing transactions
- *      with configurable quorum requirements. Submitted transactions expire after a
+ *      with configurable quorum requirements. Newly submitted transactions expire after a
  *      deadline (default 30 days) and cannot be confirmed, revoked, or executed once expired.
+ *      A stored deadline of `0` means unset (pre-upgrade pending nonce) and is not expired.
  *
  * Gas optimization — hash-only calldata storage for ordinary calls:
  *   Transaction.data (formerly dynamic `bytes`) is replaced with `bytes32 dataHash`.
@@ -67,7 +68,7 @@ abstract contract Wallet {
         mapping(uint256 nonce => bytes storedCalldata) transactionCalldata;
         /// @dev Quorum at submit time (M-04). Appended mapping is upgrade-safe; does not resize Transaction[].
         mapping(uint256 nonce => uint256 requiredQuorum) transactionRequiredQuorum;
-        /// @dev unix timestamp after which the nonce is treated as expired (non-executable)
+        /// @dev exclusive-after unix timestamp; `0` is unset (no expiry, pre-upgrade pending)
         mapping(uint256 nonce => uint256 deadline) transactionDeadline;
     }
 
@@ -119,7 +120,9 @@ abstract contract Wallet {
     }
 
     function _notExpired(uint256 nonce) internal view {
-        if (block.timestamp > _getWalletStorage().transactionDeadline[nonce]) revert IWallet.TransactionExpired();
+        uint256 deadline = _getWalletStorage().transactionDeadline[nonce];
+        // `0` is unset (legacy pending nonce) and must remain executable after upgrade.
+        if (deadline != 0 && block.timestamp > deadline) revert IWallet.TransactionExpired();
     }
 
     /**
@@ -453,7 +456,7 @@ abstract contract Wallet {
     /**
      * @notice Returns the exclusive-after unix timestamp after which `nonce` cannot be executed
      * @param nonce The index of the transaction to retrieve
-     * @return deadline The stored deadline (`block.timestamp + DEFAULT_TRANSACTION_MAX_AGE` when submit used `0`)
+     * @return deadline Stored deadline; `0` means unset / no expiry (pre-upgrade pending)
      */
     function getTransactionDeadline(uint256 nonce) public view virtual txExists(nonce) returns (uint256 deadline) {
         return _getWalletStorage().transactionDeadline[nonce];
@@ -462,10 +465,11 @@ abstract contract Wallet {
     /**
      * @notice Returns whether a transaction has passed its deadline
      * @param nonce The index of the transaction to check
-     * @return True if `block.timestamp` is strictly greater than the stored deadline
+     * @return True if a non-zero deadline is stored and `block.timestamp` is strictly greater
      */
     function isTransactionExpired(uint256 nonce) public view virtual txExists(nonce) returns (bool) {
-        return block.timestamp > _getWalletStorage().transactionDeadline[nonce];
+        uint256 deadline = _getWalletStorage().transactionDeadline[nonce];
+        return deadline != 0 && block.timestamp > deadline;
     }
 
     /**

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -13,7 +13,8 @@ pragma solidity ^0.8.30;
  *      can submit, self-confirm, and execute (a single-actor treasury). Confirmations are not
  *      capped per owner.
  *      Submit records a deadline (default 30 days, or an explicit future timestamp up to that max).
- *      After the deadline, confirm/revoke/execute revert with `TransactionExpired`.
+ *      After a non-zero deadline, confirm/revoke/execute revert with `TransactionExpired`.
+ *      Stored deadline `0` is unset (pre-upgrade pending) and is not expired.
  */
 interface IWallet {
     /**
@@ -191,14 +192,14 @@ interface IWallet {
     /**
      * @notice Returns the exclusive-after unix timestamp after which the transaction cannot be executed
      * @param nonce The index of the transaction to retrieve
-     * @return deadline Stored deadline timestamp
+     * @return deadline Stored deadline timestamp; `0` means unset / no expiry
      */
     function getTransactionDeadline(uint256 nonce) external view returns (uint256 deadline);
 
     /**
      * @notice Returns whether a transaction has passed its deadline
      * @param nonce The index of the transaction to check
-     * @return True if the transaction is expired
+     * @return True if a non-zero deadline is stored and has passed; `false` when deadline is `0`
      */
     function isTransactionExpired(uint256 nonce) external view returns (bool);
 
@@ -280,7 +281,7 @@ interface IWallet {
     /**
      * @notice Emitted when a transaction deadline is recorded at submit time
      * @param nonce The identifier of the transaction
-     * @param deadline Exclusive-after unix timestamp after which execute/confirm/revoke revert
+     * @param deadline Exclusive-after unix timestamp after which execute/confirm/revoke revert (never `0`)
      */
     event TransactionDeadlineSet(uint256 indexed nonce, uint256 deadline);
 

--- a/contracts/src/interfaces/IWallet.sol
+++ b/contracts/src/interfaces/IWallet.sol
@@ -12,6 +12,8 @@ pragma solidity ^0.8.30;
  *      That quorum is token-weighted: one address that holds `quorum` top-seat membership NFTs
  *      can submit, self-confirm, and execute (a single-actor treasury). Confirmations are not
  *      capped per owner.
+ *      Submit records a deadline (default 30 days, or an explicit future timestamp up to that max).
+ *      After the deadline, confirm/revoke/execute revert with `TransactionExpired`.
  */
 interface IWallet {
     /**
@@ -22,6 +24,17 @@ interface IWallet {
      * @param data The calldata (hash stored always; full bytes stored when `target` is this wallet)
      */
     function submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data) external;
+
+    /**
+     * @notice Submits a new transaction for approval with an explicit execution deadline
+     * @param tokenId The tokenId submitting the transaction
+     * @param target The address to send the transaction to
+     * @param value The amount of Ether to send
+     * @param data The calldata (stored onchain as keccak256 hash only)
+     * @param deadline Exclusive-after unix timestamp; `0` applies the 30-day default max age
+     */
+    function submitTransaction(uint256 tokenId, address target, uint256 value, bytes memory data, uint256 deadline)
+        external;
 
     /**
      * @notice Submits a new transaction for approval with durable proposal metadata
@@ -37,6 +50,24 @@ interface IWallet {
         uint256 value,
         bytes memory data,
         string memory metadataURI
+    ) external;
+
+    /**
+     * @notice Submits a new transaction with durable proposal metadata and an explicit deadline
+     * @param tokenId The tokenId submitting the transaction
+     * @param target The address to send the transaction to
+     * @param value The amount of Ether to send
+     * @param data The calldata (stored onchain as keccak256 hash only)
+     * @param metadataURI URI or content hash describing the proposal rationale and risk context
+     * @param deadline Exclusive-after unix timestamp; `0` applies the 30-day default max age
+     */
+    function submitTransactionWithMetadata(
+        uint256 tokenId,
+        address target,
+        uint256 value,
+        bytes memory data,
+        string memory metadataURI,
+        uint256 deadline
     ) external;
 
     /**
@@ -158,6 +189,20 @@ interface IWallet {
     function getCancelled(uint256 nonce) external view returns (bool);
 
     /**
+     * @notice Returns the exclusive-after unix timestamp after which the transaction cannot be executed
+     * @param nonce The index of the transaction to retrieve
+     * @return deadline Stored deadline timestamp
+     */
+    function getTransactionDeadline(uint256 nonce) external view returns (uint256 deadline);
+
+    /**
+     * @notice Returns whether a transaction has passed its deadline
+     * @param nonce The index of the transaction to check
+     * @return True if the transaction is expired
+     */
+    function isTransactionExpired(uint256 nonce) external view returns (bool);
+
+    /**
      * @notice Checks if a director has voted to cancel a transaction
      * @param tokenId The tokenId of the director to check
      * @param nonce The index of the transaction to check
@@ -232,6 +277,13 @@ interface IWallet {
      */
     event TransactionCancelled(uint256 indexed nonce);
 
+    /**
+     * @notice Emitted when a transaction deadline is recorded at submit time
+     * @param nonce The identifier of the transaction
+     * @param deadline Exclusive-after unix timestamp after which execute/confirm/revoke revert
+     */
+    event TransactionDeadlineSet(uint256 indexed nonce, uint256 deadline);
+
     /// Errors
     /// @notice Thrown when a transaction does not exist
     error TransactionDoesNotExist();
@@ -247,6 +299,12 @@ interface IWallet {
 
     /// @notice Thrown when a transaction has already been cancelled
     error TransactionAlreadyCancelled();
+
+    /// @notice Thrown when a transaction's deadline has passed
+    error TransactionExpired();
+
+    /// @notice Thrown when a submit deadline is not in the future or exceeds the 30-day max age
+    error InvalidDeadline();
 
     /// @notice Thrown when a director has already voted to cancel
     error TransactionCancelAlreadyConfirmed();

--- a/contracts/test/findings/FindingL04_UpgradeCalldataLiveness.t.sol
+++ b/contracts/test/findings/FindingL04_UpgradeCalldataLiveness.t.sol
@@ -35,6 +35,7 @@ contract FindingL04UpgradeCalldataLivenessTest is Test {
         chamber = IChamber(chamberAddress);
 
         _setupDirectors();
+        vm.roll(block.number + 1);
     }
 
     function _setupDirectors() internal {

--- a/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
+++ b/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IWallet} from "src/interfaces/IWallet.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+
+/**
+ * @title M-06: Wallet transactions have no deadline — FIXED
+ * @notice After the stored deadline, execute reverts. Before the deadline,
+ *         a fully confirmed transaction still executes.
+ */
+contract FindingM06WalletExpiryTest is Test {
+    Chamber public chamber;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+
+    uint256 public constant SEATS = 5;
+    bytes internal constant EMPTY = "";
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 100_000_000e18);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), SEATS, "vERC20", "VLT", address(0x9));
+
+        _setupDirector(user1, 1, 1 ether);
+        _setupDirector(user2, 2, 1 ether);
+        _setupDirector(user3, 3, 1 ether);
+    }
+
+    function test_M06_ExecuteAfterDeadline_Reverts() public {
+        address target = address(0x3);
+        uint256 value = 1 ether;
+        uint256 deadline = block.timestamp + 7 days;
+        deal(address(chamber), value);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, target, value, EMPTY, deadline);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        vm.warp(deadline + 1);
+
+        assertTrue(chamber.isTransactionExpired(0));
+        vm.expectRevert(IWallet.TransactionExpired.selector);
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, EMPTY);
+    }
+
+    function test_M06_ExecuteBeforeDeadline_Succeeds() public {
+        address target = address(0x4);
+        uint256 value = 1 ether;
+        uint256 deadline = block.timestamp + 7 days;
+        deal(address(chamber), value);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, target, value, EMPTY, deadline);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        vm.warp(deadline);
+
+        assertFalse(chamber.isTransactionExpired(0));
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, EMPTY);
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+        assertEq(target.balance, value);
+    }
+
+    function test_M06_DefaultSubmit_UsesThirtyDayMaxAge() public {
+        uint256 submittedAt = block.timestamp;
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, EMPTY);
+
+        assertEq(chamber.getTransactionDeadline(0), submittedAt + chamber.DEFAULT_TRANSACTION_MAX_AGE());
+        assertEq(chamber.DEFAULT_TRANSACTION_MAX_AGE(), 30 days);
+    }
+
+    function _setupDirector(address user, uint256 tokenId, uint256 amount) internal {
+        nft.mintWithTokenId(user, tokenId);
+        token.mint(user, amount);
+        vm.startPrank(user);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, amount);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
+++ b/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
@@ -35,6 +35,7 @@ contract FindingM06WalletExpiryTest is Test {
         _setupDirector(user1, 1, 1 ether);
         _setupDirector(user2, 2, 1 ether);
         _setupDirector(user3, 3, 1 ether);
+        vm.roll(block.number + 1);
     }
 
     function test_M06_ExecuteAfterDeadline_Reverts() public {

--- a/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
+++ b/contracts/test/findings/Finding_M06_WalletExpiry.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
 import {Chamber} from "src/Chamber.sol";
 import {IWallet} from "src/interfaces/IWallet.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
@@ -21,6 +21,8 @@ contract FindingM06WalletExpiryTest is Test {
     address public user1 = address(0x1);
     address public user2 = address(0x2);
     address public user3 = address(0x3);
+
+    using stdStorage for StdStorage;
 
     uint256 public constant SEATS = 5;
     bytes internal constant EMPTY = "";
@@ -88,6 +90,63 @@ contract FindingM06WalletExpiryTest is Test {
 
         assertEq(chamber.getTransactionDeadline(0), submittedAt + chamber.DEFAULT_TRANSACTION_MAX_AGE());
         assertEq(chamber.DEFAULT_TRANSACTION_MAX_AGE(), 30 days);
+    }
+
+    function test_M06_LegacyUnsetDeadline_ConfirmAndExecute_Succeeds() public {
+        address target = address(0x5);
+        uint256 value = 1 ether;
+        deal(address(chamber), value);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, target, value, EMPTY);
+        _clearStoredDeadline(0);
+
+        assertEq(chamber.getTransactionDeadline(0), 0);
+        assertFalse(chamber.isTransactionExpired(0));
+
+        vm.warp(block.timestamp + 365 days);
+        assertFalse(chamber.isTransactionExpired(0));
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, EMPTY);
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+        assertEq(target.balance, value);
+    }
+
+    function test_M06_FourArgSubmit_ExpiresAfterThirtyDays() public {
+        address target = address(0x6);
+        uint256 value = 1 ether;
+        uint256 submittedAt = block.timestamp;
+        deal(address(chamber), value);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, target, value, EMPTY);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        uint256 deadline = chamber.getTransactionDeadline(0);
+        assertEq(deadline, submittedAt + chamber.DEFAULT_TRANSACTION_MAX_AGE());
+
+        vm.warp(deadline + 1);
+        assertTrue(chamber.isTransactionExpired(0));
+        vm.expectRevert(IWallet.TransactionExpired.selector);
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, EMPTY);
+    }
+
+    /// @dev Simulate a pre-upgrade pending nonce: mapping value is still the zero default.
+    function _clearStoredDeadline(uint256 nonce) internal {
+        stdstore.target(address(chamber)).sig(chamber.getTransactionDeadline.selector).with_key(nonce).checked_write(
+            uint256(0)
+        );
     }
 
     function _setupDirector(address user, uint256 tokenId, uint256 amount) internal {

--- a/contracts/test/mock/MockWallet.sol
+++ b/contracts/test/mock/MockWallet.sol
@@ -32,4 +32,9 @@ contract MockWallet is Wallet {
     function revokeConfirmation(uint256 tokenId, uint256 transactionId) public {
         _revokeConfirmation(tokenId, transactionId);
     }
+
+    /// @dev Test hook: simulate a pre-upgrade pending nonce whose deadline mapping is unset (`0`).
+    function forceTransactionDeadline(uint256 nonce, uint256 deadline) public {
+        _getWalletStorage().transactionDeadline[nonce] = deadline;
+    }
 }

--- a/contracts/test/mock/MockWallet.sol
+++ b/contracts/test/mock/MockWallet.sol
@@ -15,6 +15,12 @@ contract MockWallet is Wallet {
         _submitTransaction(tokenId, to, value, data);
     }
 
+    function submitTransaction(uint256 tokenId, address to, uint256 value, bytes memory data, uint256 deadline)
+        public
+    {
+        _submitTransaction(tokenId, to, value, data, deadline);
+    }
+
     function confirmTransaction(uint256 tokenId, uint256 transactionId) public {
         _confirmTransaction(tokenId, transactionId);
     }

--- a/contracts/test/unit/Wallet.t.sol
+++ b/contracts/test/unit/Wallet.t.sol
@@ -263,6 +263,71 @@ contract WalletTest is Test {
         vm.expectRevert(IWallet.TransactionAlreadyExecuted.selector);
         wallet.confirmTransaction(2, 0);
     }
+
+    function test_Wallet_SubmitTransaction_DefaultDeadline() public {
+        uint256 submittedAt = block.timestamp;
+        wallet.submitTransaction(1, address(0x3), 0, "");
+
+        assertEq(wallet.getTransactionDeadline(0), submittedAt + wallet.DEFAULT_TRANSACTION_MAX_AGE());
+        assertFalse(wallet.isTransactionExpired(0));
+    }
+
+    function test_Wallet_SubmitTransaction_ExplicitDeadline() public {
+        uint256 deadline = block.timestamp + 1 days;
+        wallet.submitTransaction(1, address(0x3), 0, "", deadline);
+
+        assertEq(wallet.getTransactionDeadline(0), deadline);
+        assertFalse(wallet.isTransactionExpired(0));
+    }
+
+    function test_Wallet_SubmitTransaction_PastDeadline_Reverts() public {
+        vm.expectRevert(IWallet.InvalidDeadline.selector);
+        wallet.submitTransaction(1, address(0x3), 0, "", block.timestamp);
+    }
+
+    function test_Wallet_SubmitTransaction_ExceedsMaxAge_Reverts() public {
+        uint256 tooFar = block.timestamp + wallet.DEFAULT_TRANSACTION_MAX_AGE() + 1;
+        vm.expectRevert(IWallet.InvalidDeadline.selector);
+        wallet.submitTransaction(1, address(0x3), 0, "", tooFar);
+    }
+
+    function test_Wallet_ExecuteTransaction_BeforeDeadline_Succeeds() public {
+        address target = address(0x3);
+        bytes memory data = "";
+        uint256 deadline = block.timestamp + 2 days;
+        deal(address(wallet), 1 ether);
+
+        wallet.submitTransaction(1, target, 1 ether, data, deadline);
+        vm.warp(deadline);
+        wallet.executeTransaction(1, 0, data);
+
+        (bool executed,,,,) = wallet.getTransaction(0);
+        assertTrue(executed);
+        assertEq(target.balance, 1 ether);
+    }
+
+    function test_Wallet_ExecuteTransaction_AfterDeadline_Reverts() public {
+        address target = address(0x3);
+        bytes memory data = "";
+        uint256 deadline = block.timestamp + 1 days;
+        deal(address(wallet), 1 ether);
+
+        wallet.submitTransaction(1, target, 1 ether, data, deadline);
+        vm.warp(deadline + 1);
+
+        assertTrue(wallet.isTransactionExpired(0));
+        vm.expectRevert(IWallet.TransactionExpired.selector);
+        wallet.executeTransaction(1, 0, data);
+    }
+
+    function test_Wallet_ConfirmTransaction_AfterDeadline_Reverts() public {
+        uint256 deadline = block.timestamp + 1 days;
+        wallet.submitTransaction(1, address(0x3), 0, "", deadline);
+        vm.warp(deadline + 1);
+
+        vm.expectRevert(IWallet.TransactionExpired.selector);
+        wallet.confirmTransaction(2, 0);
+    }
 }
 
 contract RevertingContract {

--- a/contracts/test/unit/Wallet.t.sol
+++ b/contracts/test/unit/Wallet.t.sol
@@ -328,6 +328,46 @@ contract WalletTest is Test {
         vm.expectRevert(IWallet.TransactionExpired.selector);
         wallet.confirmTransaction(2, 0);
     }
+
+    function test_Wallet_LegacyUnsetDeadline_ConfirmAndExecute_Succeeds() public {
+        address target = address(0x3);
+        bytes memory data = "";
+        deal(address(wallet), 1 ether);
+
+        wallet.submitTransaction(1, target, 1 ether, data);
+        wallet.forceTransactionDeadline(0, 0);
+
+        assertEq(wallet.getTransactionDeadline(0), 0);
+        assertFalse(wallet.isTransactionExpired(0));
+
+        vm.warp(block.timestamp + 365 days);
+        assertFalse(wallet.isTransactionExpired(0));
+
+        wallet.confirmTransaction(2, 0);
+        wallet.executeTransaction(1, 0, data);
+
+        (bool executed,,,,) = wallet.getTransaction(0);
+        assertTrue(executed);
+        assertEq(target.balance, 1 ether);
+    }
+
+    function test_Wallet_FourArgSubmit_ExpiresAfterThirtyDays() public {
+        address target = address(0x3);
+        bytes memory data = "";
+        uint256 submittedAt = block.timestamp;
+        deal(address(wallet), 1 ether);
+
+        wallet.submitTransaction(1, target, 1 ether, data);
+
+        uint256 deadline = wallet.getTransactionDeadline(0);
+        assertEq(deadline, submittedAt + wallet.DEFAULT_TRANSACTION_MAX_AGE());
+        assertFalse(wallet.isTransactionExpired(0));
+
+        vm.warp(deadline + 1);
+        assertTrue(wallet.isTransactionExpired(0));
+        vm.expectRevert(IWallet.TransactionExpired.selector);
+        wallet.executeTransaction(1, 0, data);
+    }
 }
 
 contract RevertingContract {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **M-06**: wallet transactions stayed executable until executed or a live cancel quorum was reached, with no deadline field.

Rebased onto latest `origin/main` (includes **L-04** #128 and **M-04** #120). All three stay in place:

- **M-06**: 30-day default/max deadline; stored `0` = unset / not expired; confirm / revoke / execute expire; cancel is not gated
- **L-04**: self-call / upgrade calldata stored onchain
- **M-04**: execute requires `max(submitQuorum, liveQuorum)`

This change stores a deadline at submit and treats expiry like a cancelled / non-executable state. Confirm, revoke, and execute revert with `TransactionExpired` once a **non-zero** deadline has passed (`block.timestamp > deadline`). Cancel is not gated by expiry.

H-01 confirmer revalidation is **not** in this PR.

## Upgrade safety

Safe to upgrade live chambers that have pending nonces.

`transactionDeadline` is appended after the L-04 / M-04 mappings, so every pre-upgrade nonce reads as `0`. Stored deadline `0` means **unset / no expiry** — the same as today. Those pending txs remain confirmable and executable. This PR does **not** backfill a 30-day deadline onto legacy nonces.

Already-expired post-upgrade txs (non-zero deadline in the past) stay expired. They are not silently extended.

## API change

Existing 4-argument `submitTransaction` / `submitTransactionWithMetadata` / batch submit keep working. They now apply a **30-day default and maximum age** on **new** submits:

- submit-time `deadline == 0` → store `block.timestamp + 30 days` (never persist `0` for new txs)
- explicit `deadline` must be in `(block.timestamp, block.timestamp + 30 days]`
- stored `deadline == 0` (legacy / unset) → `isTransactionExpired` is `false`; confirm / revoke / execute still work
- `getTransactionDeadline` returns `0` to mean unset

New overloads (and matching getters / errors / event):

```solidity
submitTransaction(tokenId, target, value, data, deadline)
submitTransactionWithMetadata(tokenId, target, value, data, metadataURI, deadline)

getTransactionDeadline(nonce) → uint256  // 0 = unset / no expiry
isTransactionExpired(nonce) → bool       // false when deadline is 0
DEFAULT_TRANSACTION_MAX_AGE = 30 days

error TransactionExpired()
error InvalidDeadline()
event TransactionDeadlineSet(uint256 indexed nonce, uint256 deadline)
```

## Tests

Foundry coverage in `contracts/test/unit/Wallet.t.sol` and `contracts/test/findings/Finding_M06_WalletExpiry.t.sol`:

- After a stored deadline, `executeTransaction` reverts (`TransactionExpired`)
- At/before deadline, execute still succeeds with valid confirmations
- Default 4-arg submit records a 30-day deadline and expires after it
- Past or >30-day submit deadlines revert (`InvalidDeadline`)
- A nonce with stored deadline `0` (pre-upgrade pending) can still be confirmed and executed
- L-04 and M-04 findings suites still pass after rebase

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ae36ec-0dc9-4cca-929d-94184f7d8737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ae36ec-0dc9-4cca-929d-94184f7d8737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

