### PR TITLE
Add board-quorum pause for vault and wallet execute (L-02)

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -13,6 +13,7 @@ import {
     ERC4626Upgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {ERC20Upgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
+import {PausableUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
 import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import {
     ITransparentUpgradeableProxy
@@ -25,7 +26,7 @@ import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/
  * @notice This contract is a smart vault for managing assets with a board of directors
  * @author xhad, Loreum DAO LLC
  */
-contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver {
+contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, IChamber, IERC721Receiver {
     using EnumerableSet for EnumerableSet.UintSet;
 
     /**
@@ -63,10 +64,14 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
      *      (length word + data word) and incurs an SLOAD on every read. A bytes32 constant is
      *      inlined at compile time: zero runtime gas, zero storage slots.
      */
-    bytes32 public constant VERSION = "1.1.4";
+    bytes32 public constant VERSION = "1.1.5";
 
     /// @notice Function selector for upgradeImplementation(address,bytes)
     bytes4 private constant UPGRADE_SELECTOR = 0xc89311b6;
+    /// @notice Function selector for pause()
+    bytes4 private constant PAUSE_SELECTOR = 0x8456cb59;
+    /// @notice Function selector for unpause()
+    bytes4 private constant UNPAUSE_SELECTOR = 0x3f4ba83a;
 
     constructor() {
         _disableInitializers();
@@ -107,6 +112,7 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         __ERC4626_init(IERC20(erc20Token));
         __ERC20_init(_name, _symbol);
         __ReentrancyGuardTransient_init();
+        __Pausable_init();
 
         ChamberStorage storage $ = _getChamberStorage();
         $.nft = IERC721(erc721Token);
@@ -582,6 +588,7 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
             revert IChamber.NotEnoughConfirmations();
         }
+        _requireWalletExecuteAllowed(transaction.target, transactionId, data);
 
         _executeTransaction(tokenId, transactionId, data);
         emit IChamber.TransactionExecuted(transactionId, msg.sender);
@@ -656,12 +663,7 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
             if (targets[i] == address(0)) revert IChamber.ZeroAddress();
 
             if (targets[i] == address(this)) {
-                if (data[i].length < 4) revert IChamber.InvalidTransaction();
-                // forge-lint: disable-next-line(unsafe-typecast)
-                bytes4 selector = bytes4(data[i]);
-                if (selector != UPGRADE_SELECTOR) {
-                    revert IChamber.InvalidTransaction();
-                }
+                _requireAllowedSelfCall(data[i]);
             }
 
             _submitTransaction(tokenId, targets[i], values[i], data[i]);
@@ -692,17 +694,37 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         if (target == address(0)) revert IChamber.ZeroAddress();
 
         if (target == address(this)) {
-            if (data.length < 4) revert IChamber.InvalidTransaction();
-            // forge-lint: disable-next-line(unsafe-typecast)
-            bytes4 selector = bytes4(data);
-            if (selector != UPGRADE_SELECTOR) {
-                revert IChamber.InvalidTransaction();
-            }
+            _requireAllowedSelfCall(data);
         }
 
         if (value > 0 && address(this).balance < value) {
             revert IChamber.InsufficientChamberBalance();
         }
+    }
+
+    /// @dev Self-calls are limited to upgrade, pause, and unpause so the board cannot invoke arbitrary internals.
+    function _requireAllowedSelfCall(bytes memory data) internal pure {
+        if (data.length < 4) revert IChamber.InvalidTransaction();
+        // forge-lint: disable-next-line(unsafe-typecast)
+        bytes4 selector = bytes4(data);
+        if (selector != UPGRADE_SELECTOR && selector != PAUSE_SELECTOR && selector != UNPAUSE_SELECTOR) {
+            revert IChamber.InvalidTransaction();
+        }
+    }
+
+    /// @dev While paused, only a quorum self-call to unpause may execute. This avoids a permanent lock.
+    ///      Empty `data` uses L-04 stored self-call bytes (same as execute).
+    function _requireWalletExecuteAllowed(address target, uint256 transactionId, bytes calldata data) internal view {
+        if (!paused()) return;
+        bytes memory payload = data;
+        if (payload.length == 0) {
+            payload = _getWalletStorage().transactionCalldata[transactionId];
+        }
+        if (target == address(this) && payload.length >= 4) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            if (bytes4(payload) == UNPAUSE_SELECTOR) return;
+        }
+        _requireNotPaused();
     }
 
     /**
@@ -766,6 +788,7 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
             if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
                 revert IChamber.NotEnoughConfirmations();
             }
+            _requireWalletExecuteAllowed(transaction.target, transactionId, data[i]);
 
             _executeTransaction(tokenId, transactionId, data[i]);
             emit IChamber.TransactionExecuted(transactionId, msg.sender);
@@ -899,6 +922,29 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
     }
 
     /**
+     * @notice Pauses vault operations and wallet execution after board quorum.
+     * @dev `msg.sender` must be this chamber (self-call via `executeTransaction`).
+     */
+    function pause() external override {
+        if (msg.sender != address(this)) revert IChamber.NotAuthorized();
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses vault operations and wallet execution after board quorum.
+     * @dev `msg.sender` must be this chamber (self-call via `executeTransaction`).
+     */
+    function unpause() external override {
+        if (msg.sender != address(this)) revert IChamber.NotAuthorized();
+        _unpause();
+    }
+
+    /// @notice Returns true if vault operations and wallet execution are paused
+    function paused() public view override(PausableUpgradeable, IChamber) returns (bool) {
+        return PausableUpgradeable.paused();
+    }
+
+    /**
      * @notice Upgrades the Chamber implementation via `ProxyAdmin.upgradeAndCall`
      * @dev Reverts with `NotAuthorized` if this contract is not the `ProxyAdmin` owner.
      *      Must not take `nonReentrant`: the only legitimate caller is this contract via
@@ -994,13 +1040,42 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         return 3;
     }
 
+    /// @notice ERC-4626 deposits are disabled while paused
+    function maxDeposit(address receiver) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
+        if (paused()) return 0;
+        return super.maxDeposit(receiver);
+    }
+
+    /// @notice ERC-4626 mints are disabled while paused
+    function maxMint(address receiver) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
+        if (paused()) return 0;
+        return super.maxMint(receiver);
+    }
+
+    /// @notice ERC-4626 withdrawals are disabled while paused
+    function maxWithdraw(address owner) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
+        if (paused()) return 0;
+        return super.maxWithdraw(owner);
+    }
+
+    /// @notice ERC-4626 redemptions are disabled while paused
+    function maxRedeem(address owner) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
+        if (paused()) return 0;
+        return super.maxRedeem(owner);
+    }
+
     /**
      * @notice Deposit/mint workflow that requires the vault to receive exactly `assets`
      * @dev Hardens M-07: OpenZeppelin ERC-4626 mints shares from the requested amount, not the
      *      observed `balanceOf` delta. Fee-on-transfer tokens would otherwise credit shares for
      *      value the vault never received. Rebasing tokens remain unsupported.
+     *      Blocked while paused (L-02).
      */
-    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares)
+        internal
+        override
+        whenNotPaused
+    {
         IERC20 vaultAsset = IERC20(asset());
         uint256 balanceBefore = vaultAsset.balanceOf(address(this));
         super._deposit(caller, receiver, assets, shares);
@@ -1008,6 +1083,14 @@ contract Chamber is ERC4626Upgradeable, Board, Wallet, IChamber, IERC721Receiver
         if (balanceAfter < balanceBefore || balanceAfter - balanceBefore != assets) {
             revert IChamber.AssetAmountMismatch();
         }
+    }
+
+    function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
+        internal
+        override
+        whenNotPaused
+    {
+        super._withdraw(caller, receiver, owner, assets, shares);
     }
 
     /**

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -111,6 +111,24 @@ interface IChamber is IERC4626, IBoard, IWallet {
      */
     function upgradeImplementation(address newImplementation, bytes calldata data) external;
 
+    /**
+     * @notice Pauses vault deposit/withdraw/mint/redeem and wallet execution.
+     * @dev Must be called with `msg.sender == address(this)` after board quorum (via `executeTransaction`).
+     *      Direct EOA or director calls revert. While paused, only a quorum self-call to {unpause} may execute.
+     */
+    function pause() external;
+
+    /**
+     * @notice Unpauses vault operations and wallet execution.
+     * @dev Must be called with `msg.sender == address(this)` after board quorum (via `executeTransaction`).
+     */
+    function unpause() external;
+
+    /**
+     * @notice Returns true if the chamber is paused.
+     */
+    function paused() external view returns (bool);
+
     /// Events
     /**
      * @notice Emitted when delegation is updated

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1617,7 +1617,7 @@ contract ChamberTest is Test {
     }
 
     function test_Chamber_Version() public view {
-        assertEq(chamber.VERSION(), bytes32("1.1.4"));
+        assertEq(chamber.VERSION(), bytes32("1.1.5"));
     }
 
     // ─── acceptAdmin (no-op) ───────────────────────────────────────────

--- a/contracts/test/unit/ChamberPause.t.sol
+++ b/contracts/test/unit/ChamberPause.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {PausableUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {
+    ERC4626Upgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+
+/// @notice L-02: board-quorum pause for vault + wallet execute (no EOA guardian)
+contract ChamberPauseTest is Test {
+    Chamber public chamber;
+    IERC20 public token;
+    IERC721 public nft;
+
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+    address public stranger = address(0xBEEF);
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 1_000_000e18);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), 5, "vERC20", "Vault Token", address(0x9));
+        _addDirectors();
+    }
+
+    function test_Pause_BlocksDeposit() public {
+        _pauseViaQuorum();
+
+        uint256 amount = 1 ether;
+        MockERC20(address(token)).mint(stranger, amount);
+
+        vm.startPrank(stranger);
+        token.approve(address(chamber), amount);
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC4626Upgradeable.ERC4626ExceededMaxDeposit.selector, stranger, amount, uint256(0))
+        );
+        chamber.deposit(amount, stranger);
+        vm.stopPrank();
+    }
+
+    function test_Pause_BlocksExecute() public {
+        address recipient = address(0x3);
+        bytes memory data = "";
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, recipient, 1 ether, data);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        _pauseViaQuorum();
+
+        vm.prank(user1);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        chamber.executeTransaction(1, 0, data);
+    }
+
+    function test_Unpause_RestoresDeposit() public {
+        _pauseViaQuorum();
+        _unpauseViaQuorum();
+
+        uint256 amount = 1 ether;
+        MockERC20(address(token)).mint(stranger, amount);
+
+        vm.startPrank(stranger);
+        token.approve(address(chamber), amount);
+        uint256 shares = chamber.deposit(amount, stranger);
+        vm.stopPrank();
+
+        assertGt(shares, 0);
+        assertGt(chamber.balanceOf(stranger), 0);
+    }
+
+    function test_Unpause_RestoresExecute() public {
+        address recipient = address(0x3333);
+        bytes memory data = "";
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, recipient, 1 ether, data);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+
+        _pauseViaQuorum();
+        _unpauseViaQuorum();
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, data);
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+        assertEq(recipient.balance, 1 ether);
+    }
+
+    function test_NonDirector_CannotPause() public {
+        vm.prank(stranger);
+        vm.expectRevert(IChamber.NotAuthorized.selector);
+        chamber.pause();
+
+        MockERC721(address(nft)).mintWithTokenId(stranger, 999);
+
+        bytes memory pauseData = abi.encodeWithSelector(IChamber.pause.selector);
+        vm.prank(stranger);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(999, address(chamber), 0, pauseData);
+    }
+
+    function test_DirectorDirectPause_Reverts() public {
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotAuthorized.selector);
+        chamber.pause();
+
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotAuthorized.selector);
+        chamber.unpause();
+    }
+
+    function test_PauseViaQuorum_SetsPaused() public {
+        assertFalse(chamber.paused());
+        _pauseViaQuorum();
+        assertTrue(chamber.paused());
+        assertEq(chamber.maxDeposit(user1), 0);
+        assertEq(chamber.maxMint(user1), 0);
+        assertEq(chamber.maxWithdraw(user1), 0);
+        assertEq(chamber.maxRedeem(user1), 0);
+    }
+
+    function test_UnpauseViaQuorum_WhilePaused() public {
+        _pauseViaQuorum();
+        assertTrue(chamber.paused());
+        _unpauseViaQuorum();
+        assertFalse(chamber.paused());
+    }
+
+    function test_SubmitPauseSelector_Allowed() public {
+        bytes memory pauseData = abi.encodeWithSelector(IChamber.pause.selector);
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(chamber), 0, pauseData);
+
+        (,, address target,, bytes32 dataHash) = chamber.getTransaction(0);
+        assertEq(target, address(chamber));
+        assertEq(dataHash, keccak256(pauseData));
+    }
+
+    function _addDirectors() internal {
+        uint256 amount = 1 ether;
+
+        MockERC721(address(nft)).mintWithTokenId(user1, 1);
+        MockERC721(address(nft)).mintWithTokenId(user2, 2);
+        MockERC721(address(nft)).mintWithTokenId(user3, 3);
+
+        MockERC20(address(token)).mint(user1, amount);
+        MockERC20(address(token)).mint(user2, amount);
+        MockERC20(address(token)).mint(user3, amount);
+
+        vm.startPrank(user1);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user1);
+        chamber.delegate(1, 1);
+        vm.stopPrank();
+
+        vm.startPrank(user2);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user2);
+        chamber.delegate(2, 1);
+        vm.stopPrank();
+
+        vm.startPrank(user3);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user3);
+        chamber.delegate(3, 1);
+        vm.stopPrank();
+        vm.roll(block.number + 1);
+    }
+
+    function _pauseViaQuorum() internal {
+        bytes memory pauseData = abi.encodeWithSelector(IChamber.pause.selector);
+        _executeSelfCall(pauseData);
+    }
+
+    function _unpauseViaQuorum() internal {
+        bytes memory unpauseData = abi.encodeWithSelector(IChamber.unpause.selector);
+        _executeSelfCall(unpauseData);
+    }
+
+    function _executeSelfCall(bytes memory data) internal {
+        uint256 txId = chamber.getTransactionCount();
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(chamber), 0, data);
+        vm.prank(user2);
+        chamber.confirmTransaction(2, txId);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, txId);
+        vm.prank(user1);
+        chamber.executeTransaction(1, txId, data);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remediates **L-02**: Chamber had no pause/guardian. Installed OpenZeppelin 5.1.0 already includes `PausableUpgradeable`, but nothing could halt deposit or wallet execute short of a quorum upgrade.

This PR adds `PausableUpgradeable` controlled by the **existing wallet quorum** (self-call after board `executeTransaction`). There is no permanent EOA guardian.

- `pause()` / `unpause()` require `msg.sender == address(this)` (same pattern as `upgradeImplementation`)
- Self-call allowlist now includes `pause` and `unpause` selectors (in addition to upgrade)
- While paused:
  - ERC-4626 `maxDeposit` / `maxMint` / `maxWithdraw` / `maxRedeem` return 0
  - `_deposit` / `_withdraw` revert `EnforcedPause`
  - `executeTransaction` / `executeBatchTransactions` revert `EnforcedPause`, except a quorum self-call to `unpause`
- Delegation, submit, and confirm stay available so the board can still reach quorum to unpause

M-02 and M-05 are intentionally not addressed here.

## Tests

Foundry coverage in `contracts/test/unit/ChamberPause.t.sol`:

- Pause blocks deposit
- Pause blocks execute
- Unpause restores deposit
- Unpause restores execute
- Non-director cannot pause (direct call and submit)
- Director cannot pause/unpause without a quorum self-call

## Implementation notes

- OZ 5.1.0 `PausableUpgradeable` uses ERC-7201 namespaced storage (`openzeppelin.storage.Pausable`), so it does not collide with `loreum.Chamber`
- `__Pausable_init()` is called from `initialize`
- Version constant bumped `1.1.4` → `1.1.5`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf76d778-cb3d-4485-898a-02905473e79d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf76d778-cb3d-4485-898a-02905473e79d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

