### PR TITLE
H-02: one-block seating delay for new directors

### DIFF
--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -55,10 +55,17 @@ abstract contract Board {
         uint256 tail;
         uint32 size; // packed with seats (shares one slot)
         uint32 seats; // packed with size (shares one slot)
+        /// @notice Block number when `tokenId` last entered the top-`seats` set. Zero if not seated.
+        mapping(uint256 tokenId => uint256 seatedAtBlock) seatedAt;
     }
 
     /// @notice Maximum number of nodes allowed in the linked list
     uint256 internal constant MAX_NODES = 50;
+
+    /// @notice Blocks a newly seated tokenId must wait before exercising director rights.
+    /// @dev One block is the smallest delay that closes same-transaction board capture of
+    ///      confirm / execute / upgrade. Existing seated directors keep their original block.
+    uint256 internal constant SEATING_DELAY = 1;
 
     /**
      * @dev Transient storage slot used for the circuit-breaker reentrancy lock.
@@ -138,6 +145,7 @@ abstract contract Board {
         } else {
             _insert(tokenId, amount);
         }
+        _refreshSeating();
         emit IBoard.Delegate(msg.sender, tokenId, amount);
     }
 
@@ -161,6 +169,7 @@ abstract contract Board {
         } else {
             _reposition(tokenId);
         }
+        _refreshSeating();
         emit IBoard.Undelegate(msg.sender, tokenId, amount);
     }
 
@@ -356,6 +365,9 @@ abstract contract Board {
         }
 
         delete $.nodes[tokenId];
+        if ($.seatedAt[tokenId] != 0) {
+            delete $.seatedAt[tokenId];
+        }
 
         if ($.size > 0) {
             unchecked {
@@ -509,6 +521,52 @@ abstract contract Board {
         uint256 newSeats = proposal.proposedSeats;
         $.seats = uint32(newSeats);
         delete $.seatUpdate;
+        _refreshSeating();
         emit IBoard.ExecuteSetSeats(tokenId, newSeats);
+    }
+
+    /**
+     * @notice Syncs seating checkpoints after a board mutation.
+     * @dev TokenIds newly entering the top-`seats` set record `block.number`. TokenIds that
+     *      remain seated keep their original block. TokenIds that leave the top set are cleared.
+     */
+    function _refreshSeating() internal {
+        BoardStorage storage $ = _getBoardStorage();
+        uint256 current = $.head;
+        uint256 remaining = $.seats;
+        uint256 seatedBlock = block.number;
+
+        while (current != 0) {
+            if (remaining != 0) {
+                if ($.seatedAt[current] == 0) {
+                    $.seatedAt[current] = seatedBlock;
+                }
+                unchecked {
+                    --remaining;
+                }
+            } else if ($.seatedAt[current] != 0) {
+                delete $.seatedAt[current];
+            }
+            current = uint256($.nodes[current].next);
+        }
+    }
+
+    /**
+     * @notice Returns the block a tokenId last entered the top-`seats` set.
+     * @param tokenId The membership token ID
+     * @return seatedAtBlock Seating block, or zero if the token is not seated
+     */
+    function _getSeatedAt(uint256 tokenId) internal view returns (uint256 seatedAtBlock) {
+        return _getBoardStorage().seatedAt[tokenId];
+    }
+
+    /**
+     * @notice Whether a top-seat tokenId has completed the seating delay.
+     * @param tokenId The membership token ID
+     * @return True if `seatedAt` is set and `SEATING_DELAY` blocks have elapsed
+     */
+    function _isSeatingMature(uint256 tokenId) internal view returns (bool) {
+        uint256 seatedAt = _getBoardStorage().seatedAt[tokenId];
+        return seatedAt != 0 && block.number >= seatedAt + SEATING_DELAY;
     }
 }

--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -55,7 +55,7 @@ abstract contract Board {
         uint256 tail;
         uint32 size; // packed with seats (shares one slot)
         uint32 seats; // packed with size (shares one slot)
-        /// @notice Block number when `tokenId` last entered the top-`seats` set. Zero if not seated.
+        /// @notice First block at which `tokenId` may exercise director rights. Zero if not seated.
         mapping(uint256 tokenId => uint256 seatedAtBlock) seatedAt;
     }
 
