### PR TITLE
Unify reentrancy on OZ transient guard (M-02)

### DIFF
--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.30;
 
 import {IBoard} from "./interfaces/IBoard.sol";
+import {
+    ReentrancyGuardTransientUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardTransientUpgradeable.sol";
 
 /**
  * @title Board
@@ -9,9 +12,11 @@ import {IBoard} from "./interfaces/IBoard.sol";
  * @notice Manages a sorted linked list of nodes representing token delegations and board seats
  * @dev Abstract contract that implements core board functionality including delegation tracking
  *      and seat management. Uses a doubly linked list to maintain sorted order of delegations.
- *
+ *      Reentrancy uses OpenZeppelin `ReentrancyGuardTransientUpgradeable` (EIP-1153) at public
+ *      entry points. Internals (`_delegate` / `_undelegate`) are unguarded so callers can wrap
+ *      a full operation in a single `nonReentrant` without a nested-lock revert.
  */
-abstract contract Board {
+abstract contract Board is ReentrancyGuardTransientUpgradeable {
     /**
      * @notice Node structure for the doubly linked list
      * @dev next and prev are uint128, packed into one storage slot.
@@ -45,7 +50,7 @@ abstract contract Board {
     /**
      * @notice ERC-7201 namespaced storage layout for Board
      * @dev size and seats are uint32, sharing one 32-byte slot (max values 50 and 20 fit
-     *      comfortably). locked has been removed; reentrancy is handled via transient storage.
+     *      comfortably). Reentrancy is handled by OpenZeppelin `ReentrancyGuardTransientUpgradeable`.
      * @custom:storage-location erc7201:loreum.Board
      */
     struct BoardStorage {
@@ -69,14 +74,6 @@ abstract contract Board {
     ///      is treated as mature so a live in-place upgrade cannot lock existing directors.
     uint256 internal constant SEATING_DELAY = 1;
 
-    /**
-     * @dev Transient storage slot used for the circuit-breaker reentrancy lock.
-     *      Uses a domain-separated value to avoid collisions with other contracts that
-     *      might also use transient storage in the same call chain.
-     *      Value: uint256(keccak256("loreum.Board.circuitBreaker"))
-     */
-    uint256 private constant _TRANSIENT_LOCK_SLOT = 0x63a9d87af1ca3d71f80fefdfe0f7c45cfede4a17e7c60e4bd0c022a28e82e0c;
-
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Board")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant _BOARD_STORAGE_SLOT = 0xae916af301d5dc481b59b170e7db23e36b830da7017e456f99549768499c8800;
 
@@ -87,38 +84,6 @@ abstract contract Board {
     }
 
     /// @dev Events and errors are defined in IBoard interface
-
-    /// MODIFIERS ///
-
-    /**
-     * @notice Circuit-breaker modifier using EIP-1153 transient storage.
-     * @dev Sets a transient lock on entry; clears it after body executes.
-     *      TSTORE/TLOAD cost ~100 gas each vs. ~20k/2.1k for SSTORE/SLOAD on a cold slot.
-     */
-    modifier circuitBreaker() {
-        _circuitBreakerBefore();
-        _;
-        _circuitBreakerAfter();
-    }
-
-    function _circuitBreakerBefore() internal {
-        bool locked;
-        uint256 slot = _TRANSIENT_LOCK_SLOT;
-        assembly {
-            locked := tload(slot)
-        }
-        if (locked) revert IBoard.CircuitBreakerActive();
-        assembly {
-            tstore(slot, 1)
-        }
-    }
-
-    function _circuitBreakerAfter() internal {
-        uint256 slot = _TRANSIENT_LOCK_SLOT;
-        assembly {
-            tstore(slot, 0)
-        }
-    }
 
     /// FUNCTIONS ///
 
@@ -134,11 +99,11 @@ abstract contract Board {
     /**
      * @notice Handles token delegation to a specific tokenId
      * @dev Updates or creates a node and maintains sorted order.
-     *      The circuitBreaker modifier locks transient storage for the full operation.
+     *      Callers must hold the shared OZ `nonReentrant` lock for the full public operation.
      * @param tokenId The token ID to delegate to
      * @param amount The amount of tokens to delegate
      */
-    function _delegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+    function _delegate(uint256 tokenId, uint256 amount) internal {
         uint256[] memory prevTop = _topTokenIds();
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
@@ -155,11 +120,11 @@ abstract contract Board {
     /**
      * @notice Handles token undelegation from a specific tokenId
      * @dev Reduces delegation amount or removes node if amount becomes zero.
-     *      The circuitBreaker modifier locks transient storage for the full operation.
+     *      Callers must hold the shared OZ `nonReentrant` lock for the full public operation.
      * @param tokenId The token ID to undelegate from
      * @param amount The amount of tokens to undelegate
      */
-    function _undelegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+    function _undelegate(uint256 tokenId, uint256 amount) internal {
         uint256[] memory prevTop = _topTokenIds();
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
@@ -184,7 +149,7 @@ abstract contract Board {
      *      Compared to the previous remove+re-insert approach, this avoids a full `delete`
      *      (4-slot zero write + SSTORE refund complexity) and a fresh cold-slot insert scan.
      *      Worst case is still O(N), but the common single-step move costs ~6 SSTOREs vs ~14+.
-     *      Called only from within a circuitBreaker-locked context (_delegate / _undelegate).
+     *      Called only from a `nonReentrant` public entry (_delegate / _undelegate).
      * @param tokenId The token ID to reposition
      */
     function _reposition(uint256 tokenId) internal {

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -6,6 +6,7 @@ import {Wallet} from "src/Wallet.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
 import {IWallet} from "src/interfaces/IWallet.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC721} from "lib/openzeppelin-contracts/contracts/interfaces/IERC721.sol";
 import {IERC721Receiver} from "lib/openzeppelin-contracts/contracts/token/ERC721/IERC721Receiver.sol";
 import {
@@ -730,19 +731,29 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     /// ERC-4626 OVERRIDES ///
 
     /// @inheritdoc ERC4626Upgradeable
-    function deposit(uint256 assets, address receiver) public override nonReentrant returns (uint256) {
+    function deposit(uint256 assets, address receiver)
+        public
+        override(ERC4626Upgradeable, IERC4626)
+        nonReentrant
+        returns (uint256)
+    {
         return super.deposit(assets, receiver);
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    function mint(uint256 shares, address receiver) public override nonReentrant returns (uint256) {
+    function mint(uint256 shares, address receiver)
+        public
+        override(ERC4626Upgradeable, IERC4626)
+        nonReentrant
+        returns (uint256)
+    {
         return super.mint(shares, receiver);
     }
 
     /// @inheritdoc ERC4626Upgradeable
     function withdraw(uint256 assets, address receiver, address owner)
         public
-        override
+        override(ERC4626Upgradeable, IERC4626)
         nonReentrant
         returns (uint256)
     {
@@ -750,7 +761,12 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    function redeem(uint256 shares, address receiver, address owner) public override nonReentrant returns (uint256) {
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        override(ERC4626Upgradeable, IERC4626)
+        nonReentrant
+        returns (uint256)
+    {
         return super.redeem(shares, receiver, owner);
     }
 

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -12,9 +12,6 @@ import {
     ERC4626Upgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {ERC20Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
-import {
-    ReentrancyGuardUpgradeable
-} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import {
     ITransparentUpgradeableProxy
@@ -26,7 +23,7 @@ import {StorageSlot} from "lib/openzeppelin-contracts/contracts/utils/StorageSlo
  * @notice This contract is a smart vault for managing assets with a board of directors
  * @author xhad, Loreum DAO LLC
  */
-contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Wallet, IChamber, IERC721Receiver {
+contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver {
     /**
      * @notice ERC-7201 namespaced storage layout for Chamber
      * @dev Packing: `nft` (address, 20 bytes) sits alone in its slot; remaining fields are
@@ -102,7 +99,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
         __ERC4626_init(IERC20(erc20Token));
         __ERC20_init(_name, _symbol);
-        __ReentrancyGuard_init();
+        __ReentrancyGuardTransient_init();
 
         ChamberStorage storage $ = _getChamberStorage();
         $.nft = IERC721(erc721Token);
@@ -115,7 +112,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      * @param tokenId The tokenId to which tokens are delegated
      * @param amount The amount of tokens to delegate
      */
-    function delegate(uint256 tokenId, uint256 amount) external override {
+    function delegate(uint256 tokenId, uint256 amount) external override nonReentrant {
         if (tokenId == 0) revert IChamber.ZeroTokenId();
         if (amount == 0) revert IChamber.ZeroAmount();
 
@@ -148,7 +145,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      * @param tokenId The tokenId from which tokens are undelegated
      * @param amount The amount of tokens to undelegate
      */
-    function undelegate(uint256 tokenId, uint256 amount) external override {
+    function undelegate(uint256 tokenId, uint256 amount) external override nonReentrant {
         if (tokenId == 0) revert IChamber.ZeroTokenId();
         if (amount == 0) revert IChamber.ZeroAmount();
 
@@ -324,7 +321,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      * @param tokenId The tokenId proposing the update
      * @param numOfSeats The new number of seats
      */
-    function updateSeats(uint256 tokenId, uint256 numOfSeats) public override isDirector(tokenId) {
+    function updateSeats(uint256 tokenId, uint256 numOfSeats) public override nonReentrant isDirector(tokenId) {
         if (numOfSeats == 0) revert IChamber.ZeroSeats();
         if (numOfSeats > MAX_SEATS) revert IChamber.TooManySeats();
         _setSeats(tokenId, numOfSeats);
@@ -334,7 +331,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
      * @notice Executes a pending seat update proposal if it has enough support and the timelock has expired
      * @param tokenId The tokenId executing the update
      */
-    function executeSeatsUpdate(uint256 tokenId) public override isDirector(tokenId) {
+    function executeSeatsUpdate(uint256 tokenId) public override nonReentrant isDirector(tokenId) {
         _executeSeatsUpdate(tokenId);
     }
 
@@ -707,6 +704,10 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     /**
      * @notice Upgrades the Chamber implementation via `ProxyAdmin.upgradeAndCall`
      * @dev Reverts with `NotAuthorized` if this contract is not the `ProxyAdmin` owner.
+     *      Must not take `nonReentrant`: the only legitimate caller is this contract via
+     *      `executeTransaction` (`msg.sender == address(this)`), which already holds the shared
+     *      guard. A nested `nonReentrant` would make every upgrade revert. External reentry is
+     *      already rejected by the `NotAuthorized` sender check.
      * @param newImplementation The new implementation address
      * @param data Optional initialization data for the new implementation
      */
@@ -724,6 +725,33 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
         ITransparentUpgradeableProxy proxy = ITransparentUpgradeableProxy(address(this));
         proxyAdmin.upgradeAndCall(proxy, newImplementation, data);
+    }
+
+    /// ERC-4626 OVERRIDES ///
+
+    /// @inheritdoc ERC4626Upgradeable
+    function deposit(uint256 assets, address receiver) public override nonReentrant returns (uint256) {
+        return super.deposit(assets, receiver);
+    }
+
+    /// @inheritdoc ERC4626Upgradeable
+    function mint(uint256 shares, address receiver) public override nonReentrant returns (uint256) {
+        return super.mint(shares, receiver);
+    }
+
+    /// @inheritdoc ERC4626Upgradeable
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        override
+        nonReentrant
+        returns (uint256)
+    {
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /// @inheritdoc ERC4626Upgradeable
+    function redeem(uint256 shares, address receiver, address owner) public override nonReentrant returns (uint256) {
+        return super.redeem(shares, receiver, owner);
     }
 
     /// ERC20 OVERRIDES ///

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -140,7 +140,8 @@ interface IBoard {
     /// @notice Thrown when the linked list has reached its maximum size
     error MaxNodesReached();
 
-    /// @notice Thrown when circuit breaker is active
+    /// @notice Deprecated: reentrancy now reverts with OZ `ReentrancyGuardReentrantCall`.
+    ///         Kept for ABI compatibility.
     error CircuitBreakerActive();
 
     /// @notice Thrown when a non-proposer attempts to cancel a seat update proposal (Fix Finding 14)

--- a/contracts/test/findings/FindingM02_ReentrancyGuard.t.sol
+++ b/contracts/test/findings/FindingM02_ReentrancyGuard.t.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Registry} from "src/Registry.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployRegistry} from "test/utils/DeployRegistry.sol";
+import {
+    ReentrancyGuardTransientUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardTransientUpgradeable.sol";
+
+/**
+ * @title M-02: Shared reentrancy guard on vault, board, and seat mutators
+ * @notice Defensive coverage: during wallet `target.call`, previously ungated
+ *         public mutators now revert with the shared OZ transient guard.
+ */
+
+/// @notice Callback target that attempts one Chamber mutator during execution.
+contract GuardedReenterTarget {
+    enum Action {
+        Deposit,
+        Mint,
+        Withdraw,
+        Redeem,
+        Delegate,
+        Undelegate,
+        UpdateSeats,
+        ExecuteSeatsUpdate
+    }
+
+    Chamber public immutable chamber;
+    Action public action;
+    bool public attempted;
+    bool public reenterReverted;
+
+    constructor(address _chamber) {
+        chamber = Chamber(payable(_chamber));
+    }
+
+    function setAction(Action _action) external {
+        action = _action;
+        attempted = false;
+        reenterReverted = false;
+    }
+
+    receive() external payable {
+        if (attempted) return;
+        attempted = true;
+
+        if (action == Action.Deposit) {
+            _try(address(chamber), abi.encodeCall(chamber.deposit, (1, address(this))));
+        } else if (action == Action.Mint) {
+            _try(address(chamber), abi.encodeCall(chamber.mint, (1, address(this))));
+        } else if (action == Action.Withdraw) {
+            _try(address(chamber), abi.encodeCall(chamber.withdraw, (1, address(this), address(this))));
+        } else if (action == Action.Redeem) {
+            _try(address(chamber), abi.encodeCall(chamber.redeem, (1, address(this), address(this))));
+        } else if (action == Action.Delegate) {
+            _try(address(chamber), abi.encodeCall(chamber.delegate, (1, 1)));
+        } else if (action == Action.Undelegate) {
+            _try(address(chamber), abi.encodeCall(chamber.undelegate, (1, 1)));
+        } else if (action == Action.UpdateSeats) {
+            _try(address(chamber), abi.encodeCall(chamber.updateSeats, (1, 4)));
+        } else {
+            _try(address(chamber), abi.encodeCall(chamber.executeSeatsUpdate, (1)));
+        }
+    }
+
+    function _try(address target, bytes memory data) private {
+        (bool ok, bytes memory reason) = target.call(data);
+        reenterReverted = !ok && _isGuardError(reason);
+    }
+
+    function _isGuardError(bytes memory reason) private pure returns (bool) {
+        return reason.length >= 4
+            && bytes4(reason) == ReentrancyGuardTransientUpgradeable.ReentrancyGuardReentrantCall.selector;
+    }
+}
+
+contract FindingM02ReentrancyGuardTest is Test {
+    Registry public registry;
+    MockERC20 public token;
+    MockERC721 public nft;
+    address public admin = makeAddr("admin");
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+    address public chamberAddress;
+    IChamber public chamber;
+    GuardedReenterTarget public target;
+
+    function setUp() public {
+        token = new MockERC20("Test Token", "TEST", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        registry = DeployRegistry.deploy(admin);
+
+        chamberAddress = registry.createChamber(address(token), address(nft), 3, "Chamber Token", "CHMB");
+        chamber = IChamber(chamberAddress);
+        target = new GuardedReenterTarget(chamberAddress);
+
+        _setupDirector(user1, 1, 100e18);
+        _setupDirector(user2, 2, 100e18);
+        _setupDirector(user3, 3, 100e18);
+    }
+
+    function test_M02_DepositRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Deposit);
+    }
+
+    function test_M02_MintRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Mint);
+    }
+
+    function test_M02_WithdrawRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Withdraw);
+    }
+
+    function test_M02_RedeemRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Redeem);
+    }
+
+    function test_M02_DelegateRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Delegate);
+    }
+
+    function test_M02_UndelegateRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.Undelegate);
+    }
+
+    function test_M02_UpdateSeatsRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.UpdateSeats);
+    }
+
+    function test_M02_ExecuteSeatsUpdateRevertsOnReenter() public {
+        _assertGuarded(GuardedReenterTarget.Action.ExecuteSeatsUpdate);
+    }
+
+    function test_M02_GuardReleasedAfterExecution() public {
+        _assertGuarded(GuardedReenterTarget.Action.Deposit);
+
+        deal(address(token), user1, 1e18);
+        vm.startPrank(user1);
+        token.approve(chamberAddress, 1e18);
+        uint256 shares = chamber.deposit(1e18, user1);
+        vm.stopPrank();
+
+        assertGt(shares, 0, "deposit succeeds after the wallet guard is released");
+    }
+
+    function _assertGuarded(GuardedReenterTarget.Action action) internal {
+        target.setAction(action);
+
+        deal(chamberAddress, 1 ether);
+
+        vm.prank(user2);
+        chamber.submitTransaction(2, address(target), 0.1 ether, "");
+
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        vm.prank(user2);
+        chamber.executeTransaction(2, 0, "");
+
+        assertTrue(target.attempted(), "callback ran during execution");
+        assertTrue(target.reenterReverted(), "reenter reverted with ReentrancyGuardReentrantCall");
+    }
+
+    function _setupDirector(address user, uint256 tokenId, uint256 amount) internal {
+        token.mint(user, amount);
+        nft.mintWithTokenId(user, tokenId);
+
+        vm.startPrank(user);
+        token.approve(chamberAddress, amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, 1);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/findings/FindingM02_ReentrancyGuard.t.sol
+++ b/contracts/test/findings/FindingM02_ReentrancyGuard.t.sol
@@ -104,6 +104,7 @@ contract FindingM02ReentrancyGuardTest is Test {
         _setupDirector(user1, 1, 100e18);
         _setupDirector(user2, 2, 100e18);
         _setupDirector(user3, 3, 100e18);
+        vm.roll(block.number + 1);
     }
 
     function test_M02_DepositRevertsOnReenter() public {

--- a/contracts/test/mock/MockBoard.sol
+++ b/contracts/test/mock/MockBoard.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.24;
 import {Board} from "src/Board.sol";
 
 contract MockBoard is Board {
-    function exposed_delegate(uint256 tokenId, uint256 amount) public {
+    function exposed_delegate(uint256 tokenId, uint256 amount) public nonReentrant {
         _delegate(tokenId, amount);
     }
 
-    function exposed_undelegate(uint256 tokenId, uint256 amount) public {
+    function exposed_undelegate(uint256 tokenId, uint256 amount) public nonReentrant {
         _undelegate(tokenId, amount);
     }
 
@@ -62,20 +62,18 @@ contract MockBoard is Board {
     }
 
     /**
-     * @notice Sets the transient circuit-breaker lock and immediately tries to delegate again
-     *         in the same call — simulates reentrancy to verify the guard fires.
+     * @notice Holds the shared OZ lock and immediately calls `exposed_delegate`.
+     *         Simulates reentrancy so the second `nonReentrant` entry reverts.
      */
-    function lockAndDelegate(uint256 tokenId, uint256 amount) public {
-        _circuitBreakerBefore();
-        _delegate(tokenId, amount); // Should revert with CircuitBreakerActive
+    function lockAndDelegate(uint256 tokenId, uint256 amount) public nonReentrant {
+        this.exposed_delegate(tokenId, amount);
     }
 
     /**
-     * @notice Locks the board and tries to reposition within the same call
-     *         (used to test that reposition is guarded when called from a locked context).
+     * @notice Holds the shared OZ lock and immediately calls `exposed_undelegate`.
+     *         Simulates reentrancy so the second `nonReentrant` entry reverts.
      */
-    function lockAndReposition(uint256 tokenId) public {
-        _circuitBreakerBefore();
-        _reposition(tokenId); // NodeDoesNotExist if not inserted; CircuitBreakerActive path via _delegate
+    function lockAndUndelegate(uint256 tokenId, uint256 amount) public nonReentrant {
+        this.exposed_undelegate(tokenId, amount);
     }
 }

--- a/contracts/test/symbolic/BoardSym.t.sol
+++ b/contracts/test/symbolic/BoardSym.t.sol
@@ -52,7 +52,7 @@ contract BoardSymTest is Test, SymTest {
         _assertSortedDescending(board.getSize());
     }
 
-    /// @dev Reentrancy guard blocks a second delegate while the circuit breaker is held
+    /// @dev Shared OZ reentrancy guard blocks a second delegate while the lock is held
     function symbolicCircuitBreakerBlocksReentrantDelegate() public {
         uint256 tokenId = svm.createUint(128, "tokenId");
         uint256 amount = svm.createUint256("amount");

--- a/contracts/test/unit/Board.t.sol
+++ b/contracts/test/unit/Board.t.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 import {Test} from "lib/forge-std/src/Test.sol";
 import {MockBoard} from "test/mock/MockBoard.sol";
 import {IBoard} from "src/interfaces/IBoard.sol";
+import {
+    ReentrancyGuardTransientUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardTransientUpgradeable.sol";
 
 contract BoardTest is Test {
     MockBoard board;
@@ -411,20 +414,20 @@ contract BoardTest is Test {
         assertEq(amounts.length, 0);
     }
 
-    // ─── Circuit breaker ───────────────────────────────────────────────
+    // ─── Shared OZ reentrancy guard ────────────────────────────────────
 
-    function test_Board_CircuitBreakerActive_Delegate_Reverts() public {
-        // lockAndDelegate acquires the transient lock then immediately calls _delegate in the
-        // same transaction, simulating reentrancy. The second _delegate should revert.
-        vm.expectRevert(IBoard.CircuitBreakerActive.selector);
+    function test_Board_ReentrancyGuard_Delegate_Reverts() public {
+        // lockAndDelegate holds nonReentrant then calls exposed_delegate, which is also
+        // nonReentrant. The nested entry should revert with the shared OZ error.
+        vm.expectRevert(ReentrancyGuardTransientUpgradeable.ReentrancyGuardReentrantCall.selector);
         board.lockAndDelegate(1, 100);
     }
 
-    function test_Board_CircuitBreakerActive_Undelegate_Reverts() public {
+    function test_Board_ReentrancyGuard_Undelegate_Reverts() public {
         board.exposed_delegate(1, 100);
 
-        vm.expectRevert(IBoard.CircuitBreakerActive.selector);
-        board.lockAndDelegate(1, 50);
+        vm.expectRevert(ReentrancyGuardTransientUpgradeable.ReentrancyGuardReentrantCall.selector);
+        board.lockAndUndelegate(1, 50);
     }
 
     // ─── executeSeatsUpdate: supporter no longer in top seats ──────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wallet mutators already used OpenZeppelin `nonReentrant`, but ERC-4626 entry points, `delegate` / `undelegate`, and seat updates did not. During `executeTransaction`’s `target.call`, those functions stayed callable on the same contract.

This PR puts **one** lock on those paths:

- Switch Chamber/Board to OpenZeppelin `ReentrancyGuardTransientUpgradeable` (already in the 5.1.0 tree; matches Board’s existing EIP-1153 approach).
- Apply `nonReentrant` to `deposit`, `mint`, `withdraw`, `redeem`, `delegate`, `undelegate`, `updateSeats`, and `executeSeatsUpdate`.
- Remove Board’s custom `circuitBreaker` so there are not two uncoordinated locks. Internals stay unguarded so a public wrapper can hold the lock for the full operation (including Chamber `undelegate` when the node was evicted).

`upgradeImplementation` is **not** wrapped. It is only reachable via `msg.sender == address(this)` from `executeTransaction`, which already holds the guard. Adding `nonReentrant` there would make every legitimate upgrade revert (`test_Chamber_UpgradeViaTransaction` still passes).

`IBoard.CircuitBreakerActive` is left in the ABI and marked deprecated.

## Tests

Foundry coverage asserts the guarded functions revert with `ReentrancyGuardReentrantCall` when entered during wallet execution. They do not claim a specific value-extraction path.

- `contracts/test/findings/FindingM02_ReentrancyGuard.t.sol` — 9 passing
- Board unit tests `test_Board_ReentrancyGuard_*` — 2 passing
- Full unit + findings suites after the change — 246 passing (including upgrade-via-transaction)

## Scope

M-02 only. No L-03 rewrite beyond replacing the custom Board lock with the same OZ primitive.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e993fb65-f8b4-468f-943c-de11d84b767a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e993fb65-f8b4-468f-943c-de11d84b767a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

