### PR TITLE
feat(app): stay correct after Chamber remediations

### DIFF
--- a/app/contracts/abis.ts
+++ b/app/contracts/abis.ts
@@ -238,6 +238,41 @@ export const chamberAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
+  {
+    type: 'function',
+    name: 'cancelSeatUpdate',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'getSeatedAt',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: 'seatedAtBlock', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'pause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'unpause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'paused',
+    inputs: [],
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+  },
   // Wallet/Transaction functions
   {
     type: 'function',
@@ -374,6 +409,27 @@ export const chamberAbi = [
   },
   {
     type: 'function',
+    name: 'getTransactionRequiredQuorum',
+    inputs: [{ name: 'nonce', type: 'uint256' }],
+    outputs: [{ name: 'requiredQuorum', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTransactionDeadline',
+    inputs: [{ name: 'nonce', type: 'uint256' }],
+    outputs: [{ name: 'deadline', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'isTransactionExpired',
+    inputs: [{ name: 'nonce', type: 'uint256' }],
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'getConfirmation',
     inputs: [
       { name: 'tokenId', type: 'uint256' },
@@ -468,6 +524,29 @@ export const chamberAbi = [
     type: 'event',
     name: 'TransactionCancelled',
     inputs: [{ name: 'nonce', type: 'uint256', indexed: true }],
+  },
+  {
+    type: 'event',
+    name: 'TransactionDeadlineSet',
+    inputs: [
+      { name: 'nonce', type: 'uint256', indexed: true },
+      { name: 'deadline', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'Paused',
+    inputs: [{ name: 'account', type: 'address', indexed: false }],
+  },
+  {
+    type: 'event',
+    name: 'Unpaused',
+    inputs: [{ name: 'account', type: 'address', indexed: false }],
+  },
+  {
+    type: 'event',
+    name: 'SeatUpdateCancelled',
+    inputs: [{ name: 'tokenId', type: 'uint256', indexed: true }],
   },
   {
     type: 'event',
@@ -600,6 +679,10 @@ export const chamberAbi = [
   { type: 'error', name: 'InvalidTransaction', inputs: [] },
   { type: 'error', name: 'NotAuthorized', inputs: [] },
   { type: 'error', name: 'AssetAmountMismatch', inputs: [] },
+  { type: 'error', name: 'EnforcedPause', inputs: [] },
+  { type: 'error', name: 'ExpectedPause', inputs: [] },
+  { type: 'error', name: 'TransactionExpired', inputs: [] },
+  { type: 'error', name: 'InvalidDeadline', inputs: [] },
   // OZ ERC20 errors for better error decoding
   {
     type: 'error',
@@ -693,9 +776,45 @@ export const registryAbi = [
   },
   {
     type: 'function',
+    name: 'getChambersByAsset',
+    inputs: [
+      { name: 'asset', type: 'address' },
+      { name: 'limit', type: 'uint256' },
+      { name: 'skip', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getChambersByAssetCount',
+    inputs: [{ name: 'asset', type: 'address' }],
+    outputs: [{ name: 'count', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'getChildChambers',
     inputs: [{ name: 'chamber', type: 'address' }],
     outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getChildChambers',
+    inputs: [
+      { name: 'chamber', type: 'address' },
+      { name: 'limit', type: 'uint256' },
+      { name: 'skip', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getChildChamberCount',
+    inputs: [{ name: 'chamber', type: 'address' }],
+    outputs: [{ name: 'count', type: 'uint256' }],
     stateMutability: 'view',
   },
   {
@@ -710,6 +829,30 @@ export const registryAbi = [
     name: 'getAssets',
     inputs: [],
     outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getAssets',
+    inputs: [
+      { name: 'limit', type: 'uint256' },
+      { name: 'skip', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getAssetCount',
+    inputs: [],
+    outputs: [{ name: 'count', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'MAX_PAGE_SIZE',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
     stateMutability: 'view',
   },
   {

--- a/app/scripts/sync-contracts.mjs
+++ b/app/scripts/sync-contracts.mjs
@@ -10,7 +10,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const appRoot = join(__dirname, '..')
 const repoContracts = join(appRoot, '..', 'contracts')
 const appContracts = join(appRoot, 'contracts')
-const files = ['index.ts', 'abis.ts', 'deployments.json', 'deployments.d.ts']
+// `abis.ts` is hand-maintained in the app. `contracts/abis.ts` still lags
+// the landed interfaces (pause, seating, registry paging, M-04/M-06).
+// Do not overwrite until the handwritten repo ABI is regenerated.
+const files = ['index.ts', 'deployments.json', 'deployments.d.ts']
 
 function copyFromRepo() {
   mkdirSync(appContracts, { recursive: true })

--- a/app/src/components/DelegationManager.tsx
+++ b/app/src/components/DelegationManager.tsx
@@ -158,7 +158,10 @@ export default function DelegationManager({
       'ZeroAmount': 'Amount cannot be zero',
       'InvalidTokenId': 'This member ID does not exist',
       'NotDirector': 'You are not a director',
+      'DirectorNotSeated': 'Your seat is not mature yet',
       'ExceedsDelegatedAmount': 'Amount exceeds your delegated balance',
+      'AssetAmountMismatch': 'Fee-on-transfer or rebasing tokens are not supported',
+      'EnforcedPause': 'This chamber is paused',
     }
     
     // Check for custom error name in message

--- a/app/src/components/TreasuryOverview.tsx
+++ b/app/src/components/TreasuryOverview.tsx
@@ -158,6 +158,8 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
       'ExceedsDelegatedAmount': 'Cannot withdraw - some shares are delegated',
       'ERC20InsufficientAllowance': 'Token approval required',
       'ERC20InsufficientBalance': 'Insufficient token balance',
+      'AssetAmountMismatch': 'Fee-on-transfer or rebasing tokens revert on deposit',
+      'EnforcedPause': 'This chamber is paused',
     }
     
     // Check for custom error name in message
@@ -225,8 +227,15 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
     }
   }
 
+  const vaultPaused = chamberInfo.paused === true
+
   return (
     <div className="space-y-6">
+      {vaultPaused && (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-200">
+          This chamber is paused. Deposits and withdrawals are halted until the board unpauses.
+        </div>
+      )}
       {/* Treasury Stats */}
       <div className="grid md:grid-cols-3 gap-5">
         <motion.div
@@ -452,7 +461,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
                 <button
                   type="button"
                   onClick={handleDeposit}
-                  disabled={isDepositing || isDepositConfirming || !depositAmount || !!(depositAmount && !isDepositValid && !isDepositSimulating)}
+                  disabled={vaultPaused || isDepositing || isDepositConfirming || !depositAmount || !!(depositAmount && !isDepositValid && !isDepositSimulating)}
                   className="btn btn-primary w-full"
                 >
                   {isDepositing || isDepositConfirming ? (
@@ -568,7 +577,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
               <button
                 type="button"
                 onClick={handleWithdraw}
-                disabled={isWithdrawing || isWithdrawConfirming || !withdrawAmount || !!(withdrawAmount && !isWithdrawValid && !isWithdrawSimulating)}
+                disabled={vaultPaused || isWithdrawing || isWithdrawConfirming || !withdrawAmount || !!(withdrawAmount && !isWithdrawValid && !isWithdrawSimulating)}
                 className="btn w-full border border-rose-500/40 bg-rose-600/90 text-white hover:bg-rose-500 shadow-sm disabled:opacity-50"
               >
                 {isWithdrawing || isWithdrawConfirming ? (

--- a/app/src/hooks/useChamber.ts
+++ b/app/src/hooks/useChamber.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react'
-import { useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt, useSimulateContract, useAccount } from 'wagmi'
+import { useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt, useSimulateContract, useAccount, useBlockNumber } from 'wagmi'
 import { isAddress } from 'viem'
 import { chamberAbi, erc20Abi, erc721Abi } from '@/contracts/abis'
 import { chamberVersionBytes32ToLabel } from '@/lib/utils'
+import { isSeatingMature } from '@/lib/chamberGovernance'
 import type { Transaction, BoardMember, SeatUpdate } from '@/types'
 
 /** Public RPC / long block times: retry eth_call simulation and refresh state after txs. */
@@ -227,6 +228,16 @@ export function useChamberInfo(chamberAddress: `0x${string}` | undefined) {
     },
   })
 
+  const { data: paused } = useReadContract({
+    address: isValidAddress ? chamberAddress : undefined,
+    abi: chamberAbi,
+    functionName: 'paused',
+    query: {
+      enabled: !!isValidAddress,
+      retry: false,
+    },
+  })
+
   return {
     name: name as string | undefined,
     symbol: symbol as string | undefined,
@@ -239,6 +250,7 @@ export function useChamberInfo(chamberAddress: `0x${string}` | undefined) {
     assetToken: assetToken as `0x${string}` | undefined,
     nftToken: nftToken as `0x${string}` | undefined,
     version: chamberVersionBytes32ToLabel(versionBytes32 as `0x${string}` | undefined),
+    paused: paused === true,
   }
 }
 
@@ -867,4 +879,75 @@ export function useExecuteSeatsUpdate(chamberAddress: `0x${string}` | undefined)
   }
 
   return { executeSeatsUpdate, isPending, isConfirming, isSuccess, error, hash }
+}
+
+export function useCancelSeatUpdate(chamberAddress: `0x${string}` | undefined) {
+  const { writeContractAsync, data: hash, isPending, error } = useWriteContract()
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash })
+
+  const cancelSeatUpdate = async (tokenId: bigint) => {
+    if (!chamberAddress) return
+    return writeContractAsync({
+      address: chamberAddress,
+      abi: chamberAbi,
+      functionName: 'cancelSeatUpdate',
+      args: [tokenId],
+    })
+  }
+
+  return { cancelSeatUpdate, isPending, isConfirming, isSuccess, error, hash }
+}
+
+export function useSeatedAt(chamberAddress: `0x${string}` | undefined, tokenId: bigint | undefined) {
+  const { data, refetch } = useReadContract({
+    address: chamberAddress,
+    abi: chamberAbi,
+    functionName: 'getSeatedAt',
+    args: tokenId !== undefined ? [tokenId] : undefined,
+    query: {
+      enabled: !!chamberAddress && tokenId !== undefined,
+      retry: false,
+    },
+  })
+
+  return { seatedAt: data as bigint | undefined, refetch }
+}
+
+/**
+ * Combined director action gate (H-02): connected address owns a current
+ * top-seat tokenId AND seating is mature (`block.number >= seatedAt`).
+ * If `getSeatedAt` is not deployed yet, treat the seat as mature.
+ */
+export function useDirectorActionGate(
+  chamberAddress: `0x${string}` | undefined,
+  userAddress: `0x${string}` | undefined,
+  directors: `0x${string}`[] | undefined,
+  members: { tokenId: bigint }[],
+) {
+  const directorIndex =
+    userAddress && directors
+      ? directors.findIndex((d) => d.toLowerCase() === userAddress.toLowerCase())
+      : -1
+  const tokenId =
+    directorIndex >= 0 && directorIndex < members.length ? members[directorIndex].tokenId : undefined
+
+  const { seatedAt } = useSeatedAt(chamberAddress, tokenId)
+  const { data: blockNumber } = useBlockNumber({
+    query: {
+      enabled: !!chamberAddress && tokenId !== undefined,
+      refetchInterval: 4_000,
+    },
+  })
+
+  const getterMissing = tokenId !== undefined && seatedAt === undefined
+  const seated = tokenId === undefined ? false : getterMissing ? true : isSeatingMature(seatedAt, blockNumber)
+  const seatingPending = tokenId !== undefined && !getterMissing && !seated
+
+  return {
+    tokenId,
+    seatedAt,
+    blockNumber,
+    canAct: tokenId !== undefined && seated,
+    seatingPending,
+  }
 }

--- a/app/src/hooks/useChamberEvents.ts
+++ b/app/src/hooks/useChamberEvents.ts
@@ -178,6 +178,54 @@ export function useChamberEvents(
   useWatchContractEvent({
     address: isValidAddress ? chamberAddress : undefined,
     abi: chamberAbi,
+    eventName: 'TransactionDeadlineSet',
+    onLogs: (logs) => {
+      if (import.meta.env.DEV) console.log('Chamber TransactionDeadlineSet event:', logs)
+      invalidateChamberQueries()
+      onTransactionEvent?.()
+    },
+    enabled: watchEnabled,
+  })
+
+  useWatchContractEvent({
+    address: isValidAddress ? chamberAddress : undefined,
+    abi: chamberAbi,
+    eventName: 'Paused',
+    onLogs: (logs) => {
+      if (import.meta.env.DEV) console.log('Chamber Paused event:', logs)
+      invalidateChamberQueries()
+      onVaultEvent?.()
+    },
+    enabled: watchEnabled,
+  })
+
+  useWatchContractEvent({
+    address: isValidAddress ? chamberAddress : undefined,
+    abi: chamberAbi,
+    eventName: 'Unpaused',
+    onLogs: (logs) => {
+      if (import.meta.env.DEV) console.log('Chamber Unpaused event:', logs)
+      invalidateChamberQueries()
+      onVaultEvent?.()
+    },
+    enabled: watchEnabled,
+  })
+
+  useWatchContractEvent({
+    address: isValidAddress ? chamberAddress : undefined,
+    abi: chamberAbi,
+    eventName: 'SeatUpdateCancelled',
+    onLogs: (logs) => {
+      if (import.meta.env.DEV) console.log('Chamber SeatUpdateCancelled event:', logs)
+      invalidateChamberQueries()
+      onBoardEvent?.()
+    },
+    enabled: watchEnabled,
+  })
+
+  useWatchContractEvent({
+    address: isValidAddress ? chamberAddress : undefined,
+    abi: chamberAbi,
     eventName: 'SetSeats',
     onLogs: (logs) => {
       if (import.meta.env.DEV) console.log('Chamber SetSeats event:', logs)

--- a/app/src/hooks/useRegistry.ts
+++ b/app/src/hooks/useRegistry.ts
@@ -7,8 +7,9 @@ import {
   useChainId,
   usePublicClient,
 } from 'wagmi'
-import { zeroAddress, type Hex } from 'viem'
+import { zeroAddress, type Hex, type PublicClient } from 'viem'
 import { registryAbi, chamberAbi } from '@/contracts/abis'
+import { REGISTRY_PAGE_SIZE } from '@/lib/chamberGovernance'
 import {
   getContractAddresses,
   hasValidAddresses,
@@ -32,36 +33,92 @@ export function useHasValidConfig() {
   }
 }
 
+function isValidAddress(addr: string | undefined): addr is `0x${string}` {
+  return !!addr && addr !== zeroAddress && addr.startsWith('0x') && addr.length === 42
+}
+
+async function pageRegistryAddresses(
+  client: PublicClient,
+  registryAddress: `0x${string}`,
+  pageFn: 'getChambers' | 'getAssets',
+  countFn: 'getChamberCount' | 'getAssetCount',
+): Promise<`0x${string}`[]> {
+  const count = (await client.readContract({
+    address: registryAddress,
+    abi: registryAbi,
+    functionName: countFn,
+  })) as bigint
+
+  const out: `0x${string}`[] = []
+  for (let skip = 0n; skip < count; skip += REGISTRY_PAGE_SIZE) {
+    const page = (await client.readContract({
+      address: registryAddress,
+      abi: registryAbi,
+      functionName: pageFn,
+      args: [REGISTRY_PAGE_SIZE, skip],
+    })) as `0x${string}`[]
+    out.push(...page)
+    if (page.length === 0) break
+  }
+  return out.filter(isValidAddress)
+}
+
+async function pageKeyedRegistryAddresses(
+  client: PublicClient,
+  registryAddress: `0x${string}`,
+  pageFn: 'getChambersByAsset' | 'getChildChambers',
+  countFn: 'getChambersByAssetCount' | 'getChildChamberCount',
+  key: `0x${string}`,
+  fallbackFn: 'getChambersByAsset' | 'getChildChambers',
+): Promise<`0x${string}`[]> {
+  try {
+    const count = (await client.readContract({
+      address: registryAddress,
+      abi: registryAbi,
+      functionName: countFn,
+      args: [key],
+    })) as bigint
+
+    const out: `0x${string}`[] = []
+    for (let skip = 0n; skip < count; skip += REGISTRY_PAGE_SIZE) {
+      const page = (await client.readContract({
+        address: registryAddress,
+        abi: registryAbi,
+        functionName: pageFn,
+        args: [key, REGISTRY_PAGE_SIZE, skip],
+      })) as `0x${string}`[]
+      out.push(...page)
+      if (page.length === 0) break
+    }
+    return out.filter(isValidAddress)
+  } catch {
+    const page = (await client.readContract({
+      address: registryAddress,
+      abi: registryAbi,
+      functionName: fallbackFn,
+      args: [key],
+    })) as `0x${string}`[]
+    return page.filter(isValidAddress)
+  }
+}
+
 export function useAllChambers() {
   const registryAddress = useRegistryAddress()
-  const isValidRegistry = registryAddress && 
-    registryAddress !== '0x0000000000000000000000000000000000000000' &&
-    registryAddress.startsWith('0x') &&
-    registryAddress.length === 42
-  
-  const { data, isLoading, error, refetch } = useReadContract({
-    address: isValidRegistry ? registryAddress : undefined,
-    abi: registryAbi,
-    functionName: 'getAllChambers',
-    query: { 
-      enabled: !!isValidRegistry,
-      retry: 2,
-      retryDelay: 1000,
+  const publicClient = usePublicClient()
+  const isValidRegistry = isValidAddress(registryAddress)
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['registry-chambers-paged', registryAddress],
+    enabled: isValidRegistry && !!publicClient,
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!publicClient || !isValidRegistry) return []
+      return pageRegistryAddresses(publicClient, registryAddress, 'getChambers', 'getChamberCount')
     },
   })
 
-  // Filter out invalid addresses from the result
-  const validChambers = data 
-    ? (data as `0x${string}`[]).filter((addr) => 
-        addr && 
-        addr !== '0x0000000000000000000000000000000000000000' &&
-        addr.startsWith('0x') &&
-        addr.length === 42
-      )
-    : undefined
-
   return {
-    chambers: validChambers,
+    chambers: data,
     isLoading,
     error,
     refetch,
@@ -112,17 +169,28 @@ export function useIsChamber(address: `0x${string}` | undefined) {
 
 export function useChambersByAsset(asset: `0x${string}` | undefined) {
   const registryAddress = useRegistryAddress()
-  
-  const { data, isLoading, error, refetch } = useReadContract({
-    address: registryAddress,
-    abi: registryAbi,
-    functionName: 'getChambersByAsset',
-    args: asset ? [asset] : undefined,
-    query: { enabled: !!asset && registryAddress !== '0x0000000000000000000000000000000000000000' },
+  const publicClient = usePublicClient()
+  const isValidRegistry = isValidAddress(registryAddress)
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['registry-chambers-by-asset-paged', registryAddress, asset],
+    enabled: !!asset && isValidRegistry && !!publicClient,
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!publicClient || !isValidRegistry || !asset) return []
+      return pageKeyedRegistryAddresses(
+        publicClient,
+        registryAddress,
+        'getChambersByAsset',
+        'getChambersByAssetCount',
+        asset,
+        'getChambersByAsset',
+      )
+    },
   })
 
   return {
-    chambers: data as `0x${string}`[] | undefined,
+    chambers: data,
     isLoading,
     error,
     refetch,
@@ -131,16 +199,31 @@ export function useChambersByAsset(asset: `0x${string}` | undefined) {
 
 export function useAssets() {
   const registryAddress = useRegistryAddress()
-  
-  const { data, isLoading, error, refetch } = useReadContract({
-    address: registryAddress,
-    abi: registryAbi,
-    functionName: 'getAssets',
-    query: { enabled: registryAddress !== '0x0000000000000000000000000000000000000000' },
+  const publicClient = usePublicClient()
+  const isValidRegistry = isValidAddress(registryAddress)
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['registry-assets-paged', registryAddress],
+    enabled: isValidRegistry && !!publicClient,
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!publicClient || !isValidRegistry) return []
+      try {
+        return await pageRegistryAddresses(publicClient, registryAddress, 'getAssets', 'getAssetCount')
+      } catch {
+        const page = (await publicClient.readContract({
+          address: registryAddress,
+          abi: registryAbi,
+          functionName: 'getAssets',
+          args: [],
+        })) as `0x${string}`[]
+        return page.filter(isValidAddress)
+      }
+    },
   })
 
   return {
-    assets: data as `0x${string}`[] | undefined,
+    assets: data,
     isLoading,
     error,
     refetch,
@@ -218,17 +301,28 @@ export function useParentChamber(chamber: `0x${string}` | undefined) {
 
 export function useChildChambers(chamber: `0x${string}` | undefined) {
   const registryAddress = useRegistryAddress()
-  
-  const { data, isLoading, error, refetch } = useReadContract({
-    address: registryAddress,
-    abi: registryAbi,
-    functionName: 'getChildChambers',
-    args: chamber ? [chamber] : undefined,
-    query: { enabled: !!chamber && registryAddress !== '0x0000000000000000000000000000000000000000' },
+  const publicClient = usePublicClient()
+  const isValidRegistry = isValidAddress(registryAddress)
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['registry-child-chambers-paged', registryAddress, chamber],
+    enabled: !!chamber && isValidRegistry && !!publicClient,
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!publicClient || !isValidRegistry || !chamber) return []
+      return pageKeyedRegistryAddresses(
+        publicClient,
+        registryAddress,
+        'getChildChambers',
+        'getChildChamberCount',
+        chamber,
+        'getChildChambers',
+      )
+    },
   })
 
   return {
-    childChambers: data as `0x${string}`[] | undefined,
+    childChambers: data,
     isLoading,
     error,
     refetch,

--- a/app/src/lib/chamberGovernance.ts
+++ b/app/src/lib/chamberGovernance.ts
@@ -1,0 +1,87 @@
+/**
+ * Chamber governance constants and helpers aligned with landed remediations.
+ * Seat timings are not public ABI constants (H-03 keeps them `internal`),
+ * so they live together here to avoid drift.
+ */
+
+export const UPGRADE_SELECTOR = '0xc89311b6' as const
+/** `pause()` — L-02 / OZ Pausable */
+export const PAUSE_SELECTOR = '0x8456cb59' as const
+/** `unpause()` — L-02 / OZ Pausable */
+export const UNPAUSE_SELECTOR = '0x3f4ba83a' as const
+
+/** H-03 `SEAT_UPDATE_TIMELOCK` (internal, 7 days) */
+export const SEAT_UPDATE_TIMELOCK_SEC = 7n * 24n * 60n * 60n
+/** H-03 `SEAT_UPDATE_EXPIRY` (internal, 14 days) */
+export const SEAT_UPDATE_EXPIRY_SEC = 14n * 24n * 60n * 60n
+
+/** L-01 `Registry.MAX_PAGE_SIZE` */
+export const REGISTRY_PAGE_SIZE = 256n
+
+export function isChamberSelfCall(chamberAddress: `0x${string}`, target: string): boolean {
+  return target.toLowerCase() === chamberAddress.toLowerCase()
+}
+
+export function selectorOf(data: `0x${string}` | string): string {
+  const hex = data.startsWith('0x') ? data : `0x${data}`
+  return hex.slice(0, 10).toLowerCase()
+}
+
+/** Self-calls allowed after L-02: upgradeImplementation, pause, unpause. */
+export function isAllowedChamberSelfCall(
+  chamberAddress: `0x${string}`,
+  target: string,
+  data: `0x${string}`,
+): boolean {
+  if (!isChamberSelfCall(chamberAddress, target)) return true
+  const selector = selectorOf(data)
+  return (
+    selector === UPGRADE_SELECTOR ||
+    selector === PAUSE_SELECTOR ||
+    selector === UNPAUSE_SELECTOR
+  )
+}
+
+export function isUnpauseCall(chamberAddress: `0x${string}`, target: string, data: `0x${string}`): boolean {
+  return isChamberSelfCall(chamberAddress, target) && selectorOf(data) === UNPAUSE_SELECTOR
+}
+
+/** M-04 execute bar: max(submit snapshot, live quorum). Snapshot 0 = legacy / unset. */
+export function requiredExecuteConfirmations(
+  snapshotQuorum: number | undefined,
+  liveQuorum: number,
+): number {
+  const snapshot = snapshotQuorum && snapshotQuorum > 0 ? snapshotQuorum : 0
+  return Math.max(snapshot, liveQuorum)
+}
+
+/**
+ * H-02: seating is mature when `block.number >= seatedAt`.
+ * `seatedAt == 0` is the on-chain grandfather for pre-upgrade incumbents
+ * (`Board._isSeatingMature`) — treat those seats as mature.
+ */
+export function isSeatingMature(
+  seatedAt: bigint | undefined,
+  blockNumber: bigint | undefined,
+): boolean {
+  if (seatedAt === undefined) return false
+  if (seatedAt === 0n) return true
+  if (blockNumber === undefined) return false
+  return blockNumber >= seatedAt
+}
+
+export type QueueTxStatus = 'pending' | 'ready' | 'executed' | 'cancelled' | 'expired'
+
+export function computeQueueTxStatus(args: {
+  executed: boolean
+  cancelled: boolean
+  expired: boolean
+  liveConfirmations: number
+  requiredConfirmations: number
+}): QueueTxStatus {
+  if (args.cancelled) return 'cancelled'
+  if (args.executed) return 'executed'
+  if (args.expired) return 'expired'
+  if (args.liveConfirmations >= args.requiredConfirmations) return 'ready'
+  return 'pending'
+}

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './wagmi'
+export * from './chamberGovernance'

--- a/app/src/lib/proposalCalldata.ts
+++ b/app/src/lib/proposalCalldata.ts
@@ -1,10 +1,12 @@
 /**
- * Offchain calldata archive for Chamber proposals.
- * Onchain storage is keccak256(calldata) only; full bytes come from localStorage
- * (same browser that submitted) or SubmitTransaction logs.
+ * Calldata archive for Chamber proposals.
+ * Ordinary txs store keccak256(calldata) only; L-04 also persists full bytes
+ * for self-calls (`getTransactionCalldata`). Fallbacks: localStorage,
+ * metadata URI, SubmitTransaction logs.
  */
 
-import { keccak256, parseAbiItem, type Hex } from 'viem'
+import { keccak256, parseAbiItem, type Hex, type PublicClient } from 'viem'
+import { chamberAbi } from '@/contracts/abis'
 
 const STORAGE_PREFIX = 'chamber-proposal-calldata'
 
@@ -45,7 +47,7 @@ export function proposalCalldataMatchesHash(
   return keccak256(calldata).toLowerCase() === dataHash.toLowerCase()
 }
 
-export type ProposalCalldataSource = 'local' | 'event' | 'metadata'
+export type ProposalCalldataSource = 'local' | 'onchain' | 'event' | 'metadata'
 
 export type ResolvedProposalCalldata = {
   calldata: `0x${string}`
@@ -109,12 +111,34 @@ export function resolveCalldataFromMetadataField(
   return { calldata, source: 'metadata' }
 }
 
+export async function fetchProposalCalldataOnchain(
+  publicClient: Pick<PublicClient, 'readContract'>,
+  chamberAddress: `0x${string}`,
+  txId: number,
+  dataHash: `0x${string}`,
+): Promise<ResolvedProposalCalldata | null> {
+  try {
+    const stored = await publicClient.readContract({
+      address: chamberAddress,
+      abi: chamberAbi,
+      functionName: 'getTransactionCalldata',
+      args: [BigInt(txId)],
+    })
+    const calldata = stored as `0x${string}`
+    if (!calldata || calldata === '0x') return null
+    if (!proposalCalldataMatchesHash(calldata, dataHash)) return null
+    return { calldata, source: 'onchain' }
+  } catch {
+    return null
+  }
+}
+
 /**
- * Resolve calldata: localStorage, onchain metadata field, then SubmitTransaction logs.
+ * Resolve calldata: localStorage, on-chain self-call store (L-04), metadata, then logs.
  * Persists successful hits to localStorage.
  */
 export async function resolveProposalCalldata(
-  publicClient: Parameters<typeof fetchProposalCalldataFromEvents>[0],
+  publicClient: Parameters<typeof fetchProposalCalldataFromEvents>[0] & Pick<PublicClient, 'readContract'>,
   chamberAddress: `0x${string}`,
   txId: number,
   dataHash: `0x${string}`,
@@ -123,6 +147,12 @@ export async function resolveProposalCalldata(
   const stored = getStoredProposalCalldata(chamberAddress, txId)
   if (stored && proposalCalldataMatchesHash(stored, dataHash)) {
     return { calldata: stored, source: 'local' }
+  }
+
+  const fromOnchain = await fetchProposalCalldataOnchain(publicClient, chamberAddress, txId, dataHash)
+  if (fromOnchain) {
+    setStoredProposalCalldata(chamberAddress, txId, fromOnchain.calldata)
+    return fromOnchain
   }
 
   const fromMeta = resolveCalldataFromMetadataField(metadataCalldata, dataHash)

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -167,6 +167,9 @@ export function parseDataField(data: string): { method?: string; decoded?: strin
     '0x2e17de78': 'claim(uint256)',
     '0x3d18b912': 'withdraw(uint256,uint256)',
     '0xe2bbb158': 'deposit(uint256,uint256)',
+    '0x8456cb59': 'pause()',
+    '0x3f4ba83a': 'unpause()',
+    '0xc89311b6': 'upgradeImplementation(address,bytes)',
   }
 
   const methodId = data.slice(0, 10).toLowerCase()

--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -223,6 +223,24 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
 
   return (
     <div className="space-y-6">
+      {chamberInfo.paused && (
+        <motion.div
+          initial={{ opacity: 0, y: -6 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-100"
+          role="status"
+        >
+          <div className="flex items-start gap-3">
+            <FiAlertTriangle className="w-5 h-5 shrink-0 text-red-400 mt-0.5" aria-hidden />
+            <div>
+              <p className="font-medium text-red-100">Chamber paused</p>
+              <p className="text-red-100/80 leading-relaxed">
+                Deposits, withdrawals, and wallet execute are halted. Directors can still submit and confirm an unpause proposal.
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      )}
       {implSync.implMismatch && !implSync.isLoading && implSync.registryImplementation && (
         <motion.div
           initial={{ opacity: 0, y: -6 }}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -185,7 +185,7 @@ export default function Dashboard() {
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 sm:justify-end sm:shrink-0 text-sm border-t border-slate-700/35 pt-3 sm:border-0 sm:pt-0">
             <div className="flex items-baseline gap-1.5">
               <span className="text-lg font-heading font-bold gradient-text tabular-nums">
-                {countLoading ? '…' : validChambers.length}
+                {countLoading ? '…' : chamberCount || validChambers.length}
               </span>
               <span className="text-slate-500 text-xs">active</span>
             </div>
@@ -202,7 +202,7 @@ export default function Dashboard() {
                 title="Chamber Solidity VERSION constant (implementation)"
                 className="text-slate-200 text-sm font-mono font-semibold tabular-nums"
               >
-                v1.1.4
+                v1.1.5
               </span>
             </div>
           </div>

--- a/app/src/pages/DeployChamber.tsx
+++ b/app/src/pages/DeployChamber.tsx
@@ -62,7 +62,9 @@ export default function DeployChamber() {
               try {
                 const str = JSON.stringify(query.queryKey).toLowerCase()
                 return str.includes(registryAddrLower) &&
-                  (str.includes('getallchambers') || str.includes('getchambercount'))
+                  (str.includes('getallchambers') ||
+                    str.includes('getchambercount') ||
+                    str.includes('registry-chambers'))
               } catch { return false }
             },
           })
@@ -332,6 +334,9 @@ export default function DeployChamber() {
                       {!erc20Valid && !formData.erc20Token && (
                         <span className="text-slate-500 text-xs">The ERC20 token managed by this chamber</span>
                       )}
+                      <p className="text-amber-400/90 text-xs mt-2">
+                        Fee-on-transfer and rebasing tokens revert on deposit (`AssetAmountMismatch`). Use a standard ERC-20.
+                      </p>
                     </div>
                   </div>
 
@@ -464,7 +469,9 @@ export default function DeployChamber() {
                             <p className="text-red-400/80 text-sm">
                               {error?.message?.includes('User rejected') || error?.message?.includes('user rejected')
                                 ? 'Transaction rejected in wallet.'
-                                : 'Deployment failed. Check your wallet and network, then try again.'}
+                                : error?.message?.includes('AssetAmountMismatch')
+                                  ? 'Fee-on-transfer or rebasing tokens revert on chamber creation/deposit.'
+                                  : 'Deployment failed. Check your wallet and network, then try again.'}
                             </p>
                           </>
                         )}

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -36,11 +36,28 @@ import {
   useSeatUpdate,
   useUpdateSeats,
   useExecuteSeatsUpdate,
+  useCancelSeatUpdate,
+  useDirectorActionGate,
+  useUserNFTs,
   useChamberRegistryImplementationSync,
   useProposalCalldata,
 } from '@/hooks'
 import { chamberAbi, erc20Abi } from '@/contracts/abis'
 import { getBlockExplorerAddressUrl, hasProposalCalldata, shortenAddress } from '@/lib/utils'
+import {
+  UPGRADE_SELECTOR,
+  PAUSE_SELECTOR,
+  UNPAUSE_SELECTOR,
+  SEAT_UPDATE_TIMELOCK_SEC,
+  SEAT_UPDATE_EXPIRY_SEC,
+  isAllowedChamberSelfCall,
+  isChamberSelfCall,
+  isUnpauseCall,
+  selectorOf,
+  requiredExecuteConfirmations,
+  computeQueueTxStatus,
+} from '@/lib/chamberGovernance'
+import type { TransactionQueueItem } from '@/types'
 import {
   createProposalMetadataURI,
   getProposalMetadata,
@@ -51,27 +68,21 @@ import {
   proposalCalldataMatchesHash,
   setStoredProposalCalldata,
 } from '@/lib/proposalCalldata'
-import type { SeatUpdate, Transaction } from '@/types'
+import type { SeatUpdate } from '@/types'
 
 type TabType = 'queue' | 'history' | 'new'
 
 type RiskLevel = 'low' | 'medium' | 'high'
 
-const UPGRADE_SELECTOR = '0xc89311b6'
 const MAX_BOARD_SEATS = 20
 
-function isChamberSelfCall(chamberAddress: `0x${string}`, target: string) {
-  return target.toLowerCase() === chamberAddress.toLowerCase()
-}
-
-function isAllowedChamberSelfCall(chamberAddress: `0x${string}`, target: string, data: `0x${string}`) {
-  return !isChamberSelfCall(chamberAddress, target) || data.startsWith(UPGRADE_SELECTOR)
-}
-
 function classifyTransactionRisk(chamberAddress: `0x${string}`, target: `0x${string}`, value: bigint, data: `0x${string}`) {
-  const isSelfCall = target.toLowerCase() === chamberAddress.toLowerCase()
-  const isUpgrade = isSelfCall && data.startsWith(UPGRADE_SELECTOR)
-  const hasUnknownCallData = data !== '0x' && !isUpgrade
+  const isSelfCall = isChamberSelfCall(chamberAddress, target)
+  const selector = selectorOf(data)
+  const isUpgrade = isSelfCall && selector === UPGRADE_SELECTOR
+  const isPause = isSelfCall && selector === PAUSE_SELECTOR
+  const isUnpause = isSelfCall && selector === UNPAUSE_SELECTOR
+  const hasUnknownCallData = data !== '0x' && !isUpgrade && !isPause && !isUnpause
   const sendsEth = value > 0n
 
   if (isUpgrade) {
@@ -79,6 +90,22 @@ function classifyTransactionRisk(chamberAddress: `0x${string}`, target: `0x${str
       level: 'high' as RiskLevel,
       label: 'High risk: protocol upgrade',
       summary: 'Changes Chamber implementation. Confirm implementation address, audit status, and migration notes before approval.',
+    }
+  }
+
+  if (isPause) {
+    return {
+      level: 'high' as RiskLevel,
+      label: 'High risk: pause vault',
+      summary: 'Halts deposits, withdrawals, and wallet execute until the board unpauses.',
+    }
+  }
+
+  if (isUnpause) {
+    return {
+      level: 'high' as RiskLevel,
+      label: 'High risk: unpause vault',
+      summary: 'Restores deposits, withdrawals, and wallet execute after a pause.',
     }
   }
 
@@ -216,14 +243,28 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [activeTab, setActiveTab] = useState<TabType>('queue')
-  const [transactions, setTransactions] = useState<
-    (Transaction & { status: string; cancelled?: boolean; cancelConfirmations?: number; metadataURI?: string })[]
-  >([])
+  type QueueTx = TransactionQueueItem & {
+    cancelled?: boolean
+    cancelConfirmations?: number
+    metadataURI?: string
+    leftoverTokenId?: bigint
+  }
+
+  const [transactions, setTransactions] = useState<QueueTx[]>([])
   
   const chamberInfo = useChamberInfo(chamberAddress)
   const implSync = useChamberRegistryImplementationSync(chamberAddress)
   const { members } = useBoardMembers(chamberAddress, chamberInfo.seats || 5)
   const { seatUpdate, refetch: refetchSeatUpdate } = useSeatUpdate(chamberAddress)
+  const { tokenIds: ownedTokenIds } = useUserNFTs(chamberInfo.nftToken, userAddress)
+  const directorGate = useDirectorActionGate(
+    chamberAddress,
+    userAddress,
+    chamberInfo.directors,
+    members,
+  )
+  const canAct = directorGate.canAct
+  const userTokenId = directorGate.tokenId
 
   const upgradeProposalIntent = searchParams.get('proposal') === 'upgrade'
   const registryUpgradeDraft =
@@ -321,6 +362,71 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
     },
   })
 
+  const directorTokenKey = members.map((m) => m.tokenId.toString()).join(',')
+  const directorTokenIds = useMemo(
+    () => (directorTokenKey ? directorTokenKey.split(',').map((id) => BigInt(id)) : []),
+    [directorTokenKey],
+  )
+  const ownedTokenKey = ownedTokenIds.map((id) => id.toString()).join(',')
+  const ownedTokenIdsStable = useMemo(
+    () => (ownedTokenKey ? ownedTokenKey.split(',').map((id) => BigInt(id)) : []),
+    [ownedTokenKey],
+  )
+
+  const { data: requiredQuorumData } = useReadContracts({
+    contracts: transactionIds.map((id) => ({
+      address: chamberAddress,
+      abi: chamberAbi,
+      functionName: 'getTransactionRequiredQuorum' as const,
+      args: [BigInt(id)] as const,
+    })),
+    query: { enabled: transactionCount > 0, retry: false },
+  })
+
+  const { data: expiredData } = useReadContracts({
+    contracts: transactionIds.map((id) => ({
+      address: chamberAddress,
+      abi: chamberAbi,
+      functionName: 'isTransactionExpired' as const,
+      args: [BigInt(id)] as const,
+    })),
+    query: { enabled: transactionCount > 0, retry: false },
+  })
+
+  const { data: deadlineData } = useReadContracts({
+    contracts: transactionIds.map((id) => ({
+      address: chamberAddress,
+      abi: chamberAbi,
+      functionName: 'getTransactionDeadline' as const,
+      args: [BigInt(id)] as const,
+    })),
+    query: { enabled: transactionCount > 0, retry: false },
+  })
+
+  const { data: liveConfirmData } = useReadContracts({
+    contracts: transactionIds.flatMap((id) =>
+      directorTokenIds.map((tokenId) => ({
+        address: chamberAddress,
+        abi: chamberAbi,
+        functionName: 'getConfirmation' as const,
+        args: [tokenId, BigInt(id)] as const,
+      })),
+    ),
+    query: { enabled: transactionCount > 0 && directorTokenIds.length > 0 },
+  })
+
+  const { data: leftoverConfirmData } = useReadContracts({
+    contracts: transactionIds.flatMap((id) =>
+      ownedTokenIdsStable.map((tokenId) => ({
+        address: chamberAddress,
+        abi: chamberAbi,
+        functionName: 'getConfirmation' as const,
+        args: [tokenId, BigInt(id)] as const,
+      })),
+    ),
+    query: { enabled: transactionCount > 0 && ownedTokenIdsStable.length > 0 },
+  })
+
   // Watch for transaction events and auto-refresh when transactions are mined
   useChamberEvents(chamberAddress, {
     onTransactionEvent: () => {
@@ -348,7 +454,11 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
         metadataList[i] = r.status === 'success' && typeof r.result === 'string' ? r.result : ''
       })
 
-      const txs: (Transaction & { status: string; cancelled?: boolean; cancelConfirmations?: number; metadataURI?: string })[] = []
+      const liveQuorum = chamberInfo.quorum || 1
+      const directorCount = directorTokenIds.length
+      const ownedCount = ownedTokenIdsStable.length
+
+      const txs: QueueTx[] = []
       transactionsData.forEach((result, index) => {
         if (result.status === 'success' && result.result) {
           const [executed, confirmations, target, value, dataHash] = result.result as [
@@ -359,54 +469,102 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
             `0x${string}`,
           ]
           const cancelled = cancelledList[index] ?? false
-          const status = cancelled ? 'cancelled' : executed ? 'executed' : confirmations >= (chamberInfo.quorum || 1) ? 'ready' : 'pending'
+          const snapshotResult = requiredQuorumData?.[index]
+          const snapshot =
+            snapshotResult?.status === 'success' && snapshotResult.result !== undefined
+              ? Number(snapshotResult.result)
+              : undefined
+          const required = requiredExecuteConfirmations(snapshot, liveQuorum)
+
+          let liveConfirmations = 0
+          if (directorCount > 0 && liveConfirmData) {
+            const offset = index * directorCount
+            for (let i = 0; i < directorCount; i++) {
+              const row = liveConfirmData[offset + i]
+              if (row?.status === 'success' && row.result === true) liveConfirmations += 1
+            }
+          } else {
+            liveConfirmations = confirmations
+          }
+
+          const expiredResult = expiredData?.[index]
+          const expired =
+            expiredResult?.status === 'success' ? expiredResult.result === true : false
+          const deadlineResult = deadlineData?.[index]
+          const deadline =
+            deadlineResult?.status === 'success' && typeof deadlineResult.result === 'bigint'
+              ? deadlineResult.result
+              : undefined
+
+          let leftoverTokenId: bigint | undefined
+          if (ownedCount > 0 && leftoverConfirmData) {
+            const offset = index * ownedCount
+            for (let i = 0; i < ownedCount; i++) {
+              const row = leftoverConfirmData[offset + i]
+              if (row?.status === 'success' && row.result === true) {
+                leftoverTokenId = ownedTokenIdsStable[i]
+                break
+              }
+            }
+          }
+
+          const status = computeQueueTxStatus({
+            executed,
+            cancelled,
+            expired,
+            liveConfirmations,
+            requiredConfirmations: required,
+          })
           txs.push({
             id: index,
             executed,
             confirmations,
+            liveConfirmations,
+            requiredConfirmations: required,
             target,
             value,
             dataHash,
+            deadline,
+            expired,
             status,
             cancelled,
             cancelConfirmations: cancelConfirmationsList[index] ?? 0,
             metadataURI: metadataList[index] || undefined,
+            leftoverTokenId,
           })
         }
       })
       setTransactions(txs)
     }
-  }, [transactionsData, cancelledData, cancelConfirmationsData, metadataData, chamberInfo.quorum])
+  }, [
+    transactionsData,
+    cancelledData,
+    cancelConfirmationsData,
+    metadataData,
+    requiredQuorumData,
+    expiredData,
+    deadlineData,
+    liveConfirmData,
+    leftoverConfirmData,
+    chamberInfo.quorum,
+    directorTokenIds,
+    ownedTokenIdsStable,
+  ])
 
-  const pendingTransactions = transactions.filter(tx => !tx.executed && tx.status !== 'ready' && !tx.cancelled)
-  const readyTransactions = transactions.filter(tx => !tx.executed && tx.status === 'ready' && !tx.cancelled)
+  const pendingTransactions = transactions.filter(tx => tx.status === 'pending')
+  const readyTransactions = transactions.filter(tx => tx.status === 'ready')
+  const expiredTransactions = transactions.filter(tx => tx.status === 'expired')
   const cancelledTransactions = transactions.filter(tx => tx.cancelled)
   const executedTransactions = transactions.filter(tx => tx.executed)
   const hasSeatProposal = !!seatUpdate && seatUpdate.timestamp > 0n
   const seatProposalReady = hasSeatProposal && seatUpdate
     ? seatUpdate.supporters.length >= Number(seatUpdate.requiredQuorum) &&
-      BigInt(Math.floor(Date.now() / 1000)) >= seatUpdate.timestamp + SEAT_TIMELOCK_SEC
+      BigInt(Math.floor(Date.now() / 1000)) >= seatUpdate.timestamp + SEAT_UPDATE_TIMELOCK_SEC
     : false
   const boardProposalCount = hasSeatProposal ? 1 : 0
-  const queueCount = pendingTransactions.length + readyTransactions.length + boardProposalCount
+  const queueCount = pendingTransactions.length + readyTransactions.length + expiredTransactions.length + boardProposalCount
 
-  // Check if user is a director and get their token ID
-  // Directors array contains wallet addresses of NFT owners for board member token IDs
-  const userTokenId = useMemo(() => {
-    if (!userAddress || !chamberInfo.directors || !members.length) return undefined
-    
-    // Find the index of user's address in the directors array
-    const directorIndex = chamberInfo.directors.findIndex(
-      (director) => director.toLowerCase() === userAddress.toLowerCase()
-    )
-    
-    // If user is a director, get the corresponding token ID from members
-    if (directorIndex >= 0 && directorIndex < members.length) {
-      return members[directorIndex].tokenId
-    }
-    
-    return undefined
-  }, [userAddress, chamberInfo.directors, members])
+  const actionTokenId = canAct ? userTokenId : undefined
 
   return (
     <div className="space-y-6">
@@ -434,7 +592,7 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
             </div>
           </div>
 
-          {userTokenId !== undefined ? (
+          {canAct ? (
             <button
               onClick={() => setActiveTab('new')}
               className="btn btn-primary"
@@ -443,12 +601,25 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
               New Proposal
             </button>
           ) : (
-            <div className="text-slate-500 text-sm italic hidden md:block">Director access required</div>
+            <div className="text-slate-500 text-sm italic hidden md:block">
+              {directorGate.seatingPending ? 'Director seating is not mature yet' : 'Director access required'}
+            </div>
           )}
         </div>
 
+        {chamberInfo.paused && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-200">
+            This chamber is paused. Deposits, withdrawals, and execute are halted. Directors can still submit and confirm an unpause proposal.
+          </div>
+        )}
+        {directorGate.seatingPending && (
+          <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200">
+            You hold a live board seat, but director actions unlock at block {directorGate.seatedAt?.toString() ?? '…'}.
+          </div>
+        )}
+
         {/* Stats */}
-        <div className="grid grid-cols-5 gap-4 mt-6 pt-6 border-t border-slate-700/30">
+        <div className="grid grid-cols-6 gap-4 mt-6 pt-6 border-t border-slate-700/30">
           <div className="stat-card text-center">
             <div className="font-heading text-xl font-bold text-amber-400">
               {pendingTransactions.length + (hasSeatProposal && !seatProposalReady ? 1 : 0)}
@@ -460,6 +631,12 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
               {readyTransactions.length + (seatProposalReady ? 1 : 0)}
             </div>
             <div className="text-slate-500 text-xs mt-1">Ready</div>
+          </div>
+          <div className="stat-card text-center">
+            <div className="font-heading text-xl font-bold text-red-400/80">
+              {expiredTransactions.length}
+            </div>
+            <div className="text-slate-500 text-xs mt-1">Expired</div>
           </div>
           <div className="stat-card text-center">
             <div className="font-heading text-xl font-bold text-slate-500">
@@ -487,7 +664,7 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
         {[
           { id: 'queue', label: 'Queue', count: queueCount },
           { id: 'history', label: 'History', count: executedTransactions.length },
-          { id: 'new', label: userTokenId !== undefined ? 'New Proposal' : 'New Proposal', count: 0 },
+          { id: 'new', label: 'New Proposal', count: 0 },
         ].map((tab) => (
           <button
             key={tab.id}
@@ -537,7 +714,7 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                 </h3>
                 <BoardProposalCard
                   chamberAddress={chamberAddress}
-                  userTokenId={userTokenId}
+                  userTokenId={actionTokenId}
                   currentSeats={chamberInfo.seats ?? 5}
                   seatUpdate={seatUpdate}
                   onChanged={refetchSeatUpdate}
@@ -557,8 +734,10 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     key={tx.id}
                     transaction={tx}
                     chamberAddress={chamberAddress}
-                    quorum={chamberInfo.quorum || 1}
-                    userTokenId={userTokenId}
+                    quorum={tx.requiredConfirmations}
+                    userTokenId={actionTokenId}
+                    leftoverTokenId={tx.leftoverTokenId}
+                    paused={chamberInfo.paused}
                     chainId={chainId}
                   />
                 ))}
@@ -577,11 +756,34 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     key={tx.id}
                     transaction={tx}
                     chamberAddress={chamberAddress}
-                    quorum={chamberInfo.quorum || 1}
-                    userTokenId={userTokenId}
+                    quorum={tx.requiredConfirmations}
+                    userTokenId={actionTokenId}
+                    leftoverTokenId={tx.leftoverTokenId}
+                    paused={chamberInfo.paused}
                     chainId={chainId}
                   />
                 ))}
+
+            {expiredTransactions.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="font-heading font-semibold text-red-400/80 flex items-center gap-2">
+                  <FiClock className="w-4 h-4" />
+                  Expired
+                </h3>
+                {expiredTransactions.map((tx) => (
+                  <TransactionCard
+                    key={tx.id}
+                    transaction={tx}
+                    chamberAddress={chamberAddress}
+                    quorum={tx.requiredConfirmations}
+                    userTokenId={actionTokenId}
+                    leftoverTokenId={tx.leftoverTokenId}
+                    paused={chamberInfo.paused}
+                    chainId={chainId}
+                  />
+                ))}
+              </div>
+            )}
               </div>
             )}
 
@@ -597,15 +799,17 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     key={tx.id}
                     transaction={tx}
                     chamberAddress={chamberAddress}
-                    quorum={chamberInfo.quorum || 1}
-                    userTokenId={userTokenId}
+                    quorum={tx.requiredConfirmations}
+                    userTokenId={actionTokenId}
+                    leftoverTokenId={tx.leftoverTokenId}
+                    paused={chamberInfo.paused}
                     chainId={chainId}
                   />
                 ))}
               </div>
             )}
 
-            {pendingTransactions.length === 0 && readyTransactions.length === 0 && cancelledTransactions.length === 0 && !hasSeatProposal && (
+            {pendingTransactions.length === 0 && readyTransactions.length === 0 && expiredTransactions.length === 0 && cancelledTransactions.length === 0 && !hasSeatProposal && (
               <div className="panel p-12 text-center">
                 <FiShield className="w-12 h-12 text-slate-600 mx-auto mb-4" />
                 <h3 className="font-heading text-xl font-semibold text-slate-300 mb-2">
@@ -625,7 +829,7 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
             )}
 
             {/* Non-director banner when there are pending txs */}
-            {userTokenId === undefined && (pendingTransactions.length > 0 || readyTransactions.length > 0 || cancelledTransactions.length > 0) && (
+            {!canAct && (pendingTransactions.length > 0 || readyTransactions.length > 0 || expiredTransactions.length > 0 || cancelledTransactions.length > 0) && (
               <div className="panel p-4 border-amber-500/30 bg-amber-500/5">
                 <p className="text-amber-400 text-sm">
                   You&apos;re not a director. Delegate shares to a member to participate in governance.
@@ -655,8 +859,10 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                   key={tx.id}
                   transaction={tx}
                   chamberAddress={chamberAddress}
-                  quorum={chamberInfo.quorum || 1}
-                  userTokenId={userTokenId}
+                  quorum={tx.requiredConfirmations}
+                  userTokenId={actionTokenId}
+                  leftoverTokenId={tx.leftoverTokenId}
+                  paused={chamberInfo.paused}
                   chainId={chainId}
                 />
               ))
@@ -681,7 +887,7 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
           >
-            {userTokenId !== undefined ? (
+            {canAct ? (
               <NewTransactionForm
                 key={registryUpgradeDraft?.newImplementation ?? 'default'}
                 chamberAddress={chamberAddress}
@@ -766,14 +972,16 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
 
 // Transaction Card Component
 interface TransactionCardProps {
-  transaction: Transaction & { status: string; cancelled?: boolean; cancelConfirmations?: number; metadataURI?: string }
+  transaction: TransactionQueueItem & { cancelled?: boolean; cancelConfirmations?: number; metadataURI?: string; leftoverTokenId?: bigint }
   chamberAddress: `0x${string}`
   quorum: number
   userTokenId?: bigint
+  leftoverTokenId?: bigint
+  paused?: boolean
   chainId: number
 }
 
-function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, chainId }: TransactionCardProps) {
+function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, leftoverTokenId, paused, chainId }: TransactionCardProps) {
   const { confirm, isPending: isConfirming } = useConfirmTransaction(chamberAddress)
   const { execute, isPending: isExecuting } = useExecuteTransaction(chamberAddress)
   const { revoke, isPending: isRevoking } = useRevokeConfirmation(chamberAddress)
@@ -794,6 +1002,16 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
     transaction.dataHash,
     metadataCalldata,
   )
+  const { data: onchainStoredCalldata } = useReadContract({
+    address: chamberAddress,
+    abi: chamberAbi,
+    functionName: 'getTransactionCalldata',
+    args: [BigInt(transaction.id)],
+    query: { enabled: hasProposalCalldata(transaction.dataHash), retry: false },
+  })
+  const hasOnchainPreimage =
+    (typeof onchainStoredCalldata === 'string' && onchainStoredCalldata !== '0x') ||
+    resolvedCalldata?.source === 'onchain'
 
   useEffect(() => {
     setExecuteCalldata('0x')
@@ -806,7 +1024,7 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
   }, [resolvedCalldata, calldataTouched])
   const { isConfirmed: userHasConfirmed } = useTransactionConfirmation(
     chamberAddress,
-    userTokenId,
+    leftoverTokenId ?? userTokenId,
     transaction.id
   )
   const { hasVotedToCancel } = useTransactionCancelConfirmation(
@@ -817,7 +1035,11 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
 
   const handleConfirm = async () => {
     if (!userTokenId) {
-      toast.error('You must be a director to confirm')
+      toast.error('You must be a seated director to confirm')
+      return
+    }
+    if (transaction.expired) {
+      toast.error('This transaction has expired')
       return
     }
     try {
@@ -831,7 +1053,11 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
 
   const handleExecute = async () => {
     if (!userTokenId) {
-      toast.error('You must be a director to execute')
+      toast.error('You must be a seated director to execute')
+      return
+    }
+    if (transaction.expired) {
+      toast.error('This transaction has expired')
       return
     }
     const needsCalldata = hasProposalCalldata(transaction.dataHash)
@@ -839,17 +1065,22 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
     if (needsCalldata) {
       const raw = executeCalldata.trim()
       if (!raw || raw === '0x') {
-        toast.error(
-          isResolvingCalldata
-            ? 'Loading calldata from chain… try again in a moment.'
-            : 'Calldata not found. Paste the hex from the proposer or wait for archive sync — it must match the onchain hash.',
-        )
-        return
-      }
-      calldata = (raw.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
-      if (!proposalCalldataMatchesHash(calldata, transaction.dataHash)) {
-        toast.error('Calldata does not match the onchain commitment hash.')
-        return
+        if (hasOnchainPreimage) {
+          calldata = '0x'
+        } else {
+          toast.error(
+            isResolvingCalldata
+              ? 'Loading calldata from chain… try again in a moment.'
+              : 'Calldata not found. Paste the hex from the proposer or wait for archive sync — it must match the onchain hash.',
+          )
+          return
+        }
+      } else {
+        calldata = (raw.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
+        if (!proposalCalldataMatchesHash(calldata, transaction.dataHash)) {
+          toast.error('Calldata does not match the onchain commitment hash.')
+          return
+        }
       }
     }
     try {
@@ -861,13 +1092,19 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
     }
   }
 
+  const revokeTokenId = leftoverTokenId ?? userTokenId
+
   const handleRevoke = async () => {
-    if (!userTokenId) {
-      toast.error('You must be a director to revoke')
+    if (!revokeTokenId) {
+      toast.error('No leftover confirmation to revoke')
+      return
+    }
+    if (transaction.expired) {
+      toast.error('This transaction has expired')
       return
     }
     try {
-      await revoke(userTokenId, BigInt(transaction.id))
+      await revoke(revokeTokenId, BigInt(transaction.id))
       toast.success('Confirmation revoked!')
     } catch (err) {
       console.error(err)
@@ -897,6 +1134,16 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
   const riskSummary = proposalMeta?.riskSummary || risk.summary
 
   const isCancelled = transaction.cancelled === true
+  const isExpired = transaction.status === 'expired' || transaction.expired === true
+  const liveConfirmations = transaction.liveConfirmations ?? transaction.confirmations
+  const requiredConfirmations = transaction.requiredConfirmations || quorum
+  const executeBlockedByPause =
+    !!paused &&
+    !isUnpauseCall(
+      chamberAddress,
+      transaction.target,
+      (resolvedCalldata?.calldata ?? executeCalldata) as `0x${string}`,
+    )
 
   return (
     <motion.div
@@ -905,6 +1152,8 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
       className={`panel p-4 ${
         isCancelled
           ? 'opacity-60 border-slate-600/50 bg-slate-800/30'
+          : isExpired
+          ? 'opacity-70 border-red-500/25 bg-red-500/5'
           : transaction.executed
           ? 'opacity-75'
           : transaction.status === 'ready'
@@ -918,6 +1167,8 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
           w-12 h-12 rounded-xl flex items-center justify-center text-sm font-bold shrink-0
           ${isCancelled
             ? 'bg-slate-600/30 text-slate-500'
+            : isExpired
+            ? 'bg-red-500/15 text-red-400'
             : transaction.executed 
             ? 'bg-slate-500/20 text-slate-500' 
             : transaction.status === 'ready'
@@ -947,8 +1198,11 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
                 Executed
               </span>
             )}
-            {!transaction.executed && transaction.status === 'ready' && !isCancelled && (
+            {!transaction.executed && transaction.status === 'ready' && !isCancelled && !isExpired && (
               <span className="badge badge-success">Ready</span>
+            )}
+            {isExpired && !transaction.executed && !isCancelled && (
+              <span className="badge bg-red-500/15 text-red-400 border-red-500/30">Expired</span>
             )}
             {isCancelled && (
               <span className="badge bg-slate-600/50 text-slate-400 border-slate-500/30">
@@ -991,7 +1245,7 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
             )}
             <span className="flex items-center gap-1">
               <FiCheck className="w-3 h-3" />
-              {transaction.confirmations} / {quorum}
+              {liveConfirmations} / {requiredConfirmations}
             </span>
             {!isCancelled && !transaction.executed && (transaction.cancelConfirmations ?? 0) > 0 && (
               <span className="flex items-center gap-1 text-amber-400/80">
@@ -1015,15 +1269,22 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
               {resolvedCalldata && !calldataTouched && (
                 <p className="text-emerald-400/90 text-xs">
                   Calldata loaded from{' '}
-                  {resolvedCalldata.source === 'event'
-                    ? 'onchain submit event'
-                    : resolvedCalldata.source === 'metadata'
-                      ? 'proposal metadata'
-                      : 'this browser'}
+                  {resolvedCalldata.source === 'onchain'
+                    ? 'on-chain calldata store'
+                    : resolvedCalldata.source === 'event'
+                      ? 'onchain submit event'
+                      : resolvedCalldata.source === 'metadata'
+                        ? 'proposal metadata'
+                        : 'this browser'}
                   — review before executing.
                 </p>
               )}
-              {!isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && (
+              {!isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && hasOnchainPreimage && (
+                <p className="text-emerald-400/90 text-xs">
+                  Calldata is stored on-chain. Execute may pass empty data.
+                </p>
+              )}
+              {!isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && !hasOnchainPreimage && (
                 <p className="text-amber-400/90 text-xs">
                   Calldata not archived here. Ask the proposer for the hex, or paste from your records.
                 </p>
@@ -1046,7 +1307,7 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
             <div className="mt-3 h-1.5 bg-slate-800 rounded-full overflow-hidden">
               <motion.div
                 initial={{ width: 0 }}
-                animate={{ width: `${(transaction.confirmations / quorum) * 100}%` }}
+                animate={{ width: `${(liveConfirmations / Math.max(1, requiredConfirmations)) * 100}%` }}
                 className={`h-full rounded-full ${
                   transaction.status === 'ready'
                     ? 'bg-emerald-500'
@@ -1058,34 +1319,38 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
         </div>
 
         {/* Actions */}
-        {!transaction.executed && !isCancelled && userTokenId !== undefined && (
+        {!transaction.executed && !isCancelled && (userTokenId !== undefined || leftoverTokenId !== undefined) && (
           <div className="flex items-center gap-2">
-            <button
-              onClick={handleCancel}
-              disabled={isCancelling || hasVotedToCancel}
-              className="btn btn-secondary py-2 px-3 border-slate-600 hover:border-slate-500 text-slate-400 hover:text-slate-200"
-              title={hasVotedToCancel ? 'You have voted to cancel' : 'Vote to cancel (requires quorum)'}
-            >
-              {isCancelling ? (
-                <FiLoader className="w-4 h-4 animate-spin" />
-              ) : hasVotedToCancel ? (
-                <>
-                  <FiX className="w-4 h-4" />
-                  Voted to cancel
-                </>
-              ) : (
-                <>
-                  <FiX className="w-4 h-4" />
-                  Cancel
-                </>
-              )}
-            </button>
-            {userHasConfirmed && (
+            {userTokenId !== undefined && (
+              <button
+                onClick={handleCancel}
+                disabled={isCancelling || hasVotedToCancel}
+                className="btn btn-secondary py-2 px-3 border-slate-600 hover:border-slate-500 text-slate-400 hover:text-slate-200"
+                title={hasVotedToCancel ? 'You have voted to cancel' : 'Vote to cancel (requires quorum)'}
+              >
+                {isCancelling ? (
+                  <FiLoader className="w-4 h-4 animate-spin" />
+                ) : hasVotedToCancel ? (
+                  <>
+                    <FiX className="w-4 h-4" />
+                    Voted to cancel
+                  </>
+                ) : (
+                  <>
+                    <FiX className="w-4 h-4" />
+                    Cancel
+                  </>
+                )}
+              </button>
+            )}
+            {!isExpired && (leftoverTokenId !== undefined || userHasConfirmed) && (
               <button
                 onClick={handleRevoke}
                 disabled={isRevoking}
                 className="btn btn-secondary py-2 px-3 border-amber-500/30 hover:border-amber-500/50"
-                title="Revoke your confirmation"
+                title={leftoverTokenId !== undefined && userTokenId === undefined
+                  ? 'Revoke leftover confirmation from a former seat'
+                  : 'Revoke your confirmation'}
               >
                 {isRevoking ? (
                   <FiLoader className="w-4 h-4 animate-spin" />
@@ -1094,7 +1359,7 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
                 )}
               </button>
             )}
-            {transaction.status !== 'ready' && (
+            {userTokenId !== undefined && !isExpired && transaction.status !== 'ready' && (
               <button
                 onClick={handleConfirm}
                 disabled={isConfirming || userHasConfirmed}
@@ -1110,11 +1375,12 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
                 )}
               </button>
             )}
-            {transaction.status === 'ready' && (
+            {userTokenId !== undefined && !isExpired && transaction.status === 'ready' && (
               <button
                 onClick={handleExecute}
-                disabled={isExecuting}
+                disabled={isExecuting || executeBlockedByPause}
                 className="btn btn-primary py-2 px-3"
+                title={executeBlockedByPause ? 'Chamber is paused' : undefined}
               >
                 {isExecuting ? (
                   <FiLoader className="w-4 h-4 animate-spin" />
@@ -1138,7 +1404,9 @@ function TransactionCard({ transaction, chamberAddress, quorum, userTokenId, cha
             {transaction.dataHash}
           </code>
           <p className="text-slate-500 text-xs mt-2">
-            Only the hash is stored onchain. To execute, directors must supply the exact calldata bytes (or use <span className="font-mono">0x</span> for plain ETH with no call data).
+            {hasOnchainPreimage
+              ? 'Self-call calldata is stored on-chain. Execute may pass empty data, or re-supply the original bytes.'
+              : 'Only the hash is stored onchain. To execute, directors must supply the exact calldata bytes (or use 0x for plain ETH with no call data).'}
           </p>
         </div>
       ) : null}
@@ -1158,8 +1426,6 @@ const PROPOSAL_TEMPLATES = [
   { id: 'treasury-transfer', label: 'Treasury Transfer', title: 'Treasury Transfer', description: '', txType: 'eth' as const },
   { id: 'custom', label: 'Custom Call', title: '', description: '', txType: 'custom' as const },
 ]
-
-const SEAT_TIMELOCK_SEC = 7n * 24n * 60n * 60n
 
 function formatDurationSeconds(total: number): string {
   if (total <= 0) return '0m'
@@ -1191,18 +1457,30 @@ function BoardProposalCard({
     isPending: isExecPending,
     isConfirming: isExecConfirming,
   } = useExecuteSeatsUpdate(chamberAddress)
+  const {
+    cancelSeatUpdate,
+    isPending: isCancelPending,
+    isConfirming: isCancelConfirming,
+  } = useCancelSeatUpdate(chamberAddress)
 
   const supported =
     userTokenId !== undefined &&
     seatUpdate.supporters.some((id) => id === userTokenId)
   const nowSec = BigInt(Math.floor(Date.now() / 1000))
-  const timelockEnd = seatUpdate.timestamp + SEAT_TIMELOCK_SEC
+  const timelockEnd = seatUpdate.timestamp + SEAT_UPDATE_TIMELOCK_SEC
+  const expiryEnd = seatUpdate.timestamp + SEAT_UPDATE_EXPIRY_SEC
   const timelockExpired = nowSec >= timelockEnd
+  const proposalExpired = nowSec >= expiryEnd
   const supporterCount = seatUpdate.supporters.length
   const requiredQuorum = Number(seatUpdate.requiredQuorum)
   const quorumReached = supporterCount >= requiredQuorum
   const ready = quorumReached && timelockExpired
-  const busy = isSupportPending || isSupportConfirming || isExecPending || isExecConfirming
+  const isProposer =
+    userTokenId !== undefined &&
+    seatUpdate.supporters.length > 0 &&
+    seatUpdate.supporters[0] === userTokenId
+  const canCancelProposal = userTokenId !== undefined && (isProposer || proposalExpired)
+  const busy = isSupportPending || isSupportConfirming || isExecPending || isExecConfirming || isCancelPending || isCancelConfirming
 
   const support = async () => {
     if (userTokenId === undefined) {
@@ -1229,6 +1507,20 @@ function BoardProposalCard({
       toast.success('Board proposal executed')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Execute failed')
+    }
+  }
+
+  const cancelProposal = async () => {
+    if (userTokenId === undefined) {
+      toast.error('You must be a director to cancel board proposals')
+      return
+    }
+    try {
+      await cancelSeatUpdate(userTokenId)
+      await onChanged()
+      toast.success('Board proposal cancelled')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Cancel failed')
     }
   }
 
@@ -1271,7 +1563,13 @@ function BoardProposalCard({
               <span>
                 Timelock:{' '}
                 <span className={timelockExpired ? 'text-emerald-400' : 'text-slate-200'}>
-                  {timelockExpired ? 'Expired' : `~${formatDurationSeconds(Math.max(0, Number(timelockEnd - nowSec)))} left`}
+                  {timelockExpired ? 'Unlocked' : `~${formatDurationSeconds(Math.max(0, Number(timelockEnd - nowSec)))} left`}
+                </span>
+              </span>
+              <span>
+                Cancel after:{' '}
+                <span className={proposalExpired ? 'text-amber-300' : 'text-slate-200'}>
+                  {proposalExpired ? 'Any director' : `~${formatDurationSeconds(Math.max(0, Number(expiryEnd - nowSec)))} (14d)`}
                 </span>
               </span>
               <span>
@@ -1307,6 +1605,24 @@ function BoardProposalCard({
                   <>
                     <FiCheck className="w-4 h-4" />
                     Support
+                  </>
+                )}
+              </button>
+            )}
+            {canCancelProposal && (
+              <button
+                type="button"
+                onClick={() => void cancelProposal()}
+                disabled={busy}
+                className="btn btn-secondary py-2 px-3 border-slate-600 hover:border-slate-500 text-slate-400 hover:text-slate-200"
+                title={isProposer ? 'Proposer can cancel anytime' : 'Proposal expired — any director may cancel'}
+              >
+                {isCancelPending || isCancelConfirming ? (
+                  <FiLoader className="w-4 h-4 animate-spin" />
+                ) : (
+                  <>
+                    <FiX className="w-4 h-4" />
+                    Cancel
                   </>
                 )}
               </button>
@@ -1802,7 +2118,7 @@ function NewTransactionForm({
                 <div>
                   <h4 className="font-medium text-slate-100 text-sm">Board Proposal</h4>
                   <p className="text-slate-400 text-xs mt-1">
-                    Directors propose and support seat changes directly. Once quorum is reached, execution unlocks after the 7-day timelock.
+                    Directors propose and support seat changes directly. Once quorum is reached, execution unlocks after the 7-day timelock. The proposer can cancel anytime; any current director can cancel after 14 days.
                   </p>
                 </div>
               </div>

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,11 +1,19 @@
 export interface Transaction {
   id: number
   executed: boolean
+  /** Stored confirmation counter (includes evicted tokenIds until they revoke). */
   confirmations: number
+  /** Confirmations whose tokenId is still in the live top-seat set (H-01). */
+  liveConfirmations?: number
+  /** max(submit snapshot, live quorum) — M-04. */
+  requiredConfirmations?: number
   target: `0x${string}`
   value: bigint
-  /** `keccak256(calldata)` stored onchain; full calldata must be supplied at execution. */
+  /** `keccak256(calldata)` stored onchain; full calldata must be supplied at execution unless stored (L-04). */
   dataHash: `0x${string}`
+  /** Exclusive-after unix timestamp (M-06). */
+  deadline?: bigint
+  expired?: boolean
 }
 
 export interface BoardMember {
@@ -42,9 +50,10 @@ export interface ChamberInfo {
   assetToken: `0x${string}`
   nftToken: `0x${string}`
   version: string
+  paused?: boolean
 }
 
 export interface TransactionQueueItem extends Transaction {
-  status: 'pending' | 'ready' | 'executed' | 'failed'
+  status: 'pending' | 'ready' | 'executed' | 'failed' | 'cancelled' | 'expired'
   requiredConfirmations: number
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto latest `origin/main` (`3918b76`, includes L-02 pause, M-03 delegations, H-01/H-02, M-04/M-06, I-01, docs). App-only. Does **not** change `contracts/src`. Contract ABIs/docs stay main’s; this branch overlays the app ABI with landed interface methods that `contracts/abis.ts` still omits, then re-applies the hook/page ship-blockers.

`app/scripts/sync-contracts.mjs` still skips copying `abis.ts` so `npm run build` cannot clobber the overlay from the lagging handwritten repo ABI.

Head: `bc9e703abc5129b358bc5fc068d9ab05b7fd544d`

## Ship-blockers (product outcomes)

| # | Finding | What the app does now | Files |
|---|---------|----------------------|-------|
| 1 | **H-01 + M-04 + M-06** Queue Ready | Ready is `(live director confirm flags) >= max(getTransactionRequiredQuorum, live getQuorum)` **and** not expired **and** not cancelled. Expired txs get **Expired**. Confirm / execute / revoke hidden after deadline; cancel may remain. Deadline `0` is unset / not expired. | `TransactionQueue.tsx`, `chamberGovernance.ts`, `types/index.ts`, `abis.ts` |
| 2 | **H-02** Seating delay | `getSeatedAt(tokenId)` gates New Proposal / Confirm / Execute / seat actions. `getDirectors()` stays live. `seatedAt == 0` is mature (pre-upgrade incumbents, matches `Board._isSeatingMature`). Missing getter still treated as mature. | `useDirectorActionGate`, `TransactionQueue.tsx` |
| 3 | **H-01** Former-director revoke | Confirm / Execute hidden for evicted tokenIds. Revoke shown when leftover `getConfirmation` remains on an owned NFT. | `TransactionQueue.tsx` |
| 4 | **H-03** Seat cancel | `cancelSeatUpdate(tokenId)`: proposer (`supporters[0]`) anytime; any current director after `timestamp + 14d`. 7-day execute timelock kept. Constants are **internal**, so `SEAT_UPDATE_TIMELOCK_SEC` / `SEAT_UPDATE_EXPIRY_SEC` live in `chamberGovernance.ts`. | `useCancelSeatUpdate`, `BoardProposalCard` |
| 5 | **L-02** Pause | Self-call allowlist: upgrade `0xc89311b6`, pause `0x8456cb59`, unpause `0x3f4ba83a`. Banner; deposits / withdraws / execute halt; unpause execute still allowed. Dashboard version `v1.1.5`. | `chamberGovernance.ts`, `ChamberDetail.tsx`, `TreasuryOverview.tsx`, `TransactionQueue.tsx`, `Dashboard.tsx` |
| 6 | **L-01** Registry paging | Do not treat `getAllChambers` / 1-arg getters as complete. Page `getChambers(256, skip)` and keyed overloads + counts until `skip >= count`. Dashboard “active” uses `getChamberCount`. | `useRegistry.ts`, `Dashboard.tsx` |
| 7 | **L-04** On-chain calldata | Resolver source `'onchain'` via `getTransactionCalldata`. Empty execute data allowed when preimage is stored. Fallbacks: localStorage → onchain → metadata → `SubmitTransaction` logs. 4-arg `submitTransaction(..., bytes data)` kept. | `proposalCalldata.ts`, `TransactionQueue.tsx` |
| 8 | **M-07** FoT | `AssetAmountMismatch` + DeployChamber warning. No token picker. | `TreasuryOverview.tsx`, `DeployChamber.tsx` |
| 9 | **M-03** Delegations | TokenId-keyed undelegate unchanged. `ExceedsDelegatedAmount` still mapped. | `DelegationManager.tsx` |
| 10 | **Types** | `requiredConfirmations`, `liveConfirmations`, `deadline`, `expired`, `paused`. | `types/index.ts` |

## Intentionally not done

- **M-01 / ERC-1271**: no Safe-module UI.
- **Indexer / subgraph**: unused; not wired.
- **Optional deadline picker** (M-06 5-arg submit): 4-arg submit still used (30-day default).
- **`contracts/abis.ts`**: left as main’s lagging handwritten ABI. Overlay is `app/contracts/abis.ts` only.

## Test plan

`cd app && npx tsc --noEmit` passes after rebase.

Ready to squash-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1567b5b-483c-4581-9d79-5f76775c00fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1567b5b-483c-4581-9d79-5f76775c00fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