@@ -527,19 +527,20 @@ abstract contract Board {
 
     /**
      * @notice Syncs seating checkpoints after a board mutation.
-     * @dev TokenIds newly entering the top-`seats` set record `block.number`. TokenIds that
-     *      remain seated keep their original block. TokenIds that leave the top set are cleared.
+     * @dev TokenIds newly entering the top-`seats` set record `block.number + SEATING_DELAY`
+     *      (the first block they may act). TokenIds that remain seated keep their original
+     *      activation block. TokenIds that leave the top set are cleared.
      */
     function _refreshSeating() internal {
         BoardStorage storage $ = _getBoardStorage();
         uint256 current = $.head;
         uint256 remaining = $.seats;
-        uint256 seatedBlock = block.number;
+        uint256 activationBlock = block.number + SEATING_DELAY;
 
         while (current != 0) {
             if (remaining != 0) {
                 if ($.seatedAt[current] == 0) {
-                    $.seatedAt[current] = seatedBlock;
+                    $.seatedAt[current] = activationBlock;
                 }
                 unchecked {
                     --remaining;
@@ -552,9 +553,9 @@ abstract contract Board {
     }
 
     /**
-     * @notice Returns the block a tokenId last entered the top-`seats` set.
+     * @notice Returns the first block a tokenId may exercise director rights.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Seating block, or zero if the token is not seated
+     * @return seatedAtBlock Activation block, or zero if the token is not seated
      */
     function _getSeatedAt(uint256 tokenId) internal view returns (uint256 seatedAtBlock) {
         return _getBoardStorage().seatedAt[tokenId];
@@ -563,10 +564,10 @@ abstract contract Board {
     /**
      * @notice Whether a top-seat tokenId has completed the seating delay.
      * @param tokenId The membership token ID
-     * @return True if `seatedAt` is set and `SEATING_DELAY` blocks have elapsed
+     * @return True if `seatedAt` is set and the current block has reached that activation block
      */
     function _isSeatingMature(uint256 tokenId) internal view returns (bool) {
         uint256 seatedAt = _getBoardStorage().seatedAt[tokenId];
-        return seatedAt != 0 && block.number >= seatedAt + SEATING_DELAY;
+        return seatedAt != 0 && block.number >= seatedAt;
     }
 }

--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -55,7 +55,8 @@ abstract contract Board {
         uint256 tail;
         uint32 size; // packed with seats (shares one slot)
         uint32 seats; // packed with size (shares one slot)
-        /// @notice First block at which `tokenId` may exercise director rights. Zero if not seated.
+        /// @notice First block at which `tokenId` may exercise director rights.
+        /// @dev Zero means no checkpoint: a pre-upgrade incumbent, or a token not in the top set.
         mapping(uint256 tokenId => uint256 seatedAtBlock) seatedAt;
     }
 
@@ -64,7 +65,8 @@ abstract contract Board {
 
     /// @notice Blocks a newly seated tokenId must wait before exercising director rights.
     /// @dev One block is the smallest delay that closes same-transaction board capture of
-    ///      confirm / execute / upgrade. Existing seated directors keep their original block.
+    ///      confirm / execute / upgrade. Incumbents keep their checkpoint; `seatedAt == 0`
+    ///      is treated as mature so a live in-place upgrade cannot lock existing directors.
     uint256 internal constant SEATING_DELAY = 1;
 
     /**
@@ -137,6 +139,7 @@ abstract contract Board {
      * @param amount The amount of tokens to delegate
      */
     function _delegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+        uint256[] memory prevTop = _topTokenIds();
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
         if (node.tokenId == tokenId) {
@@ -145,7 +148,7 @@ abstract contract Board {
         } else {
             _insert(tokenId, amount);
         }
-        _refreshSeating();
+        _refreshSeating(prevTop);
         emit IBoard.Delegate(msg.sender, tokenId, amount);
     }
 
@@ -157,6 +160,7 @@ abstract contract Board {
      * @param amount The amount of tokens to undelegate
      */
     function _undelegate(uint256 tokenId, uint256 amount) internal circuitBreaker {
+        uint256[] memory prevTop = _topTokenIds();
         BoardStorage storage $ = _getBoardStorage();
         Node storage node = $.nodes[tokenId];
         if (node.tokenId != tokenId) revert IBoard.NodeDoesNotExist();
@@ -169,7 +173,7 @@ abstract contract Board {
         } else {
             _reposition(tokenId);
         }
-        _refreshSeating();
+        _refreshSeating(prevTop);
         emit IBoard.Undelegate(msg.sender, tokenId, amount);
     }
 
@@ -480,6 +484,7 @@ abstract contract Board {
      * @param tokenId The token ID executing the update
      */
     function _executeSeatsUpdate(uint256 tokenId) internal {
+        uint256[] memory prevTop = _topTokenIds();
         BoardStorage storage $ = _getBoardStorage();
         SeatUpdate storage proposal = $.seatUpdate;
 
@@ -521,17 +526,64 @@ abstract contract Board {
         uint256 newSeats = proposal.proposedSeats;
         $.seats = uint32(newSeats);
         delete $.seatUpdate;
-        _refreshSeating();
+        _refreshSeating(prevTop);
         emit IBoard.ExecuteSetSeats(tokenId, newSeats);
     }
 
     /**
-     * @notice Syncs seating checkpoints after a board mutation.
-     * @dev TokenIds newly entering the top-`seats` set record `block.number + SEATING_DELAY`
-     *      (the first block they may act). TokenIds that remain seated keep their original
-     *      activation block. TokenIds that leave the top set are cleared.
+     * @notice Current top-`seats` tokenIds, in rank order (empty slots omitted).
      */
-    function _refreshSeating() internal {
+    function _topTokenIds() internal view returns (uint256[] memory ids) {
+        BoardStorage storage $ = _getBoardStorage();
+        uint256 n = $.seats;
+        if (n == 0 || $.head == 0) {
+            return new uint256[](0);
+        }
+
+        ids = new uint256[](n);
+        uint256 current = $.head;
+        uint256 filled;
+        unchecked {
+            while (current != 0 && filled < n) {
+                ids[filled] = current;
+                current = uint256($.nodes[current].next);
+                ++filled;
+            }
+        }
+        if (filled == n) {
+            return ids;
+        }
+
+        uint256[] memory trimmed = new uint256[](filled);
+        for (uint256 i; i < filled;) {
+            trimmed[i] = ids[i];
+            unchecked {
+                ++i;
+            }
+        }
+        return trimmed;
+    }
+
+    function _wasInTop(uint256 tokenId, uint256[] memory prevTop) private pure returns (bool) {
+        uint256 len = prevTop.length;
+        for (uint256 i; i < len;) {
+            if (prevTop[i] == tokenId) return true;
+            unchecked {
+                ++i;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @notice Syncs seating checkpoints after a board mutation.
+     * @dev Only tokenIds that newly enter the top-`seats` set (absent from `prevTop`)
+     *      receive `block.number + SEATING_DELAY`. Incumbents — including post-upgrade
+     *      directors whose `seatedAt` is still zero — keep their checkpoint. TokenIds
+     *      that leave the top set are cleared so a later re-entry waits again.
+     * @param prevTop Top-seat tokenIds captured before the mutation
+     */
+    function _refreshSeating(uint256[] memory prevTop) internal {
         BoardStorage storage $ = _getBoardStorage();
         uint256 current = $.head;
         uint256 remaining = $.seats;
@@ -539,7 +591,7 @@ abstract contract Board {
 
         while (current != 0) {
             if (remaining != 0) {
-                if ($.seatedAt[current] == 0) {
+                if ($.seatedAt[current] == 0 && !_wasInTop(current, prevTop)) {
                     $.seatedAt[current] = activationBlock;
                 }
                 unchecked {
@@ -555,19 +607,23 @@ abstract contract Board {
     /**
      * @notice Returns the first block a tokenId may exercise director rights.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Activation block, or zero if the token is not seated
+     * @return seatedAtBlock Activation block, or zero if no checkpoint is stored
      */
     function _getSeatedAt(uint256 tokenId) internal view returns (uint256 seatedAtBlock) {
         return _getBoardStorage().seatedAt[tokenId];
     }
 
     /**
-     * @notice Whether a top-seat tokenId has completed the seating delay.
-     * @param tokenId The membership token ID
-     * @return True if `seatedAt` is set and the current block has reached that activation block
+     * @notice Whether a live top-seat tokenId may exercise director rights.
+     * @dev `seatedAt == 0` is mature: live in-place upgrades leave this mapping unset,
+     *      so incumbents already on the board must keep confirm/execute/submit.
+     *      Newly entering tokenIds always receive a non-zero activation block.
+     * @param tokenId The membership token ID (caller has already verified top-seat membership)
+     * @return True if the seating delay has elapsed, or no checkpoint is stored
      */
     function _isSeatingMature(uint256 tokenId) internal view returns (bool) {
         uint256 seatedAt = _getBoardStorage().seatedAt[tokenId];
-        return seatedAt != 0 && block.number >= seatedAt;
+        if (seatedAt == 0) return true;
+        return block.number >= seatedAt;
     }
 }

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -652,9 +652,9 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     }
 
     /**
-     * @notice Block number when `tokenId` last entered the live top-`seats` set.
+     * @notice First block at which `tokenId` may exercise director rights.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Seating block, or zero if not seated
+     * @return seatedAtBlock Activation block, or zero if not seated
      */
     function getSeatedAt(uint256 tokenId) public view override returns (uint256 seatedAtBlock) {
         return _getSeatedAt(tokenId);

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -654,7 +654,7 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
     /**
      * @notice First block at which `tokenId` may exercise director rights.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Activation block, or zero if not seated
+     * @return seatedAtBlock Activation block, or zero if no checkpoint is stored
      */
     function getSeatedAt(uint256 tokenId) public view override returns (uint256 seatedAtBlock) {
         return _getSeatedAt(tokenId);

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -642,12 +642,22 @@ contract Chamber is ERC4626Upgradeable, ReentrancyGuardUpgradeable, Board, Walle
 
         while (current != 0 && remaining > 0) {
             if (current == tokenId) {
+                if (!_isSeatingMature(tokenId)) revert IChamber.DirectorNotSeated();
                 return;
             }
             current = $b.nodes[current].next;
             remaining--;
         }
         revert IChamber.NotDirector();
+    }
+
+    /**
+     * @notice Block number when `tokenId` last entered the live top-`seats` set.
+     * @param tokenId The membership token ID
+     * @return seatedAtBlock Seating block, or zero if not seated
+     */
+    function getSeatedAt(uint256 tokenId) public view override returns (uint256 seatedAtBlock) {
+        return _getSeatedAt(tokenId);
     }
 
     /// PROXY UPGRADE FUNCTIONS ///

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -54,6 +54,15 @@ interface IBoard {
     function getDirectors() external view returns (address[] memory directors);
 
     /**
+     * @notice Block number when `tokenId` last entered the live top-`seats` set.
+     * @dev Zero if the token is not currently seated. Director confirm/execute rights require
+     *      this checkpoint plus `SEATING_DELAY` blocks.
+     * @param tokenId The membership token ID
+     * @return seatedAtBlock Seating block, or zero if not seated
+     */
+    function getSeatedAt(uint256 tokenId) external view returns (uint256 seatedAtBlock);
+
+    /**
      * @notice Active seat-change proposal, if any.
      * @return proposedSeats Target seat count
      * @return timestamp Proposal start (`block.timestamp`); zero if no proposal

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -54,11 +54,11 @@ interface IBoard {
     function getDirectors() external view returns (address[] memory directors);
 
     /**
-     * @notice Block number when `tokenId` last entered the live top-`seats` set.
-     * @dev Zero if the token is not currently seated. Director confirm/execute rights require
-     *      this checkpoint plus `SEATING_DELAY` blocks.
+     * @notice First block at which `tokenId` may exercise director rights.
+     * @dev Zero if the token is not currently seated. Set to `block.number + SEATING_DELAY`
+     *      when the token newly enters the live top-`seats` set.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Seating block, or zero if not seated
+     * @return seatedAtBlock Activation block, or zero if not seated
      */
     function getSeatedAt(uint256 tokenId) external view returns (uint256 seatedAtBlock);
 

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -55,10 +55,11 @@ interface IBoard {
 
     /**
      * @notice First block at which `tokenId` may exercise director rights.
-     * @dev Zero if the token is not currently seated. Set to `block.number + SEATING_DELAY`
-     *      when the token newly enters the live top-`seats` set.
+     * @dev Zero means no checkpoint: a pre-upgrade incumbent already in the top set
+     *      (treated as mature), or a token that is not seated. Newly entering tokenIds
+     *      are set to `block.number + SEATING_DELAY`.
      * @param tokenId The membership token ID
-     * @return seatedAtBlock Activation block, or zero if not seated
+     * @return seatedAtBlock Activation block, or zero if no checkpoint is stored
      */
     function getSeatedAt(uint256 tokenId) external view returns (uint256 seatedAtBlock);
 

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -193,6 +193,9 @@ interface IChamber is IERC4626, IBoard, IWallet {
     /// @notice Thrown when caller is not a director
     error NotDirector();
 
+    /// @notice Thrown when a tokenId is in the live top seats but the seating delay has not elapsed
+    error DirectorNotSeated();
+
     /// @notice Thrown when address is zero
     error ZeroAddress();
 

--- a/contracts/test/e2e/Lifecycle.t.sol
+++ b/contracts/test/e2e/Lifecycle.t.sol
@@ -58,6 +58,7 @@ contract LifecycleTest is Test {
             chamber.delegate(directorTokenIds[i], 2000e18);
         }
         vm.stopPrank();
+        vm.roll(block.number + 1);
 
         address[] memory board = chamber.getDirectors();
         assertEq(board.length, 5);

--- a/contracts/test/findings/2026-03-14/Finding14_SeatProposalGriefing.t.sol
+++ b/contracts/test/findings/2026-03-14/Finding14_SeatProposalGriefing.t.sol
@@ -44,6 +44,7 @@ contract SeatProposalGriefingTest is Test {
         _setupDirector(director2, 2, 1000e18);
         _setupDirector(director3, 3, 1000e18);
         _setupDirector(griefer, 4, 1e18); // just 1 share — weakest director
+        vm.roll(block.number + 1);
 
         assertEq(chamber.getSeats(), 4, "4 seats");
         assertEq(chamber.getQuorum(), 3, "quorum = 3");

--- a/contracts/test/findings/Finding7_StaleSeatUpdateSupporters.t.sol
+++ b/contracts/test/findings/Finding7_StaleSeatUpdateSupporters.t.sol
@@ -37,6 +37,7 @@ contract StaleSeatUpdateSupportersTest is Test {
         _setupDirector(user1, 1, 100e18);
         _setupDirector(user2, 2, 100e18);
         _setupDirector(user3, 3, 100e18);
+        vm.roll(block.number + 1);
     }
 
     /**

--- a/contracts/test/findings/Finding9_WalletReentrancy.t.sol
+++ b/contracts/test/findings/Finding9_WalletReentrancy.t.sol
@@ -64,6 +64,7 @@ contract WalletReentrancyTest is Test {
         _setupDirector(user1, 1, 100e18);
         _setupDirector(user2, 2, 100e18);
         _setupDirector(user3, 3, 100e18);
+        vm.roll(block.number + 1);
     }
 
     /**

--- a/contracts/test/findings/FindingH02_SeatingDelay.t.sol
+++ b/contracts/test/findings/FindingH02_SeatingDelay.t.sol
@@ -41,7 +41,7 @@ contract FindingH02SeatingDelayTest is Test {
 
         _seat(user3, 3, 50 ether);
 
-        assertEq(chamber.getSeatedAt(3), block.number, "new top-seat token records this block");
+        assertEq(chamber.getSeatedAt(3), block.number + SEATING_DELAY, "new top-seat token activates next block");
         assertTrue(_isLiveDirector(3), "live ranking includes the new token immediately");
 
         vm.prank(user3);
@@ -110,7 +110,7 @@ contract FindingH02SeatingDelayTest is Test {
         _seat(user3, 3, 50 ether);
 
         assertEq(chamber.getSeatedAt(1), seatedAtBefore, "incumbent seating checkpoint is unchanged");
-        assertTrue(block.number >= seatedAtBefore + SEATING_DELAY);
+        assertTrue(block.number >= seatedAtBefore);
 
         vm.prank(user1);
         chamber.submitTransaction(1, address(0x3), 0, "");
@@ -131,7 +131,7 @@ contract FindingH02SeatingDelayTest is Test {
 
         vm.prank(user3);
         chamber.delegate(3, 50 ether);
-        assertEq(chamber.getSeatedAt(3), block.number);
+        assertEq(chamber.getSeatedAt(3), block.number + SEATING_DELAY);
 
         vm.prank(user3);
         vm.expectRevert(IChamber.DirectorNotSeated.selector);

--- a/contracts/test/findings/FindingH02_SeatingDelay.t.sol
+++ b/contracts/test/findings/FindingH02_SeatingDelay.t.sol
@@ -125,13 +125,15 @@ contract FindingH02SeatingDelayTest is Test {
         _seat(user3, 3, 50 ether);
         vm.roll(block.number + SEATING_DELAY);
 
+        uint256 firstActivation = chamber.getSeatedAt(3);
+
         vm.prank(user3);
         chamber.undelegate(3, 50 ether);
         assertEq(chamber.getSeatedAt(3), 0);
 
         vm.prank(user3);
         chamber.delegate(3, 50 ether);
-        assertEq(chamber.getSeatedAt(3), block.number + SEATING_DELAY);
+        assertGt(chamber.getSeatedAt(3), firstActivation, "re-entry writes a later activation block");
 
         vm.prank(user3);
         vm.expectRevert(IChamber.DirectorNotSeated.selector);

--- a/contracts/test/findings/FindingH02_SeatingDelay.t.sol
+++ b/contracts/test/findings/FindingH02_SeatingDelay.t.sol
@@ -144,6 +144,125 @@ contract FindingH02SeatingDelayTest is Test {
         assertEq(chamber.getTransactionCount(), 1);
     }
 
+    /// @dev ERC-7201 Board storage + inlined SeatUpdate (4 slots) + head + tail + packed size/seats.
+    bytes32 private constant _BOARD_STORAGE_SLOT = 0xae916af301d5dc481b59b170e7db23e36b830da7017e456f99549768499c8800;
+    uint256 private constant _SEATED_AT_SLOT_OFFSET = 8;
+
+    /**
+     * @notice After an in-place impl upgrade, `seatedAt` is unset (0) for every incumbent.
+     *         Those directors must still submit/confirm/execute immediately.
+     */
+    function test_H02_PostUpgradeUnsetSeatedAt_IncumbentsCanActImmediately() public {
+        deal(address(chamber), 1 ether);
+        _simulatePostUpgradeStorage(1);
+        _simulatePostUpgradeStorage(2);
+        assertEq(chamber.getSeatedAt(1), 0);
+        assertEq(chamber.getSeatedAt(2), 0);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 1 ether, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, "");
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed, "upgrade must not lock incumbents with unset seatedAt");
+    }
+
+    /**
+     * @notice Post-upgrade incumbents stay live; a tokenId that newly enters the top set
+     *         still waits `SEATING_DELAY` even after a later board mutation.
+     */
+    function test_H02_PostUpgradeUnsetSeatedAt_NewSeatStillWaits() public {
+        _simulatePostUpgradeStorage(1);
+        _simulatePostUpgradeStorage(2);
+        assertEq(chamber.getSeatedAt(1), 0);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        _seat(user3, 3, 50 ether);
+        assertGt(chamber.getSeatedAt(3), 0, "new seat still receives an activation block");
+        assertEq(chamber.getSeatedAt(1), 0, "incumbent checkpoint stays unset after refresh");
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.confirmTransaction(3, 0);
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        assertTrue(chamber.getConfirmation(2, 0));
+
+        vm.roll(block.number + SEATING_DELAY);
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+        assertTrue(chamber.getConfirmation(3, 0));
+    }
+
+    /**
+     * @notice A later delegate (which runs `_refreshSeating`) must not stamp incumbents
+     *         and lock them for a block.
+     */
+    function test_H02_PostUpgradeUnsetSeatedAt_RefreshDoesNotLockIncumbents() public {
+        _simulatePostUpgradeStorage(1);
+        _simulatePostUpgradeStorage(2);
+
+        token.mint(user1, 1 ether);
+        vm.startPrank(user1);
+        token.approve(address(chamber), 1 ether);
+        chamber.deposit(1 ether, user1);
+        chamber.delegate(1, 1 ether);
+        vm.stopPrank();
+
+        assertEq(chamber.getSeatedAt(1), 0, "refresh must not assign an activation to an incumbent");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        assertEq(chamber.getTransactionCount(), 1);
+    }
+
+    function test_H02_PostUpgradeUnsetSeatedAt_ReentryStillWaits() public {
+        _simulatePostUpgradeStorage(1);
+        _simulatePostUpgradeStorage(2);
+
+        _seat(user3, 3, 50 ether);
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(user3);
+        chamber.undelegate(3, 50 ether);
+        assertEq(chamber.getSeatedAt(3), 0);
+
+        vm.prank(user3);
+        chamber.delegate(3, 50 ether);
+        assertGt(chamber.getSeatedAt(3), 0);
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.submitTransaction(3, address(0x3), 0, "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        assertEq(chamber.getTransactionCount(), 1);
+    }
+
+    function _seatedAtSlot(uint256 tokenId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(tokenId, uint256(_BOARD_STORAGE_SLOT) + _SEATED_AT_SLOT_OFFSET));
+    }
+
+    /// @dev Zero `seatedAt[tokenId]` as an in-place upgrade would: the new mapping is empty.
+    function _simulatePostUpgradeStorage(uint256 tokenId) internal {
+        uint256 recorded = chamber.getSeatedAt(tokenId);
+        assertGt(recorded, 0, "precondition: token has a checkpoint to clear");
+        assertEq(
+            uint256(vm.load(address(chamber), _seatedAtSlot(tokenId))),
+            recorded,
+            "seatedAt ERC-7201 slot offset must match BoardStorage layout"
+        );
+        vm.store(address(chamber), _seatedAtSlot(tokenId), bytes32(0));
+        assertEq(chamber.getSeatedAt(tokenId), 0);
+    }
+
     function _seat(address user, uint256 tokenId, uint256 amount) internal {
         try nft.ownerOf(tokenId) returns (address owner) {
             if (owner != user) revert("token already minted to another owner");

--- a/contracts/test/findings/FindingH02_SeatingDelay.t.sol
+++ b/contracts/test/findings/FindingH02_SeatingDelay.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+
+/**
+ * @title H-02: Live board ranking has no seating delay
+ * @notice A tokenId that newly enters the top-`seats` set cannot confirm or execute
+ *         until `SEATING_DELAY` (1 block) elapses. Already-seated directors keep rights.
+ */
+contract FindingH02SeatingDelayTest is Test {
+    Chamber public chamber;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+
+    uint256 public constant SEATS = 3;
+    uint256 public constant SEATING_DELAY = 1;
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), SEATS, "vERC20", "VLT", address(0x9));
+
+        _seat(user1, 1, 100 ether);
+        _seat(user2, 2, 100 ether);
+        vm.roll(block.number + SEATING_DELAY);
+    }
+
+    function test_H02_NewDirectorCannotConfirmUntilDelay() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        _seat(user3, 3, 50 ether);
+
+        assertEq(chamber.getSeatedAt(3), block.number, "new top-seat token records this block");
+        assertTrue(_isLiveDirector(3), "live ranking includes the new token immediately");
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.confirmTransaction(3, 0);
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        assertTrue(chamber.getConfirmation(2, 0), "existing seated director can still confirm");
+    }
+
+    function test_H02_NewDirectorCannotExecuteUntilDelay() public {
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 1 ether, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        _seat(user3, 3, 50 ether);
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.executeTransaction(3, 0, "");
+
+        vm.prank(user1);
+        chamber.executeTransaction(1, 0, "");
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed, "existing seated director can still execute");
+    }
+
+    function test_H02_NewDirectorCannotSubmitUntilDelay() public {
+        _seat(user3, 3, 50 ether);
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.submitTransaction(3, address(0x3), 0, "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        assertEq(chamber.getTransactionCount(), 1, "existing seated director can still submit");
+    }
+
+    function test_H02_NewDirectorCanActAfterDelay() public {
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 1 ether, "");
+
+        _seat(user3, 3, 50 ether);
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
+        assertTrue(chamber.getConfirmation(3, 0));
+
+        vm.prank(user3);
+        chamber.executeTransaction(3, 0, "");
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed);
+    }
+
+    function test_H02_ExistingDirectorUnaffectedByLaterSeating() public {
+        uint256 seatedAtBefore = chamber.getSeatedAt(1);
+
+        _seat(user3, 3, 50 ether);
+
+        assertEq(chamber.getSeatedAt(1), seatedAtBefore, "incumbent seating checkpoint is unchanged");
+        assertTrue(block.number >= seatedAtBefore + SEATING_DELAY);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        assertTrue(chamber.getConfirmation(1, 0));
+        assertTrue(chamber.getConfirmation(2, 0));
+    }
+
+    function test_H02_ReseatedTokenMustWaitAgain() public {
+        _seat(user3, 3, 50 ether);
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(user3);
+        chamber.undelegate(3, 50 ether);
+        assertEq(chamber.getSeatedAt(3), 0);
+
+        vm.prank(user3);
+        chamber.delegate(3, 50 ether);
+        assertEq(chamber.getSeatedAt(3), block.number);
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.submitTransaction(3, address(0x3), 0, "");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        assertEq(chamber.getTransactionCount(), 1);
+    }
+
+    function _seat(address user, uint256 tokenId, uint256 amount) internal {
+        try nft.ownerOf(tokenId) returns (address owner) {
+            if (owner != user) revert("token already minted to another owner");
+        } catch {
+            nft.mintWithTokenId(user, tokenId);
+        }
+
+        token.mint(user, amount);
+        vm.startPrank(user);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, amount);
+        vm.stopPrank();
+    }
+
+    function _isLiveDirector(uint256 tokenId) internal view returns (bool) {
+        (uint256[] memory topIds,) = chamber.getTop(SEATS);
+        for (uint256 i = 0; i < topIds.length; i++) {
+            if (topIds[i] == tokenId) return true;
+        }
+        return false;
+    }
+}

--- a/contracts/test/findings/OffensiveReviewFindings.t.sol
+++ b/contracts/test/findings/OffensiveReviewFindings.t.sol
@@ -48,6 +48,7 @@ contract OffensiveReviewFindingsTest is Test {
         _depositAndDelegate(user1, 1, small);
         _depositAndDelegate(user2, 2, small);
         _depositAndDelegate(user3, 3, small);
+        vm.roll(block.number + 1);
     }
 
     function _depositAndDelegate(address user, uint256 tokenId, uint256 amount) internal {
@@ -111,6 +112,7 @@ contract OffensiveReviewFindingsTest is Test {
         _depositAndDelegate(user6, 6, large);
         _depositAndDelegate(user7, 7, large);
         _depositAndDelegate(user8, 8, large);
+        vm.roll(block.number + 1);
 
         assertFalse(_isDirectorToken(1), "token 1 should no longer be in top seats");
         assertFalse(_isDirectorToken(2), "token 2 should no longer be in top seats");
@@ -139,6 +141,7 @@ contract OffensiveReviewFindingsTest is Test {
         token.approve(address(chamber), amount);
         chamber.deposit(amount, address(this));
         chamber.delegate(tokenId, amount);
+        vm.roll(block.number + 1);
 
         assertTrue(_isDirectorToken(tokenId));
 

--- a/contracts/test/findings/OffensiveReviewFindings.t.sol
+++ b/contracts/test/findings/OffensiveReviewFindings.t.sol
@@ -112,7 +112,9 @@ contract OffensiveReviewFindingsTest is Test {
         _depositAndDelegate(user6, 6, large);
         _depositAndDelegate(user7, 7, large);
         _depositAndDelegate(user8, 8, large);
-        vm.roll(block.number + 1);
+        // Second roll in this test: `block.number` is the test-tx start, so +2 reaches
+        // the block after the new directors' seating checkpoint.
+        vm.roll(block.number + 2);
 
         assertFalse(_isDirectorToken(1), "token 1 should no longer be in top seats");
         assertFalse(_isDirectorToken(2), "token 2 should no longer be in top seats");

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -154,6 +154,7 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
 
         chamber.submitTransaction(1, target, value, data);
         vm.stopPrank();
@@ -183,6 +184,7 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
 
         chamber.submitTransactionWithMetadata(1, target, value, data, metadataURI);
         vm.stopPrank();
@@ -212,6 +214,7 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
 
         chamber.submitTransaction(1, target, value, data);
         vm.stopPrank();
@@ -234,6 +237,7 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
 
         chamber.submitTransaction(1, target, value, data);
         chamber.revokeConfirmation(1, 0);
@@ -266,22 +270,29 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
-        chamber.submitTransaction(1, target, value, data);
         vm.stopPrank();
 
         vm.startPrank(user2);
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user2);
         chamber.delegate(tokenId + 1, 1);
-        chamber.confirmTransaction(2, 0);
         vm.stopPrank();
 
         vm.startPrank(user3);
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user3);
         chamber.delegate(tokenId + 2, 1);
-        chamber.confirmTransaction(3, 0);
         vm.stopPrank();
+        vm.roll(block.number + 1);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, target, value, data);
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        vm.prank(user3);
+        chamber.confirmTransaction(3, 0);
 
         vm.startPrank(user1);
         chamber.executeTransaction(1, 0, data);
@@ -307,6 +318,7 @@ contract ChamberTest is Test {
         MockERC20(address(token)).approve(address(chamber), amount);
         chamber.deposit(amount, user1);
         chamber.delegate(tokenId, 1);
+        vm.roll(block.number + 1);
 
         chamber.submitTransaction(1, target, value, data);
         vm.stopPrank();
@@ -792,6 +804,7 @@ contract ChamberTest is Test {
         chamber.deposit(amount, user3);
         chamber.delegate(3, 1);
         vm.stopPrank();
+        vm.roll(block.number + 1);
     }
 
     function test_Chamber_GetTotalHolderDelegations() public {
@@ -1705,6 +1718,7 @@ contract ChamberTest is Test {
         token.approve(address(chamber), 1 ether);
         chamber.deposit(1 ether, address(this));
         chamber.delegate(tokenId, 1 ether);
+        vm.roll(block.number + 1);
 
         // authorized address submits a transaction using the contract's tokenId
         // _isDirector: owner=wallet (contract), msg.sender=authorized ≠ wallet
@@ -1777,6 +1791,7 @@ contract ChamberTest is Test {
 
         // Delegate tokens to Chamber A's tokenId
         chamberB.delegate(tokenId, delegationAmount);
+        vm.roll(block.number + 1);
 
         // 3. Verify Chamber A is now a director of Chamber B
         // Chamber A should be in top 3 positions (seats = 3)
@@ -1806,6 +1821,7 @@ contract ChamberTest is Test {
 
         // Delegate to tokenId2
         chamberB.delegate(tokenId2, 500e18);
+        vm.roll(block.number + 1);
 
         // testUser2 confirms the transaction
         vm.prank(testUser2);
@@ -1853,6 +1869,7 @@ contract ChamberTest is Test {
 
         // Delegate tokens to Chamber A's tokenId
         chamberB.delegate(tokenId, delegationAmount);
+        vm.roll(block.number + 1);
 
         // 3. Verify Chamber A is now a director of Chamber B
         address[] memory directors = chamberB.getDirectors();
@@ -1887,6 +1904,7 @@ contract ChamberTest is Test {
 
         // Delegate to tokenId2
         chamberB.delegate(tokenId2, 500e18);
+        vm.roll(block.number + 1);
 
         // director2 confirms the transaction
         vm.prank(director2);
@@ -1899,6 +1917,7 @@ contract ChamberTest is Test {
 
         // Delegate to tokenId3
         chamberB.delegate(tokenId3, 400e18);
+        vm.roll(block.number + 1);
 
         // director3 confirms the transaction
         vm.prank(director3);

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1791,7 +1791,6 @@ contract ChamberTest is Test {
 
         // Delegate tokens to Chamber A's tokenId
         chamberB.delegate(tokenId, delegationAmount);
-        vm.roll(block.number + 1);
 
         // 3. Verify Chamber A is now a director of Chamber B
         // Chamber A should be in top 3 positions (seats = 3)
@@ -1805,14 +1804,6 @@ contract ChamberTest is Test {
         }
         assertTrue(chamberAIsDirector, "Chamber A should be a director of Chamber B");
 
-        // 4. Chamber A (via authorizedAddress) submits a transaction on Chamber B
-        // This simulates Chamber A acting as director
-        bytes memory testData = abi.encodeWithSignature("testFunction()");
-        chamberB.submitTransaction(tokenId, address(0x1234), 0, testData);
-
-        // Verify transaction was submitted
-        assertEq(chamberB.getTransactionCount(), 1);
-
         // 5. Get other directors to confirm (need quorum)
         // Mint more NFTs and delegate to get more directors
         uint256 tokenId2 = 2;
@@ -1822,6 +1813,14 @@ contract ChamberTest is Test {
         // Delegate to tokenId2
         chamberB.delegate(tokenId2, 500e18);
         vm.roll(block.number + 1);
+
+        // 4. Chamber A (via authorizedAddress) submits a transaction on Chamber B
+        // This simulates Chamber A acting as director
+        bytes memory testData = abi.encodeWithSignature("testFunction()");
+        chamberB.submitTransaction(tokenId, address(0x1234), 0, testData);
+
+        // Verify transaction was submitted
+        assertEq(chamberB.getTransactionCount(), 1);
 
         // testUser2 confirms the transaction
         vm.prank(testUser2);
@@ -1869,7 +1868,6 @@ contract ChamberTest is Test {
 
         // Delegate tokens to Chamber A's tokenId
         chamberB.delegate(tokenId, delegationAmount);
-        vm.roll(block.number + 1);
 
         // 3. Verify Chamber A is now a director of Chamber B
         address[] memory directors = chamberB.getDirectors();
@@ -1886,6 +1884,24 @@ contract ChamberTest is Test {
         uint256 transferAmount = 100e18;
         MockERC20(address(token)).mint(address(chamberB), transferAmount);
 
+        // 6. Get other directors to confirm (need quorum)
+        // Create second director
+        uint256 tokenId2 = 2;
+        address director2 = address(0x20);
+        MockERC721(address(nft)).mintWithTokenId(director2, tokenId2);
+
+        // Delegate to tokenId2
+        chamberB.delegate(tokenId2, 500e18);
+
+        // Create third director
+        uint256 tokenId3 = 3;
+        address director3 = address(0x30);
+        MockERC721(address(nft)).mintWithTokenId(director3, tokenId3);
+
+        // Delegate to tokenId3
+        chamberB.delegate(tokenId3, 400e18);
+        vm.roll(block.number + 1);
+
         // 5. Chamber A (via authorizedAddress) submits a transaction on Chamber B
         // This transaction will transfer tokens from Chamber B to Chamber C
         bytes memory transferData = abi.encodeWithSelector(IERC20.transfer.selector, address(chamberC), transferAmount);
@@ -1896,28 +1912,9 @@ contract ChamberTest is Test {
         // Verify transaction was submitted
         assertEq(chamberB.getTransactionCount(), 1);
 
-        // 6. Get other directors to confirm (need quorum)
-        // Create second director
-        uint256 tokenId2 = 2;
-        address director2 = address(0x20);
-        MockERC721(address(nft)).mintWithTokenId(director2, tokenId2);
-
-        // Delegate to tokenId2
-        chamberB.delegate(tokenId2, 500e18);
-        vm.roll(block.number + 1);
-
         // director2 confirms the transaction
         vm.prank(director2);
         chamberB.confirmTransaction(tokenId2, 0);
-
-        // Create third director
-        uint256 tokenId3 = 3;
-        address director3 = address(0x30);
-        MockERC721(address(nft)).mintWithTokenId(director3, tokenId3);
-
-        // Delegate to tokenId3
-        chamberB.delegate(tokenId3, 400e18);
-        vm.roll(block.number + 1);
 
         // director3 confirms the transaction
         vm.prank(director3);

--- a/contracts/test/unit/ChamberUpgrade.t.sol
+++ b/contracts/test/unit/ChamberUpgrade.t.sol
@@ -82,6 +82,7 @@ contract ChamberUpgradeTest is Test {
         chamber.deposit(amount, user3);
         chamber.delegate(3, amount);
         vm.stopPrank();
+        vm.roll(block.number + 1);
     }
 
     function test_Chamber_GetProxyAdmin() public view {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Finding

**H-02** — Live delegation ranking has no snapshot or seating delay. Director rights were the live top-`seats` owners, so a tokenId that just entered the board could confirm or execute (including `upgradeImplementation`) in the same transaction that changed the board.

## What changed

- `Board` records a seating checkpoint (`seatedAt`) only when a tokenId **newly enters** the top-`seats` set. The value is the activation block (`block.number + 1`).
- Incumbents keep their original checkpoint. Tokens that leave the top set are cleared so a later re-entry waits again.
- `Chamber._isDirector` requires `block.number >= seatedAt` before confirm/execute/submit, **except** `seatedAt == 0`, which is treated as mature.
- `getDirectors()` / `getTop()` stay live; `getSeatedAt(tokenId)` exposes the checkpoint (0 = no checkpoint).
- Smallest delay that closes same-transaction board capture of execute/upgrade. Does not rewrite the governance model. Does not address H-01, H-03, or other findings.

## Upgrade note

Safe to upgrade live chambers because of this guard. A live in-place implementation upgrade leaves the new `seatedAt` mapping unset (0) for every existing director. Those incumbents stay able to submit, confirm, and execute immediately — no reinitializer / `upgradeAndCall` is required. The first later board mutation does not stamp them with a new delay. TokenIds that newly enter the top set after this implementation still wait one block.

## Test plan

- `forge test --match-contract FindingH02SeatingDelayTest -vv` — **10 passed**
  - New director cannot confirm, execute, or submit until the delay elapses
  - Existing seated directors can still confirm/execute when a new token enters
  - After 1 block, the new director can confirm and execute
  - A reseated token must wait again
  - Post-upgrade storage (`seatedAt` unset): incumbents can submit/confirm/execute immediately
  - Post-upgrade storage: a newly seated tokenId still waits one block
  - Post-upgrade storage: `_refreshSeating` does not lock incumbents
- Chamber, ChamberUpgrade, Lifecycle, Board, ChamberFuzz, Wallet, Vault, and `test/findings/**`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54e2b1a8-11a4-4d4a-a186-93cff172404c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54e2b1a8-11a4-4d4a-a186-93cff172404c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

