### PR TITLE
Fix H-03: expire stuck seat-update proposals

### DIFF
--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -74,6 +74,15 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
     ///      is treated as mature so a live in-place upgrade cannot lock existing directors.
     uint256 internal constant SEATING_DELAY = 1;
 
+    /// @notice Delay after a seat-update proposal is created before it may be executed
+    uint256 internal constant SEAT_UPDATE_TIMELOCK = 7 days;
+
+    /// @notice Age after which any current director may delete a seat-update proposal.
+    /// @dev Longer than {SEAT_UPDATE_TIMELOCK} so a quorum-ready proposal has an execute window
+    ///      before a minority can clear the single slot (Finding 14). Unblocks the slot when the
+    ///      original proposer has left and cannot cancel (H-03).
+    uint256 internal constant SEAT_UPDATE_EXPIRY = 14 days;
+
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Board")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant _BOARD_STORAGE_SLOT = 0xae916af301d5dc481b59b170e7db23e36b830da7017e456f99549768499c8800;
 
@@ -399,7 +408,9 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
 
     /**
      * @notice Sets or proposes a new number of board seats
-     * @dev Initial call sets seats directly; subsequent calls create/update proposals
+     * @dev Initial call sets seats directly; subsequent calls create/update proposals.
+     *      A different `numOfSeats` cancels the active proposal: the original proposer may
+     *      cancel at any time, and after {SEAT_UPDATE_EXPIRY} any director may cancel (H-03).
      * @param tokenId The token ID proposing the change (0 for initial setup)
      * @param numOfSeats The proposed number of seats
      */
@@ -422,10 +433,7 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
             proposal.requiredQuorum = _getQuorum();
         } else {
             if (proposal.proposedSeats != numOfSeats) {
-                // Only proposer can cancel (Fix Finding 14 — prevents minority griefing)
-                if (proposal.supporters.length == 0 || proposal.supporters[0] != tokenId) {
-                    revert IBoard.OnlyProposerCanCancel();
-                }
+                _authorizeSeatUpdateCancel(proposal, tokenId);
                 delete $.seatUpdate;
                 emit IBoard.SeatUpdateCancelled(tokenId);
                 return;
@@ -460,7 +468,7 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
         SeatUpdate storage proposal = $.seatUpdate;
 
         if (proposal.timestamp == 0) revert IBoard.InvalidProposal();
-        if (block.timestamp < proposal.timestamp + 7 days) revert IBoard.TimelockNotExpired();
+        if (block.timestamp < proposal.timestamp + SEAT_UPDATE_TIMELOCK) revert IBoard.TimelockNotExpired();
 
         // Build the top-seat set with a single O(seats) list walk
         uint256 s = $.seats;
@@ -596,5 +604,36 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
         uint256 seatedAt = _getBoardStorage().seatedAt[tokenId];
         if (seatedAt == 0) return true;
         return block.number >= seatedAt;
+    }
+
+    /**
+     * @notice Deletes a pending seat-update proposal.
+     * @dev The original proposer may cancel at any time. After {SEAT_UPDATE_EXPIRY}, any caller
+     *      (Chamber gates this to a current director) may clear the single slot so a departed
+     *      proposer cannot permanently block later seat changes.
+     * @param tokenId The token ID requesting cancellation
+     */
+    function _cancelSeatUpdate(uint256 tokenId) internal {
+        BoardStorage storage $ = _getBoardStorage();
+        SeatUpdate storage proposal = $.seatUpdate;
+        if (proposal.timestamp == 0) revert IBoard.InvalidProposal();
+
+        _authorizeSeatUpdateCancel(proposal, tokenId);
+        delete $.seatUpdate;
+        emit IBoard.SeatUpdateCancelled(tokenId);
+    }
+
+    /**
+     * @notice Reverts unless `tokenId` may cancel the active seat-update proposal.
+     * @dev Proposer (`supporters[0]`) may always cancel. After expiry, any director may cancel.
+     */
+    function _authorizeSeatUpdateCancel(SeatUpdate storage proposal, uint256 tokenId) internal view {
+        if (proposal.supporters.length > 0 && proposal.supporters[0] == tokenId) {
+            return;
+        }
+        if (proposal.timestamp != 0 && block.timestamp >= proposal.timestamp + SEAT_UPDATE_EXPIRY) {
+            return;
+        }
+        revert IBoard.OnlyProposerCanCancel();
     }
 }

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -336,6 +336,14 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         _executeSeatsUpdate(tokenId);
     }
 
+    /**
+     * @notice Deletes the pending seat-update proposal
+     * @param tokenId The tokenId requesting cancellation
+     */
+    function cancelSeatUpdate(uint256 tokenId) public override nonReentrant isDirector(tokenId) {
+        _cancelSeatUpdate(tokenId);
+    }
+
     /// WALLET ///
 
     /**

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -144,7 +144,7 @@ interface IBoard {
     ///         Kept for ABI compatibility.
     error CircuitBreakerActive();
 
-    /// @notice Thrown when a non-proposer attempts to cancel a seat update proposal (Fix Finding 14)
+    /// @notice Thrown when a non-proposer attempts to cancel a seat update proposal before expiry (Fix Finding 14 / H-03)
     error OnlyProposerCanCancel();
 
     /// @notice Thrown when a tokenId exceeds type(uint128).max (Node.next/prev are packed as uint128)

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -80,6 +80,14 @@ interface IChamber is IERC4626, IBoard, IWallet {
     function executeSeatsUpdate(uint256 tokenId) external;
 
     /**
+     * @notice Deletes the pending seat-update proposal.
+     * @dev The original proposer may cancel at any time. After the 14-day expiry, any current
+     *      director may clear the single slot (H-03). Does not change the 7-day execute timelock.
+     * @param tokenId The director token ID requesting cancellation
+     */
+    function cancelSeatUpdate(uint256 tokenId) external;
+
+    /**
      * @notice Optional hook reserved for registry flows; current implementation is a no-op.
      * @dev The registry transfers `ProxyAdmin` ownership to the chamber directly after deployment.
      */

--- a/contracts/test/findings/FindingH03_SeatUpdateExpiry.t.sol
+++ b/contracts/test/findings/FindingH03_SeatUpdateExpiry.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Registry} from "src/Registry.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {IBoard} from "src/interfaces/IBoard.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployRegistry} from "test/utils/DeployRegistry.sol";
+
+/**
+ * @title H-03: Seat-update slot has no expiry [HIGH] — FIXED
+ *
+ * @notice The single SeatUpdate slot could only be cancelled by supporters[0], and
+ *         updateSeats is isDirector-gated. If the proposer left before quorum, the
+ *         slot stayed occupied forever. After a 14-day expiry, any current director
+ *         may delete the proposal. The 7-day execute timelock is unchanged.
+ */
+contract SeatUpdateExpiryTest is Test {
+    Registry public registry;
+    MockERC20 public token;
+    MockERC721 public nft;
+    address public admin = makeAddr("admin");
+    address public director1 = address(0x1);
+    address public director2 = address(0x2);
+    address public director3 = address(0x3);
+    address public minority = address(0x4);
+    address public chamberAddress;
+    IChamber public chamber;
+
+    function setUp() public {
+        token = new MockERC20("Test Token", "TEST", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        registry = DeployRegistry.deploy(admin);
+
+        // 4 seats; quorum = 1 + (4 * 51) / 100 = 3
+        chamberAddress = registry.createChamber(address(token), address(nft), 4, "Chamber Token", "CHMB");
+        chamber = IChamber(chamberAddress);
+
+        _setupDirector(director1, 1, 1000e18);
+        _setupDirector(director2, 2, 1000e18);
+        _setupDirector(director3, 3, 1000e18);
+        _setupDirector(minority, 4, 1e18);
+        vm.roll(block.number + 1);
+
+        assertEq(chamber.getSeats(), 4);
+        assertEq(chamber.getQuorum(), 3);
+    }
+
+    /**
+     * @notice After expiry, a current director can clear a stuck proposal even if the
+     *         original proposer is no longer a director.
+     */
+    function test_ExpiredProposal_CurrentDirectorCanClear() public {
+        vm.prank(director1);
+        chamber.updateSeats(1, 5);
+
+        // Proposer leaves the board — cannot cancel via isDirector-gated updateSeats
+        uint256 stake = chamber.getHolderDelegation(director1, 1);
+        vm.prank(director1);
+        chamber.undelegate(1, stake);
+        assertEq(chamber.getSize(), 3, "proposer left the leaderboard");
+
+        vm.prank(director1);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.cancelSeatUpdate(1);
+
+        vm.prank(director2);
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        chamber.cancelSeatUpdate(2);
+
+        vm.warp(block.timestamp + 14 days);
+
+        vm.prank(director2);
+        chamber.cancelSeatUpdate(2);
+
+        (uint256 proposedSeats, uint256 timestamp,, uint256[] memory supporters) = chamber.getSeatUpdate();
+        assertEq(proposedSeats, 0, "proposal cleared");
+        assertEq(timestamp, 0, "slot empty");
+        assertEq(supporters.length, 0, "no leftover supporters");
+
+        // Slot is reusable: a remaining director can open a new proposal
+        vm.prank(director2);
+        chamber.updateSeats(2, 3);
+        (uint256 nextSeats, uint256 nextTimestamp,,) = chamber.getSeatUpdate();
+        assertEq(nextSeats, 3);
+        assertGt(nextTimestamp, 0);
+    }
+
+    /**
+     * @notice Before expiry, a minority director cannot grief-cancel by proposing a
+     *         different seat count or calling cancelSeatUpdate.
+     */
+    function test_UnexpiredProposal_MinorityCannotGriefCancel() public {
+        vm.prank(director1);
+        chamber.updateSeats(1, 3);
+        vm.prank(director2);
+        chamber.updateSeats(2, 3);
+        vm.prank(director3);
+        chamber.updateSeats(3, 3);
+
+        vm.prank(minority);
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        chamber.updateSeats(4, 5);
+
+        vm.prank(minority);
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        chamber.cancelSeatUpdate(4);
+
+        // Still inside the 7–14 day execute window: minority still cannot cancel
+        vm.warp(block.timestamp + 8 days);
+        vm.prank(minority);
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        chamber.cancelSeatUpdate(4);
+
+        (uint256 proposedSeats, uint256 timestamp,,) = chamber.getSeatUpdate();
+        assertEq(proposedSeats, 3, "proposal intact");
+        assertGt(timestamp, 0, "proposal still active");
+    }
+
+    /**
+     * @notice Execute still requires the 7-day timelock even when the proposal has quorum.
+     */
+    function test_ExecuteStillRequiresTimelock() public {
+        vm.prank(director1);
+        chamber.updateSeats(1, 3);
+        vm.prank(director2);
+        chamber.updateSeats(2, 3);
+        vm.prank(director3);
+        chamber.updateSeats(3, 3);
+
+        vm.prank(director1);
+        vm.expectRevert(IBoard.TimelockNotExpired.selector);
+        chamber.executeSeatsUpdate(1);
+
+        vm.warp(block.timestamp + 7 days - 1);
+        vm.prank(director1);
+        vm.expectRevert(IBoard.TimelockNotExpired.selector);
+        chamber.executeSeatsUpdate(1);
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(director1);
+        chamber.executeSeatsUpdate(1);
+        assertEq(chamber.getSeats(), 3, "seats reduced after timelock");
+    }
+
+    function _setupDirector(address user, uint256 tokenId, uint256 amount) internal {
+        token.mint(user, amount);
+        nft.mintWithTokenId(user, tokenId);
+
+        vm.startPrank(user);
+        token.approve(chamberAddress, amount);
+        chamber.deposit(amount, user);
+        uint256 shares = chamber.balanceOf(user);
+        chamber.delegate(tokenId, shares);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/mock/MockBoard.sol
+++ b/contracts/test/mock/MockBoard.sol
@@ -48,6 +48,10 @@ contract MockBoard is Board {
         _executeSeatsUpdate(tokenId);
     }
 
+    function cancelSeatUpdate(uint256 tokenId) public {
+        _cancelSeatUpdate(tokenId);
+    }
+
     function getQuorum() public view returns (uint256) {
         return _getQuorum();
     }

--- a/contracts/test/unit/Board.t.sol
+++ b/contracts/test/unit/Board.t.sol
@@ -264,6 +264,60 @@ contract BoardTest is Test {
         board.setSeats(2, 8);
     }
 
+    function test_Board_SetSeats_ExpiredNonProposerCanCancel() public {
+        board.setSeats(1, 7);
+        board.setSeats(2, 7);
+
+        vm.warp(block.timestamp + 14 days);
+
+        board.setSeats(2, 8);
+
+        (uint256 proposedSeats, uint256 timestamp,,) = board.getSeatUpdate();
+        assertEq(proposedSeats, 0);
+        assertEq(timestamp, 0);
+    }
+
+    function test_Board_CancelSeatUpdate_ExpiredNonProposerClears() public {
+        board.setSeats(1, 7);
+
+        vm.warp(block.timestamp + 14 days);
+
+        board.cancelSeatUpdate(2);
+
+        (, uint256 timestamp,,) = board.getSeatUpdate();
+        assertEq(timestamp, 0);
+    }
+
+    function test_Board_CancelSeatUpdate_UnexpiredNonProposerReverts() public {
+        board.setSeats(1, 7);
+
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        board.cancelSeatUpdate(2);
+    }
+
+    function test_Board_CancelSeatUpdate_NoProposal_Reverts() public {
+        vm.expectRevert(IBoard.InvalidProposal.selector);
+        board.cancelSeatUpdate(1);
+    }
+
+    function test_Board_ExecuteSeatsUpdate_StillRequiresTimelockAfterPartialExpiryWindow() public {
+        board.insert(1, 100);
+        board.insert(2, 100);
+        board.insert(3, 100);
+
+        board.setSeats(1, 7);
+        board.setSeats(2, 7);
+        board.setSeats(3, 7);
+
+        // 8 days: execute window is open, 14-day cancel expiry is not
+        vm.warp(block.timestamp + 8 days);
+        vm.expectRevert(IBoard.OnlyProposerCanCancel.selector);
+        board.cancelSeatUpdate(2);
+
+        board.executeSeatsUpdate(1);
+        assertEq(board.getSeats(), 7);
+    }
+
     function test_Board_SetSeats_AlreadyVoted_Reverts() public {
         board.setSeats(1, 7);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The single `SeatUpdate` slot could only be cancelled by `supporters[0]`, and `updateSeats` is `isDirector`-gated. If the original proposer left the board before quorum, nobody could cancel or replace the proposal. Chambers that had already raised seats above populated size could not recover quorum.

This change adds a **14-day expiry**. After that, any current director may delete the proposal (`cancelSeatUpdate`, or `updateSeats` with a different seat count). The original proposer can still cancel at any time.

## What stayed the same

- **7-day execute timelock** is unchanged. Execute still reverts with `TimelockNotExpired` until `timestamp + 7 days`.
- **Finding 14** still holds: before expiry, a minority director cannot grief-cancel (`OnlyProposerCanCancel`).
- No `numOfSeats <= max(size, 1)` cap. Seats may exceed current list size so a chamber can grow; that would be a product rule beyond unblocking the slot.

## Tests

All required assertions pass locally:

```
forge test --match-contract "SeatUpdateExpiryTest|BoardTest|SeatProposalGriefingTest|StaleSeatUpdateSupportersTest"
```

- `test_ExpiredProposal_CurrentDirectorCanClear` — after the proposer leaves, a remaining director clears the slot at 14 days.
- `test_UnexpiredProposal_MinorityCannotGriefCancel` — minority cannot cancel before expiry, including during the 7–14 day execute window.
- `test_ExecuteStillRequiresTimelock` — execute reverts until `timestamp + 7 days`.
- Finding 14 griefing tests and Chamber `updateSeats` / `executeSeatsUpdate` unit tests still pass.

## Scope

H-03 only. No other findings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27168e16-7b44-4721-9634-7628d7e3c243?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27168e16-7b44-4721-9634-7628d7e3c243&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

