### PR TITLE
feat: Factory deploy path and My chambers dashboard

### DIFF
--- a/app/contracts/abis.ts
+++ b/app/contracts/abis.ts
@@ -891,6 +891,95 @@ export const registryAbi = [
   },
 ] as const
 
+// Factory ABI — thin Chamber deployer (no world directory)
+export const factoryAbi = [
+  {
+    type: 'constructor',
+    inputs: [
+      { name: 'implementation_', type: 'address' },
+      { name: 'admin', type: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'createChamber',
+    inputs: [
+      { name: 'erc20Token', type: 'address' },
+      { name: 'erc721Token', type: 'address' },
+      { name: 'seats', type: 'uint256' },
+      { name: 'name', type: 'string' },
+      { name: 'symbol', type: 'string' },
+    ],
+    outputs: [{ name: 'chamber', type: 'address' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'setImplementation',
+    inputs: [{ name: 'newImplementation', type: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'implementation',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'owner',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'transferOwnership',
+    inputs: [{ name: 'newOwner', type: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'renounceOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    name: 'ChamberCreated',
+    inputs: [
+      { name: 'chamber', type: 'address', indexed: true },
+      { name: 'asset', type: 'address', indexed: true },
+      { name: 'nft', type: 'address', indexed: true },
+      { name: 'seats', type: 'uint256', indexed: false },
+      { name: 'name', type: 'string', indexed: false },
+      { name: 'symbol', type: 'string', indexed: false },
+      { name: 'creator', type: 'address', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'ChamberImplementationUpdated',
+    inputs: [
+      { name: 'previousImplementation', type: 'address', indexed: true },
+      { name: 'newImplementation', type: 'address', indexed: true },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferred',
+    inputs: [
+      { name: 'previousOwner', type: 'address', indexed: true },
+      { name: 'newOwner', type: 'address', indexed: true },
+    ],
+  },
+] as const
+
 // ERC20 ABI for token interactions
 export const erc20Abi = [
   {

--- a/app/contracts/deployments.d.ts
+++ b/app/contracts/deployments.d.ts
@@ -2,6 +2,7 @@
 // This file is auto-generated - do not edit manually
 declare const deployments: {
   registry: `0x${string}`
+  factory?: `0x${string}`
   chamberImplementation: `0x${string}`
   mockERC20: `0x${string}`
   mockERC721: `0x${string}`

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useChamber'
 export * from './useRegistry'
+export * from './useMyChambers'
 export * from './useTransactionStatus'
 export * from './useChamberEvents'
 export * from './useNftTokenImage'

--- a/app/src/hooks/useMyChambers.ts
+++ b/app/src/hooks/useMyChambers.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useAccount, useChainId, usePublicClient } from 'wagmi'
+import { useQuery } from '@tanstack/react-query'
+import { multicall } from 'viem/actions'
+import { parseAbiItem, type Address, type PublicClient } from 'viem'
+import { chamberAbi, factoryAbi, registryAbi } from '@/contracts/abis'
+import { addRecentChamber, getRecentChambers } from '@/lib/recentChambers'
+import { isNonZeroAddress } from '@/lib/wagmi'
+import { useFactoryAddress, useRegistryAddress } from './useRegistry'
+
+const factoryCreatedEvent = parseAbiItem(
+  'event ChamberCreated(address indexed chamber, address indexed asset, address indexed nft, uint256 seats, string name, string symbol, address creator)',
+)
+
+const registryCreatedEvent = parseAbiItem(
+  'event ChamberCreated(address indexed chamber, uint256 seats, string name, string symbol, address erc20Token, address erc721Token)',
+)
+
+const LOG_LOOKBACK_BLOCKS = 100_000n
+
+export function useRecentChambers() {
+  const chainId = useChainId()
+  const [recents, setRecents] = useState<`0x${string}`[]>(() => getRecentChambers(chainId))
+
+  useEffect(() => {
+    setRecents(getRecentChambers(chainId))
+  }, [chainId])
+
+  const remember = useCallback(
+    (address: string) => {
+      setRecents(addRecentChamber(chainId, address))
+    },
+    [chainId],
+  )
+
+  return { recents, remember }
+}
+
+async function getLogsChunked(
+  client: PublicClient,
+  params: Parameters<PublicClient['getLogs']>[0],
+): Promise<Awaited<ReturnType<PublicClient['getLogs']>>> {
+  try {
+    return await client.getLogs({ ...params, fromBlock: 0n, toBlock: 'latest' })
+  } catch {
+    const latest = await client.getBlockNumber()
+    const from = latest > LOG_LOOKBACK_BLOCKS ? latest - LOG_LOOKBACK_BLOCKS : 0n
+    return client.getLogs({ ...params, fromBlock: from, toBlock: 'latest' })
+  }
+}
+
+async function fetchCreatedChambers(
+  client: PublicClient,
+  factoryAddress: `0x${string}` | undefined,
+  registryAddress: `0x${string}` | undefined,
+): Promise<{ addresses: `0x${string}`[]; creators: Map<string, `0x${string}`> }> {
+  const creators = new Map<string, `0x${string}`>()
+  const addresses: `0x${string}`[] = []
+  const seen = new Set<string>()
+
+  const push = (chamber: Address | undefined, creator?: Address) => {
+    if (!chamber || !isNonZeroAddress(chamber)) return
+    const key = chamber.toLowerCase() as `0x${string}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      addresses.push(key)
+    }
+    if (creator && isNonZeroAddress(creator) && !creators.has(key)) {
+      creators.set(key, creator.toLowerCase() as `0x${string}`)
+    }
+  }
+
+  if (isNonZeroAddress(factoryAddress)) {
+    try {
+      const logs = await getLogsChunked(client, {
+        address: factoryAddress,
+        event: factoryCreatedEvent,
+      })
+      for (const log of logs) {
+        push(log.args.chamber, log.args.creator)
+      }
+    } catch {
+      // RPC getLogs limits — recents / open-address still work
+    }
+  }
+
+  if (isNonZeroAddress(registryAddress)) {
+    try {
+      const logs = await getLogsChunked(client, {
+        address: registryAddress,
+        event: registryCreatedEvent,
+      })
+      for (const log of logs) {
+        push(log.args.chamber)
+      }
+    } catch {
+      // leftover Registry index is best-effort
+    }
+  }
+
+  return { addresses, creators }
+}
+
+export type MyChamberEntry = {
+  address: `0x${string}`
+  isDirector: boolean
+  balance: bigint
+  isCreator: boolean
+}
+
+/**
+ * Chambers the connected user participates in: Factory/Registry `ChamberCreated`
+ * logs plus local recents, kept when the user is creator, a director, or holds shares.
+ */
+export function useMyChambers() {
+  const { address: userAddress } = useAccount()
+  const chainId = useChainId()
+  const publicClient = usePublicClient()
+  const factoryAddress = useFactoryAddress()
+  const registryAddress = useRegistryAddress()
+  const { recents, remember } = useRecentChambers()
+
+  const factoryOk = isNonZeroAddress(factoryAddress)
+  const registryOk = isNonZeroAddress(registryAddress)
+
+  const query = useQuery({
+    queryKey: [
+      'my-chambers',
+      chainId,
+      userAddress,
+      factoryOk ? factoryAddress : '0x0',
+      registryOk ? registryAddress : '0x0',
+      recents.join(),
+    ],
+    enabled: !!publicClient && !!userAddress && (factoryOk || registryOk || recents.length > 0),
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!publicClient || !userAddress) return [] as MyChamberEntry[]
+
+      const { addresses: fromLogs, creators } = await fetchCreatedChambers(
+        publicClient,
+        factoryOk ? factoryAddress : undefined,
+        registryOk ? registryAddress : undefined,
+      )
+
+      const candidates: `0x${string}`[] = []
+      const seen = new Set<string>()
+      for (const addr of [...fromLogs, ...recents]) {
+        const key = addr.toLowerCase()
+        if (seen.has(key)) continue
+        seen.add(key)
+        candidates.push(addr)
+      }
+
+      if (candidates.length === 0) return [] as MyChamberEntry[]
+
+      const user = userAddress.toLowerCase()
+      const [dirs, bals] = await Promise.all([
+        multicall(publicClient, {
+          contracts: candidates.map((address) => ({
+            address,
+            abi: chamberAbi,
+            functionName: 'getDirectors' as const,
+          })),
+          allowFailure: true,
+        }),
+        multicall(publicClient, {
+          contracts: candidates.map((address) => ({
+            address,
+            abi: chamberAbi,
+            functionName: 'balanceOf' as const,
+            args: [userAddress] as const,
+          })),
+          allowFailure: true,
+        }),
+      ])
+
+      const mine: MyChamberEntry[] = []
+      for (let i = 0; i < candidates.length; i++) {
+        const address = candidates[i]!
+        const dirResult = dirs[i]
+        const balResult = bals[i]
+        const directors =
+          dirResult?.status === 'success' ? (dirResult.result as `0x${string}`[]) : undefined
+        const balance = balResult?.status === 'success' ? (balResult.result as bigint) : 0n
+        const isDirector = !!directors?.some((d) => d.toLowerCase() === user)
+        const hasBalance = balance > 0n
+        const isCreator = creators.get(address) === user
+        const isRecent = recents.some((r) => r === address)
+        if (isCreator || isDirector || hasBalance || isRecent) {
+          mine.push({ address, isDirector, balance, isCreator })
+        }
+      }
+      return mine
+    },
+  })
+
+  return {
+    chambers: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+    recents,
+    remember,
+    factoryAddress,
+    registryAddress,
+  }
+}
+
+export function useCreateChamberTarget() {
+  const factoryAddress = useFactoryAddress()
+  const registryAddress = useRegistryAddress()
+  if (isNonZeroAddress(factoryAddress)) {
+    return { address: factoryAddress, abi: factoryAbi, source: 'factory' as const }
+  }
+  if (isNonZeroAddress(registryAddress)) {
+    return { address: registryAddress, abi: registryAbi, source: 'registry' as const }
+  }
+  return { address: undefined, abi: factoryAbi, source: 'none' as const }
+}

--- a/app/src/hooks/useMyChambers.ts
+++ b/app/src/hooks/useMyChambers.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useAccount, useChainId, usePublicClient } from 'wagmi'
 import { useQuery } from '@tanstack/react-query'
 import { multicall } from 'viem/actions'
-import { parseAbiItem, type Address, type PublicClient } from 'viem'
+import { parseAbiItem, type AbiEvent, type Address, type PublicClient } from 'viem'
 import { chamberAbi, factoryAbi, registryAbi } from '@/contracts/abis'
 import { addRecentChamber, getRecentChambers } from '@/lib/recentChambers'
 import { isNonZeroAddress } from '@/lib/wagmi'
@@ -36,16 +36,17 @@ export function useRecentChambers() {
   return { recents, remember }
 }
 
-async function getLogsChunked(
+async function getCreatedLogs<TEvent extends AbiEvent>(
   client: PublicClient,
-  params: Parameters<PublicClient['getLogs']>[0],
-): Promise<Awaited<ReturnType<PublicClient['getLogs']>>> {
+  address: `0x${string}`,
+  event: TEvent,
+) {
   try {
-    return await client.getLogs({ ...params, fromBlock: 0n, toBlock: 'latest' })
+    return await client.getLogs({ address, event, fromBlock: 0n, toBlock: 'latest' })
   } catch {
     const latest = await client.getBlockNumber()
     const from = latest > LOG_LOOKBACK_BLOCKS ? latest - LOG_LOOKBACK_BLOCKS : 0n
-    return client.getLogs({ ...params, fromBlock: from, toBlock: 'latest' })
+    return client.getLogs({ address, event, fromBlock: from, toBlock: 'latest' })
   }
 }
 
@@ -72,10 +73,7 @@ async function fetchCreatedChambers(
 
   if (isNonZeroAddress(factoryAddress)) {
     try {
-      const logs = await getLogsChunked(client, {
-        address: factoryAddress,
-        event: factoryCreatedEvent,
-      })
+      const logs = await getCreatedLogs(client, factoryAddress, factoryCreatedEvent)
       for (const log of logs) {
         push(log.args.chamber, log.args.creator)
       }
@@ -86,10 +84,7 @@ async function fetchCreatedChambers(
 
   if (isNonZeroAddress(registryAddress)) {
     try {
-      const logs = await getLogsChunked(client, {
-        address: registryAddress,
-        event: registryCreatedEvent,
-      })
+      const logs = await getCreatedLogs(client, registryAddress, registryCreatedEvent)
       for (const log of logs) {
         push(log.args.chamber)
       }

--- a/app/src/hooks/useRegistry.ts
+++ b/app/src/hooks/useRegistry.ts
@@ -8,11 +8,12 @@ import {
   usePublicClient,
 } from 'wagmi'
 import { zeroAddress, type Hex, type PublicClient } from 'viem'
-import { registryAbi, chamberAbi } from '@/contracts/abis'
+import { registryAbi, chamberAbi, factoryAbi } from '@/contracts/abis'
 import { REGISTRY_PAGE_SIZE } from '@/lib/chamberGovernance'
 import {
   getContractAddresses,
   hasValidAddresses,
+  isNonZeroAddress,
 } from '@/lib/wagmi'
 import {
   ERC1967_IMPLEMENTATION_SLOT,
@@ -23,6 +24,11 @@ import {
 export function useRegistryAddress() {
   const chainId = useChainId()
   return getContractAddresses(chainId)?.registry ?? '0x0000000000000000000000000000000000000000' as `0x${string}`
+}
+
+export function useFactoryAddress() {
+  const chainId = useChainId()
+  return getContractAddresses(chainId)?.factory ?? '0x0000000000000000000000000000000000000000' as `0x${string}`
 }
 
 export function useHasValidConfig() {
@@ -153,18 +159,45 @@ export function useChamberCount() {
   }
 }
 
+/**
+ * Probe the address (`VERSION` / `nft` / `getSeats`) instead of requiring Registry.isChamber.
+ * Registry.isChamber remains a soft hint for chambers that are still in the deprecated index.
+ */
 export function useIsChamber(address: `0x${string}` | undefined) {
   const registryAddress = useRegistryAddress()
-  
-  const { data } = useReadContract({
-    address: registryAddress,
+  const registryOk = isNonZeroAddress(registryAddress)
+
+  const {
+    data: probe,
+    isFetched: probeFetched,
+    isFetching: probeFetching,
+  } = useReadContracts({
+    contracts: address
+      ? [
+          { address, abi: chamberAbi, functionName: 'VERSION' as const },
+          { address, abi: chamberAbi, functionName: 'nft' as const },
+          { address, abi: chamberAbi, functionName: 'getSeats' as const },
+        ]
+      : [],
+    query: { enabled: !!address, retry: 1 },
+  })
+
+  const { data: registryHint, isFetched: hintFetched } = useReadContract({
+    address: registryOk ? registryAddress : undefined,
     abi: registryAbi,
     functionName: 'isChamber',
     args: address ? [address] : undefined,
-    query: { enabled: !!address && registryAddress !== '0x0000000000000000000000000000000000000000' },
+    query: { enabled: !!address && registryOk },
   })
 
-  return data as boolean | undefined
+  if (!address) return undefined
+
+  const looksLikeChamber = !!probe?.some((r) => r.status === 'success' && r.result !== undefined)
+  if (looksLikeChamber) return true
+  if (registryHint === true) return true
+  if (probeFetched && (!registryOk || hintFetched)) return false
+  if (probeFetching) return undefined
+  return undefined
 }
 
 export function useChambersByAsset(asset: `0x${string}` | undefined) {
@@ -231,12 +264,10 @@ export function useAssets() {
 }
 
 /**
- * Groups chambers by their membership NFT (ERC721).
- * Organizations are defined by shared membership token.
+ * Groups the given chambers by their membership NFT (ERC721).
+ * Pass the user's chambers — do not crawl the world index.
  */
-export function useOrganizationsByNFT() {
-  const { chambers, isLoading: chambersLoading } = useAllChambers()
-  
+export function useOrganizationsByNFT(chambers?: readonly `0x${string}`[]) {
   const validChambers = (chambers ?? []).filter(
     (addr): addr is `0x${string}` =>
       !!addr &&
@@ -276,7 +307,7 @@ export function useOrganizationsByNFT() {
 
   return {
     organizations,
-    isLoading: chambersLoading || nftsLoading,
+    isLoading: nftsLoading && validChambers.length > 0,
   }
 }
 
@@ -330,7 +361,10 @@ export function useChildChambers(chamber: `0x${string}` | undefined) {
 }
 
 export function useCreateChamber() {
+  const factoryAddress = useFactoryAddress()
   const registryAddress = useRegistryAddress()
+  const createAddress = isNonZeroAddress(factoryAddress) ? factoryAddress : registryAddress
+  const createAbi = isNonZeroAddress(factoryAddress) ? factoryAbi : registryAbi
   const { writeContract, data: hash, isPending, error } = useWriteContract()
   const { isLoading: isConfirming, isSuccess, data: receipt } = useWaitForTransactionReceipt({ hash })
 
@@ -342,8 +376,8 @@ export function useCreateChamber() {
     symbol: string
   ) => {
     writeContract({
-      address: registryAddress,
-      abi: registryAbi,
+      address: createAddress,
+      abi: createAbi,
       functionName: 'createChamber',
       args: [erc20Token, erc721Token, BigInt(seats), name, symbol],
     })
@@ -366,25 +400,31 @@ export function useCreateChamber() {
  * its implementation pointer, existing proxies may lag until upgraded.
  */
 export function useChamberRegistryImplementationSync(chamberAddress: `0x${string}` | undefined) {
+  const factoryAddress = useFactoryAddress()
   const registryAddress = useRegistryAddress()
   const chainId = useChainId()
   const publicClient = usePublicClient()
-  const registryOk =
-    registryAddress &&
-    registryAddress !== zeroAddress &&
-    registryAddress.startsWith('0x') &&
-    registryAddress.length === 42
+  const factoryOk = isNonZeroAddress(factoryAddress)
+  const registryOk = isNonZeroAddress(registryAddress)
 
-  const { data: registryImplementation, isLoading: registryImplLoading } = useReadContract({
-    address: registryOk ? registryAddress : undefined,
-    abi: registryAbi,
+  const { data: factoryImplementation, isLoading: factoryImplLoading } = useReadContract({
+    address: factoryOk ? factoryAddress : undefined,
+    abi: factoryAbi,
     functionName: 'implementation',
-    query: { enabled: !!registryOk && !!chamberAddress },
+    query: { enabled: factoryOk && !!chamberAddress },
   })
 
+  const { data: registryImplementation, isLoading: registryImplLoading } = useReadContract({
+    address: registryOk && !factoryOk ? registryAddress : undefined,
+    abi: registryAbi,
+    functionName: 'implementation',
+    query: { enabled: registryOk && !factoryOk && !!chamberAddress },
+  })
+
+  const preferredImpl = factoryOk ? factoryImplementation : registryImplementation
   const regImpl =
-    registryImplementation && registryImplementation !== zeroAddress
-      ? (registryImplementation as `0x${string}`)
+    preferredImpl && preferredImpl !== zeroAddress
+      ? (preferredImpl as `0x${string}`)
       : undefined
 
   const { data: proxyImplementationAddress, isLoading: slotLoading } = useQuery({
@@ -428,8 +468,8 @@ export function useChamberRegistryImplementationSync(chamberAddress: `0x${string
     chamberVersionLabel,
     registryImplementationVersionLabel,
     implMismatch,
-    registryAddress: registryOk ? registryAddress : undefined,
+    registryAddress: factoryOk ? factoryAddress : registryOk ? registryAddress : undefined,
     isLoading:
-      registryImplLoading || slotLoading || chamberVerLoading || registryVerLoading,
+      factoryImplLoading || registryImplLoading || slotLoading || chamberVerLoading || registryVerLoading,
   }
 }

--- a/app/src/hooks/useTransactionStatus.ts
+++ b/app/src/hooks/useTransactionStatus.ts
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef, useState } from 'react'
 import { useWaitForTransactionReceipt, useWatchPendingTransactions, useWriteContract } from 'wagmi'
 import { type Hash } from 'viem'
 import toast from 'react-hot-toast'
-import { chamberAbi, erc20Abi, registryAbi } from '@/contracts/abis'
+import { chamberAbi, erc20Abi, factoryAbi, registryAbi } from '@/contracts/abis'
 
 export type TransactionStatus = 'idle' | 'pending' | 'confirming' | 'success' | 'error'
 
@@ -546,14 +546,15 @@ export function useTokenApproveWithStatus(
  * Enhanced hook for creating chambers with status tracking
  */
 export function useCreateChamberWithStatus(
-  registryAddress: `0x${string}` | undefined,
-  options?: UseTransactionStatusOptions
+  createAddress: `0x${string}` | undefined,
+  options?: UseTransactionStatusOptions & { abi?: typeof factoryAbi | typeof registryAbi }
 ) {
   const { writeContract, data: hash, isPending, error: writeError } = useWriteContract()
   const transactionStatus = useTransactionStatus({
     hash,
     ...options,
   })
+  const createAbi = options?.abi ?? registryAbi
 
   const createChamber = async (
     erc20Token: `0x${string}`,
@@ -562,12 +563,12 @@ export function useCreateChamberWithStatus(
     name: string,
     symbol: string
   ) => {
-    if (!registryAddress) return
+    if (!createAddress) return
     try {
       transactionStatus.reset()
       const txHash = await writeContract({
-        address: registryAddress,
-        abi: registryAbi,
+        address: createAddress,
+        abi: createAbi,
         functionName: 'createChamber',
         args: [erc20Token, erc721Token, BigInt(seats), name, symbol],
       })

--- a/app/src/lib/recentChambers.ts
+++ b/app/src/lib/recentChambers.ts
@@ -1,0 +1,47 @@
+const MAX_RECENTS = 20
+
+function storageKey(chainId: number): string {
+  return `chamber:recents:${chainId}`
+}
+
+function normalize(addr: string): `0x${string}` | undefined {
+  const value = addr.trim().toLowerCase()
+  if (!value.startsWith('0x') || value.length !== 42) return undefined
+  return value as `0x${string}`
+}
+
+export function getRecentChambers(chainId: number): `0x${string}`[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(storageKey(chainId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    const out: `0x${string}`[] = []
+    const seen = new Set<string>()
+    for (const item of parsed) {
+      if (typeof item !== 'string') continue
+      const addr = normalize(item)
+      if (!addr || seen.has(addr)) continue
+      seen.add(addr)
+      out.push(addr)
+    }
+    return out
+  } catch {
+    return []
+  }
+}
+
+export function addRecentChamber(chainId: number, address: string): `0x${string}`[] {
+  const addr = normalize(address)
+  if (!addr) return getRecentChambers(chainId)
+  const next = [addr, ...getRecentChambers(chainId).filter((item) => item !== addr)].slice(0, MAX_RECENTS)
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(storageKey(chainId), JSON.stringify(next))
+    } catch {
+      // ignore quota / private mode
+    }
+  }
+  return next
+}

--- a/app/src/lib/wagmi.ts
+++ b/app/src/lib/wagmi.ts
@@ -175,7 +175,10 @@ export const CONTRACT_ADDRESSES = {
   // Localhost - auto-populated from deployments.json via `make deploy-anvil-all`
   localhost: {
     registry: addressFromEnv(localDeployments.registry, import.meta.env.VITE_LOCALHOST_REGISTRY),
-    factory: addressFromEnv(localDeployments.factory, import.meta.env.VITE_LOCALHOST_FACTORY),
+    factory: addressFromEnv(
+      (localDeployments as { factory?: string }).factory,
+      import.meta.env.VITE_LOCALHOST_FACTORY,
+    ),
     chamberImplementation: addressFromEnv(localDeployments.chamberImplementation),
     mockERC20: addressFromEnv(localDeployments.mockERC20),
     mockERC721: addressFromEnv(localDeployments.mockERC721),

--- a/app/src/lib/wagmi.ts
+++ b/app/src/lib/wagmi.ts
@@ -6,13 +6,21 @@ import { alchemySupportsChain, getAlchemyApiKeyFromEnv, getAlchemyV2RpcUrl } fro
 
 const productionApp = import.meta.env.PROD
 
-const ZERO_REGISTRY = '0x0000000000000000000000000000000000000000'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`
 
-/** Mainnet is only offered when `VITE_MAINNET_REGISTRY` is set (same rule as `hasValidAddresses(1)`). */
-const mainnetRegistryRaw = import.meta.env.VITE_MAINNET_REGISTRY?.trim() ?? ''
+function envAddress(raw: string | undefined): string {
+  return raw?.trim() ?? ''
+}
+
+function isConfiguredAddress(raw: string): boolean {
+  return raw !== '' && raw.toLowerCase() !== ZERO_ADDRESS
+}
+
+/** Mainnet is offered when `VITE_MAINNET_FACTORY` or `VITE_MAINNET_REGISTRY` is set. */
+const mainnetFactoryRaw = envAddress(import.meta.env.VITE_MAINNET_FACTORY)
+const mainnetRegistryRaw = envAddress(import.meta.env.VITE_MAINNET_REGISTRY)
 export const isMainnetConfigured =
-  mainnetRegistryRaw !== '' &&
-  mainnetRegistryRaw.toLowerCase() !== ZERO_REGISTRY
+  isConfiguredAddress(mainnetFactoryRaw) || isConfiguredAddress(mainnetRegistryRaw)
 
 // Use the chain ID from deployments.json so that localhost accurately matches Anvil forks (dev only)
 export const LOCAL_CHAIN_ID = localDeployments.chainId || 31337
@@ -75,7 +83,7 @@ if (import.meta.env.DEV && alchemyApiKey) {
   console.info('[wagmi] Alchemy RPC enabled for Ethereum, Sepolia, Base, Arbitrum, and local RPC')
 }
 
-/** Production: Sepolia, plus Mainnet only when `VITE_MAINNET_REGISTRY` is set. Dev adds Base, Arbitrum, local. */
+/** Production: Sepolia, plus Mainnet when factory or registry env is set. Dev adds Base, Arbitrum, local. */
 export const config = productionApp
   ? isMainnetConfigured
     ? getDefaultConfig({
@@ -126,50 +134,62 @@ export const config = productionApp
 
 // Contract addresses - localhost uses auto-generated deployments.json from `make deploy-anvil-all`
 // Testnet/mainnet addresses can be overridden with environment variables
+function addressFromEnv(...candidates: (string | undefined)[]): `0x${string}` {
+  for (const raw of candidates) {
+    const value = envAddress(raw)
+    if (isConfiguredAddress(value)) return value as `0x${string}`
+  }
+  return ZERO_ADDRESS
+}
+
 export const CONTRACT_ADDRESSES = {
   // Sepolia testnet addresses
   sepolia: {
-    registry: (import.meta.env.VITE_SEPOLIA_REGISTRY || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    chamberImplementation: (import.meta.env.VITE_SEPOLIA_CHAMBER_IMPL || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    mockERC20: (import.meta.env.VITE_SEPOLIA_MOCK_ERC20 ||
-      '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    mockERC721: (import.meta.env.VITE_SEPOLIA_MOCK_ERC721 ||
-      '0x0000000000000000000000000000000000000000') as `0x${string}`,
+    registry: addressFromEnv(import.meta.env.VITE_SEPOLIA_REGISTRY),
+    factory: addressFromEnv(import.meta.env.VITE_SEPOLIA_FACTORY),
+    chamberImplementation: addressFromEnv(import.meta.env.VITE_SEPOLIA_CHAMBER_IMPL),
+    mockERC20: addressFromEnv(import.meta.env.VITE_SEPOLIA_MOCK_ERC20),
+    mockERC721: addressFromEnv(import.meta.env.VITE_SEPOLIA_MOCK_ERC721),
   },
   mainnet: {
-    registry: (import.meta.env.VITE_MAINNET_REGISTRY || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    chamberImplementation: (import.meta.env.VITE_MAINNET_CHAMBER_IMPL || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    mockERC20: '0x0000000000000000000000000000000000000000' as `0x${string}`,
-    mockERC721: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    registry: addressFromEnv(import.meta.env.VITE_MAINNET_REGISTRY),
+    factory: addressFromEnv(import.meta.env.VITE_MAINNET_FACTORY),
+    chamberImplementation: addressFromEnv(import.meta.env.VITE_MAINNET_CHAMBER_IMPL),
+    mockERC20: ZERO_ADDRESS as `0x${string}`,
+    mockERC721: ZERO_ADDRESS as `0x${string}`,
   },
   base: {
-    registry: (import.meta.env.VITE_BASE_REGISTRY || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    chamberImplementation: (import.meta.env.VITE_BASE_CHAMBER_IMPL || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    mockERC20: '0x0000000000000000000000000000000000000000' as `0x${string}`,
-    mockERC721: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    registry: addressFromEnv(import.meta.env.VITE_BASE_REGISTRY),
+    factory: addressFromEnv(import.meta.env.VITE_BASE_FACTORY),
+    chamberImplementation: addressFromEnv(import.meta.env.VITE_BASE_CHAMBER_IMPL),
+    mockERC20: ZERO_ADDRESS as `0x${string}`,
+    mockERC721: ZERO_ADDRESS as `0x${string}`,
   },
   arbitrum: {
-    registry: (import.meta.env.VITE_ARBITRUM_REGISTRY || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    chamberImplementation: (import.meta.env.VITE_ARBITRUM_CHAMBER_IMPL || '0x0000000000000000000000000000000000000000') as `0x${string}`,
-    mockERC20: '0x0000000000000000000000000000000000000000' as `0x${string}`,
-    mockERC721: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    registry: addressFromEnv(import.meta.env.VITE_ARBITRUM_REGISTRY),
+    factory: addressFromEnv(import.meta.env.VITE_ARBITRUM_FACTORY),
+    chamberImplementation: addressFromEnv(import.meta.env.VITE_ARBITRUM_CHAMBER_IMPL),
+    mockERC20: ZERO_ADDRESS as `0x${string}`,
+    mockERC721: ZERO_ADDRESS as `0x${string}`,
   },
   // Localhost - auto-populated from deployments.json via `make deploy-anvil-all`
   localhost: {
-    registry: localDeployments.registry as `0x${string}`,
-    chamberImplementation: localDeployments.chamberImplementation as `0x${string}`,
-    mockERC20: localDeployments.mockERC20 as `0x${string}`,
-    mockERC721: localDeployments.mockERC721 as `0x${string}`,
+    registry: addressFromEnv(localDeployments.registry, import.meta.env.VITE_LOCALHOST_REGISTRY),
+    factory: addressFromEnv(localDeployments.factory, import.meta.env.VITE_LOCALHOST_FACTORY),
+    chamberImplementation: addressFromEnv(localDeployments.chamberImplementation),
+    mockERC20: addressFromEnv(localDeployments.mockERC20),
+    mockERC721: addressFromEnv(localDeployments.mockERC721),
   },
 } as const
 
 // Export localhost deployment info for convenience
 export const localhostDeployment = {
   ...localDeployments,
-  registry: localDeployments.registry as `0x${string}`,
-  chamberImplementation: localDeployments.chamberImplementation as `0x${string}`,
-  mockERC20: localDeployments.mockERC20 as `0x${string}`,
-  mockERC721: localDeployments.mockERC721 as `0x${string}`,
+  registry: CONTRACT_ADDRESSES.localhost.registry,
+  factory: CONTRACT_ADDRESSES.localhost.factory,
+  chamberImplementation: CONTRACT_ADDRESSES.localhost.chamberImplementation,
+  mockERC20: CONTRACT_ADDRESSES.localhost.mockERC20,
+  mockERC721: CONTRACT_ADDRESSES.localhost.mockERC721,
 }
 
 export function getContractAddresses(chainId: number) {
@@ -195,9 +215,13 @@ export function getContractAddresses(chainId: number) {
   }
 }
 
-// Helper to check if we have valid addresses configured
+export function isNonZeroAddress(addr: string | undefined): addr is `0x${string}` {
+  return !!addr && addr !== ZERO_ADDRESS && addr.startsWith('0x') && addr.length === 42
+}
+
+// Helper to check if we have valid addresses configured (factory or registry)
 export function hasValidAddresses(chainId: number): boolean {
   const addresses = getContractAddresses(chainId)
   if (!addresses) return false
-  return addresses.registry !== '0x0000000000000000000000000000000000000000'
+  return isNonZeroAddress(addresses.factory) || isNonZeroAddress(addresses.registry)
 }

--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAccount, useBalance, useReadContract, useReadContracts, useChainId } from 'wagmi'
@@ -43,6 +43,7 @@ import TreasuryOverview from '@/components/TreasuryOverview'
 import DelegationManager from '@/components/DelegationManager'
 import ChamberAssetsAlchemy from '@/components/ChamberAssetsAlchemy'
 import { NftRetryableImage } from '@/components/NftRetryableImage'
+import { addRecentChamber } from '@/lib/recentChambers'
 import { getBlockExplorerAddressUrl, shortenAddress } from '@/lib/utils'
 import type { SeatUpdate } from '@/types'
 
@@ -71,7 +72,7 @@ export default function ChamberDetail() {
     return (
       <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
         <FiLoader className="w-10 h-10 text-accent-400 animate-spin" />
-        <p className="text-slate-400 text-sm">Verifying chamber registration…</p>
+        <p className="text-slate-400 text-sm">Verifying chamber…</p>
       </div>
     )
   }
@@ -81,7 +82,7 @@ export default function ChamberDetail() {
       <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
         <FiAlertTriangle className="w-12 h-12 text-red-400" />
         <h2 className="font-heading text-xl font-bold text-slate-100">Not a Chamber</h2>
-        <p className="text-slate-400">This address is not registered in the Registry.</p>
+        <p className="text-slate-400">This address does not look like a Chamber contract.</p>
         <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
       </div>
     )
@@ -95,6 +96,10 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
   const navigate = useNavigate()
   const { address: userAddress } = useAccount()
   const chainId = useChainId()
+
+  useEffect(() => {
+    addRecentChamber(chainId, chamberAddress)
+  }, [chainId, chamberAddress])
 
   const activeTab: Tab = tab && validTabs.includes(tab as Tab) ? (tab as Tab) : 'overview'
   

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,35 +1,42 @@
 import { useEffect, useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useAccount, usePublicClient, useChainId, useReadContracts } from 'wagmi'
-import { formatUnits } from 'viem'
-import { multicall } from 'viem/actions'
-import { useQuery } from '@tanstack/react-query'
-import { FiLayers, FiPlus, FiAlertTriangle, FiGrid, FiBriefcase, FiShield, FiUser } from 'react-icons/fi'
-import { useAllChambers, useChamberCount, useHasValidConfig, useOrganizationsByNFT } from '@/hooks'
+import { useAccount, useChainId, useReadContracts } from 'wagmi'
+import { formatUnits, isAddress } from 'viem'
+import { FiLayers, FiPlus, FiAlertTriangle, FiUser, FiBriefcase, FiShield, FiArrowRight } from 'react-icons/fi'
+import { useHasValidConfig, useMyChambers, useOrganizationsByNFT } from '@/hooks'
 import { erc721Abi } from '@/contracts'
-import { chamberAbi } from '@/contracts/abis'
-import ChamberCard from '@/components/ChamberCard'
 import { isMainnetConfigured } from '@/lib/wagmi'
+import ChamberCard from '@/components/ChamberCard'
 
 export default function Dashboard() {
-  const { isConnected, address: userAddress } = useAccount()
+  const { isConnected } = useAccount()
   const location = useLocation()
+  const navigate = useNavigate()
   const chainId = useChainId()
-  const [viewMode, setViewMode] = useState<'all' | 'organizations'>('all')
+  const [viewMode, setViewMode] = useState<'mine' | 'organizations'>('mine')
+  const [openAddress, setOpenAddress] = useState('')
+  const [openError, setOpenError] = useState<string | null>(null)
 
-  const { chambers, isLoading, refetch: refetchChambers, error: chambersError } = useAllChambers()
-  const { count: chamberCount, refetch: refetchCount, isLoading: countLoading, error: countError, registryAddress } = useChamberCount()
-  const { organizations, isLoading: orgsLoading } = useOrganizationsByNFT()
+  const {
+    chambers: myChambers,
+    isLoading,
+    refetch: refetchMine,
+    error: chambersError,
+    recents,
+    remember,
+    factoryAddress,
+    registryAddress,
+  } = useMyChambers()
+  const myAddresses = myChambers.map((entry) => entry.address)
+  const { organizations, isLoading: orgsLoading } = useOrganizationsByNFT(myAddresses)
   const { isValid } = useHasValidConfig()
 
-  // Refetch when navigating to dashboard so newly created chambers appear immediately
   useEffect(() => {
     if (location.pathname === '/') {
-      refetchChambers()
-      refetchCount()
+      refetchMine()
     }
-  }, [location.pathname, refetchChambers, refetchCount])
+  }, [location.pathname, refetchMine])
 
   const getNetworkName = (id: number) => {
     switch (id) {
@@ -40,55 +47,17 @@ export default function Dashboard() {
     }
   }
 
-  const validChambers = chambers || []
-
-  const publicClient = usePublicClient()
-  const participationQuery = useQuery({
-    queryKey: ['dashboard-chamber-participation', chainId, userAddress, validChambers.join()],
-    enabled: !!publicClient && !!userAddress && validChambers.length > 0,
-    staleTime: 30_000,
-    queryFn: async () => {
-      if (!publicClient || !userAddress) throw new Error('Missing client or account')
-      const directorReads = validChambers.map((address) => ({
-        address,
-        abi: chamberAbi,
-        functionName: 'getDirectors' as const,
-      }))
-      const balanceReads = validChambers.map((address) => ({
-        address,
-        abi: chamberAbi,
-        functionName: 'balanceOf' as const,
-        args: [userAddress] as const,
-      }))
-      const [dirs, bals] = await Promise.all([
-        multicall(publicClient, { contracts: directorReads, allowFailure: true }),
-        multicall(publicClient, { contracts: balanceReads, allowFailure: true }),
-      ])
-      return { dirs, bals }
-    },
-  })
-
-  const allDirectors = participationQuery.data?.dirs.map((r) =>
-    r.status === 'success'
-      ? ({ status: 'success' as const, result: r.result })
-      : ({ status: 'failure' as const }),
-  )
-  const allBalances = participationQuery.data?.bals.map((r) =>
-    r.status === 'success'
-      ? ({ status: 'success' as const, result: r.result })
-      : ({ status: 'failure' as const }),
-  )
-
-  const myChambers = validChambers.filter((_addr, i) => {
-    const dirs = allDirectors?.[i]?.result as `0x${string}`[] | undefined
-    const bal = allBalances?.[i]?.result as bigint | undefined
-    const isDirector = dirs?.some((d) => d.toLowerCase() === userAddress?.toLowerCase())
-    const hasBalance = bal !== undefined && bal > 0n
-    return isDirector || hasBalance
-  })
-
-  const myChambersReady =
-    !!userAddress && validChambers.length > 0 && participationQuery.isSuccess && participationQuery.data !== undefined
+  const handleOpenAddress = (e: React.FormEvent) => {
+    e.preventDefault()
+    const value = openAddress.trim()
+    if (!isAddress(value)) {
+      setOpenError('Enter a valid chamber address')
+      return
+    }
+    setOpenError(null)
+    remember(value)
+    navigate(`/chamber/${value}`)
+  }
 
   return (
     <div className="space-y-10">
@@ -105,7 +74,6 @@ export default function Dashboard() {
         </motion.div>
       )}
 
-      {/* Configuration Warning */}
       {!isValid && !(chainId === 1 && !isMainnetConfigured) && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
@@ -117,16 +85,23 @@ export default function Dashboard() {
             <div>
               <h4 className="font-medium text-amber-400 mb-1">Contract Addresses Not Configured</h4>
               <p className="text-slate-400 text-sm">
-                No Registry contract address configured for <strong>{getNetworkName(chainId)}</strong> (Chain ID: {chainId}).
+                No Factory or Registry address configured for <strong>{getNetworkName(chainId)}</strong> (Chain ID: {chainId}).
                 {chainId === 31337 ? (
                   <>
-                    {' '}Deploy contracts to Anvil and update your <code className="text-accent-400">.env</code> file:
+                    {' '}Deploy contracts to Anvil and update your <code className="text-accent-400">.env</code> file
+                    (Factory preferred; Registry is enough for legacy deploys):
                     <code className="block mt-2 p-2 bg-slate-800/50 rounded text-xs">
+                      VITE_LOCALHOST_FACTORY=0x...your_factory_address
+                    </code>
+                    <code className="block mt-1 p-2 bg-slate-800/50 rounded text-xs">
                       VITE_LOCALHOST_REGISTRY=0x...your_registry_address
                     </code>
                   </>
                 ) : (
-                  <> Update your <code className="text-accent-400">.env</code> file with the contract addresses.</>
+                  <>
+                    {' '}Set <code className="text-accent-400">VITE_*_FACTORY</code> or{' '}
+                    <code className="text-accent-400">VITE_*_REGISTRY</code> in your <code className="text-accent-400">.env</code> file.
+                  </>
                 )}
               </p>
             </div>
@@ -134,8 +109,7 @@ export default function Dashboard() {
         </motion.div>
       )}
 
-      {/* Dev debug info – only shown when there are errors */}
-      {import.meta.env.DEV && (countError || chambersError || !isValid) && (
+      {import.meta.env.DEV && (chambersError || !isValid) && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -143,17 +117,15 @@ export default function Dashboard() {
         >
           <div className="text-xs font-mono text-slate-400 space-y-1">
             <div><strong>Chain ID:</strong> {chainId} ({getNetworkName(chainId)})</div>
+            <div><strong>Factory Address:</strong> {factoryAddress || 'Not set'}</div>
             <div><strong>Registry Address:</strong> {registryAddress || 'Not set'}</div>
             <div><strong>Config Valid:</strong> {isValid ? 'Yes' : 'No'}</div>
-            {countError && <div className="text-red-400"><strong>Count Error:</strong> {countError.message}</div>}
-            {chambersError && <div className="text-red-400"><strong>Chambers Error:</strong> {chambersError.message}</div>}
-            <div><strong>Chamber Count:</strong> {chamberCount}</div>
-            <div><strong>Chambers Array Length:</strong> {validChambers.length}</div>
+            {chambersError && <div className="text-red-400"><strong>My Chambers Error:</strong> {chambersError.message}</div>}
+            <div><strong>My Chambers:</strong> {myChambers.length}</div>
           </div>
         </motion.div>
       )}
 
-      {/* Hero Section */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -177,7 +149,7 @@ export default function Dashboard() {
                 Loreum Chambers
               </h1>
               <p className="text-slate-500 text-xs sm:text-sm mt-0.5 leading-snug">
-                Liquid, decentralized governance.
+                Your chambers, not a global directory.
               </p>
             </div>
           </div>
@@ -185,9 +157,9 @@ export default function Dashboard() {
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 sm:justify-end sm:shrink-0 text-sm border-t border-slate-700/35 pt-3 sm:border-0 sm:pt-0">
             <div className="flex items-baseline gap-1.5">
               <span className="text-lg font-heading font-bold gradient-text tabular-nums">
-                {countLoading ? '…' : chamberCount || validChambers.length}
+                {isLoading && isConnected ? '…' : myChambers.length}
               </span>
-              <span className="text-slate-500 text-xs">active</span>
+              <span className="text-slate-500 text-xs">mine</span>
             </div>
             <span className="hidden sm:inline h-3 w-px bg-slate-600/60" aria-hidden />
             <div className="flex items-center gap-1.5">
@@ -209,67 +181,23 @@ export default function Dashboard() {
         </div>
       </motion.div>
 
-      {/* My Participation — only when connected and has involvement */}
-      {isConnected && userAddress && myChambersReady && myChambers.length > 0 && (
-        <motion.section
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="space-y-4"
-        >
-          <div className="flex items-center gap-3">
-            <FiUser className="w-4 h-4 text-accent-400" />
-            <h2 className="font-heading text-lg font-semibold text-slate-100">Your Participation</h2>
-            <span className="badge badge-primary">{myChambers.length}</span>
-          </div>
-          <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 340px), 1fr))' }}>
-            {myChambers.map((addr) => {
-              const idx = validChambers.indexOf(addr)
-              const dirs = allDirectors?.[idx]?.result as `0x${string}`[] | undefined
-              const bal = allBalances?.[idx]?.result as bigint | undefined
-              const isDirector = dirs?.some((d) => d.toLowerCase() === userAddress.toLowerCase())
-              return (
-                <div key={addr} className="relative">
-                  {isDirector && (
-                    <div className="absolute -top-2 -left-2 z-10">
-                      <span className="badge bg-accent-600/80 text-white border-accent-500/40 text-[10px]">
-                        <FiShield className="w-3 h-3 mr-1" />
-                        Director
-                      </span>
-                    </div>
-                  )}
-                  {bal !== undefined && bal > 0n && !isDirector && (
-                    <div className="absolute -top-2 -left-2 z-10">
-                      <span className="badge bg-slate-700 text-slate-300 border-slate-600 text-[10px]">
-                        {parseFloat(formatUnits(bal, 18)).toFixed(2)} shares
-                      </span>
-                    </div>
-                  )}
-                  <ChamberCard address={addr as `0x${string}`} />
-                </div>
-              )
-            })}
-          </div>
-        </motion.section>
-      )}
-
-      {/* Chambers List */}
-      <section id="chambers" className="space-y-6">
+      <section className="space-y-6">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div>
-            <h2 className="font-heading text-2xl font-bold text-slate-100">Registry</h2>
-            <p className="text-slate-500 text-sm mt-1">Active governance instances</p>
+            <h2 className="font-heading text-2xl font-bold text-slate-100">My chambers</h2>
+            <p className="text-slate-500 text-sm mt-1">Chambers you created, direct, or hold shares in</p>
           </div>
 
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1 p-1 bg-slate-900/80 rounded-xl border border-slate-700/50">
               <button
-                onClick={() => setViewMode('all')}
+                onClick={() => setViewMode('mine')}
                 className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
-                  viewMode === 'all' ? 'bg-accent-500/10 text-accent-400 shadow-sm' : 'text-slate-400 hover:text-slate-200'
+                  viewMode === 'mine' ? 'bg-accent-500/10 text-accent-400 shadow-sm' : 'text-slate-400 hover:text-slate-200'
                 }`}
               >
-                <FiGrid className="w-4 h-4" />
-                All
+                <FiUser className="w-4 h-4" />
+                Mine
               </button>
               <button
                 onClick={() => setViewMode('organizations')}
@@ -289,16 +217,54 @@ export default function Dashboard() {
           </div>
         </div>
 
+        <form onSubmit={handleOpenAddress} className="panel p-4 flex flex-col sm:flex-row gap-3 sm:items-end">
+          <div className="flex-1 min-w-0">
+            <label className="block text-slate-400 text-xs font-medium mb-1.5">Open address</label>
+            <input
+              type="text"
+              placeholder="0x… chamber address"
+              className="input font-mono"
+              value={openAddress}
+              onChange={(e) => {
+                setOpenAddress(e.target.value)
+                if (openError) setOpenError(null)
+              }}
+            />
+            {openError && <p className="text-red-400 text-xs mt-1.5">{openError}</p>}
+          </div>
+          <button type="submit" className="btn btn-secondary shrink-0">
+            Open
+            <FiArrowRight className="w-4 h-4" />
+          </button>
+        </form>
+
+        {recents.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-slate-500 text-xs uppercase tracking-wider">Recents</span>
+            {recents.map((addr) => (
+              <Link
+                key={addr}
+                to={`/chamber/${addr}`}
+                className="badge bg-slate-800 text-slate-300 border-slate-600/60 font-mono text-[11px] hover:text-slate-100"
+              >
+                {addr.slice(0, 8)}…{addr.slice(-6)}
+              </Link>
+            ))}
+          </div>
+        )}
+
         <AnimatePresence mode="wait">
-          {viewMode === 'all' ? (
+          {viewMode === 'mine' ? (
             <motion.div
-              key="all-chambers"
+              key="my-chambers"
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: 20 }}
               transition={{ duration: 0.2 }}
             >
-              {isLoading ? (
+              {!isConnected ? (
+                <EmptyChambers disconnected />
+              ) : isLoading ? (
                 <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 340px), 1fr))' }}>
                   {[1, 2, 3].map((i) => (
                     <div key={i} className="card animate-pulse">
@@ -308,16 +274,32 @@ export default function Dashboard() {
                     </div>
                   ))}
                 </div>
-              ) : validChambers.length > 0 ? (
+              ) : myChambers.length > 0 ? (
                 <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 340px), 1fr))' }}>
-                  {validChambers.map((address, index) => (
+                  {myChambers.map((entry, index) => (
                     <motion.div
-                      key={address}
+                      key={entry.address}
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: index * 0.05 }}
+                      className="relative"
                     >
-                      <ChamberCard address={address as `0x${string}`} />
+                      {entry.isDirector && (
+                        <div className="absolute -top-2 -left-2 z-10">
+                          <span className="badge bg-accent-600/80 text-white border-accent-500/40 text-[10px]">
+                            <FiShield className="w-3 h-3 mr-1" />
+                            Director
+                          </span>
+                        </div>
+                      )}
+                      {entry.balance > 0n && !entry.isDirector && (
+                        <div className="absolute -top-2 -left-2 z-10">
+                          <span className="badge bg-slate-700 text-slate-300 border-slate-600 text-[10px]">
+                            {parseFloat(formatUnits(entry.balance, 18)).toFixed(2)} shares
+                          </span>
+                        </div>
+                      )}
+                      <ChamberCard address={entry.address} />
                     </motion.div>
                   ))}
                 </div>
@@ -334,13 +316,15 @@ export default function Dashboard() {
               transition={{ duration: 0.2 }}
               className="space-y-8"
             >
-              {orgsLoading ? (
+              {!isConnected ? (
+                <EmptyChambers disconnected />
+              ) : orgsLoading ? (
                 <div className="space-y-8">
-                  {[1, 2].map(i => (
+                  {[1, 2].map((i) => (
                     <div key={i} className="space-y-4">
                       <div className="h-8 bg-slate-800 rounded-lg w-1/4 animate-pulse" />
                       <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 340px), 1fr))' }}>
-                        {[1, 2].map(j => (
+                        {[1, 2].map((j) => (
                           <div key={j} className="card h-40 animate-pulse" />
                         ))}
                       </div>
@@ -407,7 +391,7 @@ function OrganizationGroup({ nftToken, chambers, index }: { nftToken: `0x${strin
   )
 }
 
-function EmptyChambers() {
+function EmptyChambers({ disconnected = false }: { disconnected?: boolean }) {
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -417,13 +401,17 @@ function EmptyChambers() {
       <div className="w-16 h-16 bg-slate-800/80 rounded-2xl flex items-center justify-center mx-auto mb-5">
         <FiLayers className="w-8 h-8 text-slate-600" />
       </div>
-      <h3 className="font-heading text-xl font-semibold text-slate-300 mb-2">No Chambers Yet</h3>
+      <h3 className="font-heading text-xl font-semibold text-slate-300 mb-2">
+        {disconnected ? 'Connect to see your chambers' : 'No chambers yet'}
+      </h3>
       <p className="text-slate-500 max-w-md mx-auto mb-6">
-        No Chambers have been deployed yet. Deploy the first one to get started.
+        {disconnected
+          ? 'Connect a wallet to list chambers you created, direct, or hold. You can also open one by address.'
+          : 'Deploy a chamber, or paste an address above if it is not in this wallet’s recents yet.'}
       </p>
       <Link to="/deploy" className="btn btn-primary inline-flex">
         <FiPlus className="w-4 h-4" />
-        Deploy Your First Chamber
+        Deploy a Chamber
       </Link>
     </motion.div>
   )

--- a/app/src/pages/DeployChamber.tsx
+++ b/app/src/pages/DeployChamber.tsx
@@ -2,12 +2,13 @@ import { useState, useEffect } from 'react'
 import { useSearchParams, Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAccount, useReadContract } from 'wagmi'
-import { isAddress, zeroAddress } from 'viem'
+import { isAddress, parseEventLogs, zeroAddress } from 'viem'
 import { useQueryClient } from '@tanstack/react-query'
 import { FiAlertCircle, FiCheck, FiLoader, FiArrowRight, FiArrowLeft, FiCopy } from 'react-icons/fi'
-import { useCreateChamberWithStatus } from '@/hooks'
-import { useRegistryAddress } from '@/hooks/useRegistry'
+import { useCreateChamberTarget, useCreateChamberWithStatus } from '@/hooks'
 import { getContractAddresses } from '@/lib/wagmi'
+import { addRecentChamber } from '@/lib/recentChambers'
+import { factoryAbi, registryAbi } from '@/contracts/abis'
 import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { erc20Abi, erc721Abi } from '@/contracts'
 import toast from 'react-hot-toast'
@@ -24,11 +25,12 @@ function isValidAddress(s: string): boolean {
 
 export default function DeployChamber() {
   const { isConnected, chainId } = useAccount()
-  const registryAddress = useRegistryAddress()
+  const { address: createAddress, abi: createAbi, source: createSource } = useCreateChamberTarget()
   const queryClient = useQueryClient()
 
   const [step, setStep] = useState<Step>('form')
   const [deployedTxHash, setDeployedTxHash] = useState<string | undefined>()
+  const [deployedChamber, setDeployedChamber] = useState<`0x${string}` | undefined>()
   const [formData, setFormData] = useState({
     erc20Token: '',
     erc721Token: '',
@@ -45,30 +47,32 @@ export default function DeployChamber() {
     error,
     hash,
     reset,
-  } = useCreateChamberWithStatus(registryAddress, {
-    onSuccess: () => {
-      const registryAddrLower = registryAddress?.toLowerCase()
-      if (registryAddrLower) {
-        queryClient.invalidateQueries({
-          predicate: (query) => {
-            try {
-              return JSON.stringify(query.queryKey).toLowerCase().includes(registryAddrLower)
-            } catch { return false }
-          },
+  } = useCreateChamberWithStatus(createAddress, {
+    abi: createAbi,
+    onSuccess: (receipt) => {
+      const createAddrLower = createAddress?.toLowerCase()
+      queryClient.invalidateQueries({
+        predicate: (query) => {
+          try {
+            const str = JSON.stringify(query.queryKey).toLowerCase()
+            return str.includes('my-chambers') ||
+              (createAddrLower ? str.includes(createAddrLower) : false)
+          } catch { return false }
+        },
+      })
+      try {
+        const parsed = parseEventLogs({
+          abi: createSource === 'factory' ? factoryAbi : registryAbi,
+          logs: receipt?.logs ?? [],
+          eventName: 'ChamberCreated',
         })
-        setTimeout(() => {
-          queryClient.refetchQueries({
-            predicate: (query) => {
-              try {
-                const str = JSON.stringify(query.queryKey).toLowerCase()
-                return str.includes(registryAddrLower) &&
-                  (str.includes('getallchambers') ||
-                    str.includes('getchambercount') ||
-                    str.includes('registry-chambers'))
-              } catch { return false }
-            },
-          })
-        }, 500)
+        const chamber = parsed[0]?.args?.chamber as `0x${string}` | undefined
+        if (chamber && typeof chainId === 'number') {
+          addRecentChamber(chainId, chamber)
+          setDeployedChamber(chamber)
+        }
+      } catch {
+        // receipt may omit decoded logs; dashboard getLogs / recents still pick it up
       }
       setDeployedTxHash(hash)
       setStep('success')
@@ -215,8 +219,8 @@ export default function DeployChamber() {
             </div>
           )}
           <div className="flex gap-3 justify-center">
-            <Link to="/" className="btn btn-primary">
-              Go to Dashboard
+            <Link to={deployedChamber ? `/chamber/${deployedChamber}` : '/'} className="btn btn-primary">
+              {deployedChamber ? 'Open Chamber' : 'Go to Dashboard'}
               <FiArrowRight className="w-4 h-4" />
             </Link>
             <button

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -218,7 +218,7 @@ export default function TransactionQueue() {
     return (
       <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
         <FiLoader className="w-10 h-10 text-accent-400 animate-spin" />
-        <p className="text-slate-400 text-sm">Verifying chamber registration…</p>
+        <p className="text-slate-400 text-sm">Verifying chamber…</p>
       </div>
     )
   }
@@ -228,7 +228,7 @@ export default function TransactionQueue() {
       <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
         <FiAlertCircle className="w-12 h-12 text-red-400" />
         <h2 className="font-heading text-xl font-bold text-slate-100">Not a Chamber</h2>
-        <p className="text-slate-400">This address is not registered in the Registry.</p>
+        <p className="text-slate-400">This address does not look like a Chamber contract.</p>
         <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
       </div>
     )

--- a/contracts/deployments.d.ts
+++ b/contracts/deployments.d.ts
@@ -2,6 +2,7 @@
 // This file is auto-generated - do not edit manually
 declare const deployments: {
   registry: `0x${string}`
+  factory?: `0x${string}`
   chamberImplementation: `0x${string}`
   mockERC20: `0x${string}`
   mockERC721: `0x${string}`

--- a/contracts/generated-abis.ts
+++ b/contracts/generated-abis.ts
@@ -723,6 +723,242 @@ export const registryAbi = [
   }
 ] as const
 
+export const factoryAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "admin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createChamber",
+    "inputs": [
+      {
+        "name": "erc20Token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "erc721Token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "seats",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "symbol",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "chamber",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setImplementation",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "ChamberCreated",
+    "inputs": [
+      {
+        "name": "chamber",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "asset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "nft",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "seats",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "symbol",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "creator",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ChamberImplementationUpdated",
+    "inputs": [
+      {
+        "name": "previousImplementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "InvalidSeats",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  }
+] as const
+
 export const chamberAbi = [
   {
     "type": "constructor",
@@ -736,6 +972,19 @@ export const chamberAbi = [
   {
     "type": "receive",
     "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "DEFAULT_TRANSACTION_MAX_AGE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -836,6 +1085,19 @@ export const chamberAbi = [
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "cancelSeatUpdate",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -1465,6 +1727,25 @@ export const chamberAbi = [
   },
   {
     "type": "function",
+    "name": "getTransactionDeadline",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getTransactionMetadata",
     "inputs": [
       {
@@ -1478,6 +1759,25 @@ export const chamberAbi = [
         "name": "",
         "type": "string",
         "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTransactionRequiredQuorum",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -1517,10 +1817,29 @@ export const chamberAbi = [
   },
   {
     "type": "function",
+    "name": "isTransactionExpired",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "maxDeposit",
     "inputs": [
       {
-        "name": "",
+        "name": "receiver",
         "type": "address",
         "internalType": "address"
       }
@@ -1539,7 +1858,7 @@ export const chamberAbi = [
     "name": "maxMint",
     "inputs": [
       {
-        "name": "",
+        "name": "receiver",
         "type": "address",
         "internalType": "address"
       }
@@ -1674,6 +1993,26 @@ export const chamberAbi = [
       }
     ],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -1856,6 +2195,39 @@ export const chamberAbi = [
   },
   {
     "type": "function",
+    "name": "submitTransaction",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "submitTransactionWithMetadata",
     "inputs": [
       {
@@ -1882,6 +2254,44 @@ export const chamberAbi = [
         "name": "metadataURI",
         "type": "string",
         "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submitTransactionWithMetadata",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "metadataURI",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],
@@ -1994,6 +2404,13 @@ export const chamberAbi = [
         "internalType": "uint256"
       }
     ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
@@ -2259,6 +2676,19 @@ export const chamberAbi = [
   },
   {
     "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ProposalMetadataSet",
     "inputs": [
       {
@@ -2461,6 +2891,25 @@ export const chamberAbi = [
   },
   {
     "type": "event",
+    "name": "TransactionDeadlineSet",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "TransactionExecuted",
     "inputs": [
       {
@@ -2549,6 +2998,19 @@ export const chamberAbi = [
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       }
     ],
     "anonymous": false
@@ -2797,7 +3259,17 @@ export const chamberAbi = [
   },
   {
     "type": "error",
+    "name": "EnforcedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "ExceedsDelegatedAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ExpectedPause",
     "inputs": []
   },
   {
@@ -2813,6 +3285,11 @@ export const chamberAbi = [
   {
     "type": "error",
     "name": "InsufficientVotes",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidDeadline",
     "inputs": []
   },
   {
@@ -2934,6 +3411,11 @@ export const chamberAbi = [
   {
     "type": "error",
     "name": "TransactionDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransactionExpired",
     "inputs": []
   },
   {

--- a/contracts/script/DeployAllAnvil.s.sol
+++ b/contracts/script/DeployAllAnvil.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Script, console} from "forge-std/Script.sol";
 import {Registry} from "src/Registry.sol";
+import {Factory} from "src/Factory.sol";
 import {DeployRegistry as DeployRegistryLib} from "test/utils/DeployRegistry.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
 import {MockERC721} from "test/mock/MockERC721.sol";
@@ -28,9 +29,13 @@ contract DeployAllAnvil is Script {
 
         vm.startBroadcast();
 
-        // Deploy Registry
+        // Deploy Registry (deprecated index + legacy create path)
         Registry registry = DeployRegistryLib.deploy(admin);
         console.log("Registry deployed at:", address(registry));
+
+        // Deploy Factory (preferred create path; shares the Registry Chamber implementation)
+        Factory factory = new Factory(registry.implementation(), admin);
+        console.log("Factory deployed at:", address(factory));
 
         // Deploy MockERC20
         MockERC20 mockERC20 = new MockERC20(tokenName, tokenSymbol, initialSupply);
@@ -49,6 +54,7 @@ contract DeployAllAnvil is Script {
 
         // Write deployment addresses to JSON file for the app to consume
         string memory json = vm.serializeAddress("deployment", "registry", address(registry));
+        json = vm.serializeAddress("deployment", "factory", address(factory));
         json = vm.serializeAddress("deployment", "chamberImplementation", registry.implementation());
         json = vm.serializeAddress("deployment", "mockERC20", address(mockERC20));
         json = vm.serializeAddress("deployment", "mockERC721", address(mockERC721));

--- a/contracts/script/DeployFactory.s.sol
+++ b/contracts/script/DeployFactory.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Factory} from "src/Factory.sol";
+import {Chamber} from "src/Chamber.sol";
+
+/// @notice Deploys a non-proxy Factory next to (not instead of) an existing Chamber implementation.
+contract DeployFactory is Script {
+    function run() external {
+        address admin;
+
+        try vm.envAddress("ADMIN") returns (address envAdmin) {
+            admin = envAdmin;
+        } catch {
+            admin = msg.sender;
+        }
+
+        vm.startBroadcast();
+
+        address chamberImplementation;
+        try vm.envAddress("CHAMBER_IMPLEMENTATION") returns (address envImpl) {
+            chamberImplementation = envImpl;
+        } catch {
+            chamberImplementation = address(new Chamber());
+        }
+
+        Factory factory = new Factory(chamberImplementation, admin);
+
+        vm.stopBroadcast();
+
+        console.log("========================================");
+        console.log("DeployFactory");
+        console.log("========================================");
+        console.log("ADMIN                  ", admin);
+        console.log("Factory                ", address(factory));
+        console.log("Chamber implementation ", factory.implementation());
+        console.log("========================================");
+    }
+}

--- a/contracts/script/Factory.s.sol
+++ b/contracts/script/Factory.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Factory} from "src/Factory.sol";
+import {Chamber} from "src/Chamber.sol";
+
+contract DeployFactory is Script {
+    function run() external {
+        address admin;
+
+        try vm.envAddress("ADMIN") returns (address envAdmin) {
+            admin = envAdmin;
+        } catch {
+            admin = msg.sender;
+        }
+
+        vm.startBroadcast();
+
+        address impl;
+        try vm.envAddress("CHAMBER_IMPLEMENTATION") returns (address envImpl) {
+            impl = envImpl;
+        } catch {
+            impl = address(new Chamber());
+        }
+
+        Factory factory = new Factory(impl, admin);
+
+        vm.stopBroadcast();
+
+        console.log("Factory deployed at:", address(factory));
+        console.log("Chamber implementation:", factory.implementation());
+        console.log("Owner:", factory.owner());
+    }
+}

--- a/contracts/script/sync-abis.js
+++ b/contracts/script/sync-abis.js
@@ -21,6 +21,7 @@ const forgeOutRoot = join(repoRoot, 'contracts', 'out');
 // Contracts to sync ABIs for
 const contracts = [
   { name: 'Registry', path: 'src/Registry.sol' },
+  { name: 'Factory', path: 'src/Factory.sol' },
   { name: 'Chamber', path: 'src/Chamber.sol' },
   { name: 'MockERC20', path: 'test/mock/MockERC20.sol' },
   { name: 'MockERC721', path: 'test/mock/MockERC721.sol' },

--- a/contracts/src/Factory.sol
+++ b/contracts/src/Factory.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import {
+    TransparentUpgradeableProxy
+} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {IChamber} from "./interfaces/IChamber.sol";
+import {IFactory} from "./interfaces/IFactory.sol";
+
+/**
+ * @title Factory
+ * @author xhad, Loreum DAO LLC
+ * @notice Thin, non-proxy deployer for Chamber `TransparentUpgradeableProxy` instances.
+ * @dev Mirrors {Registry}`createChamber` proxy construction (current impl, initialize,
+ *      transfer `ProxyAdmin` to the chamber) but does **not** store an enumerable world
+ *      list, asset index, or parent/child tables. Discover chambers via `ChamberCreated`
+ *      logs (indexer or `getLogs`).
+ *
+ *      `setImplementation` is owner-gated and applies to future deploys only. Existing
+ *      chambers upgrade through their own `ProxyAdmin`. Ownable (not
+ *      `AccessControlDefaultAdminRules`) is enough for this non-upgradeable factory.
+ */
+contract Factory is Ownable, IFactory {
+    /// @notice Chamber implementation used for the next `createChamber`
+    address private _implementation;
+
+    /// @notice Thrown when address is zero
+    error ZeroAddress();
+
+    /// @notice Thrown when seats value is invalid (0 or > 20)
+    error InvalidSeats();
+
+    /**
+     * @param implementation_ Chamber implementation for new proxies (non-zero)
+     * @param admin Owner that may call `setImplementation` (non-zero; Ownable reverts otherwise)
+     */
+    constructor(address implementation_, address admin) Ownable(admin) {
+        if (implementation_ == address(0)) revert ZeroAddress();
+        _implementation = implementation_;
+    }
+
+    /// @inheritdoc IFactory
+    function implementation() external view returns (address) {
+        return _implementation;
+    }
+
+    /**
+     * @inheritdoc IFactory
+     * @dev Same-address updates are a no-op (no event), matching {Registry}`setChamberImplementation`.
+     */
+    function setImplementation(address newImplementation) external onlyOwner {
+        if (newImplementation == address(0)) revert ZeroAddress();
+        address previous = _implementation;
+        if (previous == newImplementation) {
+            return;
+        }
+        _implementation = newImplementation;
+        emit ChamberImplementationUpdated(previous, newImplementation);
+    }
+
+    /**
+     * @inheritdoc IFactory
+     * @dev `erc20Token` must be a standard ERC-20. There is no factory allowlist; Chamber
+     *      deposit/mint revert with `AssetAmountMismatch` if the vault receives less (or more)
+     *      than the requested amount (fee-on-transfer). Rebasing/elastic tokens are unsupported
+     *      and are not fully detectable at deposit time.
+     */
+    function createChamber(
+        address erc20Token,
+        address erc721Token,
+        uint256 seats,
+        string memory name,
+        string memory symbol
+    ) external returns (address payable chamber) {
+        if (erc20Token == address(0) || erc721Token == address(0)) revert ZeroAddress();
+        if (seats == 0 || seats > 20) revert InvalidSeats();
+        if (_implementation == address(0)) revert ZeroAddress();
+
+        bytes memory initData =
+            abi.encodeWithSelector(IChamber.initialize.selector, erc20Token, erc721Token, seats, name, symbol);
+
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(_implementation, address(this), initData);
+
+        chamber = payable(address(proxy));
+
+        _transferChamberAdmin(chamber);
+
+        emit ChamberCreated(chamber, erc20Token, erc721Token, seats, name, symbol, msg.sender);
+    }
+
+    /**
+     * @notice Transfers ProxyAdmin ownership to the chamber itself
+     * @param chamber The chamber proxy address
+     */
+    function _transferChamberAdmin(address chamber) internal {
+        address proxyAdminAddress = IChamber(chamber).getProxyAdmin();
+        if (proxyAdminAddress == address(0)) revert ZeroAddress();
+
+        ProxyAdmin proxyAdminInstance = ProxyAdmin(proxyAdminAddress);
+        proxyAdminInstance.transferOwnership(chamber);
+    }
+}

--- a/contracts/src/Registry.sol
+++ b/contracts/src/Registry.sol
@@ -14,8 +14,14 @@ import {IRegistry} from "./interfaces/IRegistry.sol";
 /**
  * @title Registry
  * @author xhad, Loreum DAO LLC
- * @notice Central registry for deploying and managing Chamber instances
- * @dev Uses OpenZeppelin `TransparentUpgradeableProxy`; registry is proxy admin until
+ * @notice DEPRECATED as a world directory and create path. Historical index of chambers
+ *         deployed through this contract, plus the original `createChamber` entrypoint.
+ * @dev Prefer {Factory} for new deploys. Existing chambers stay valid. This contract is
+ *      not migrated and must not be in-place-upgraded as part of the Factory cut.
+ *      Enumerable getters (`getAllChambers`, `getChambersByAsset`, parent/child tables)
+ *      remain for already-indexed addresses only.
+ *
+ *      Uses OpenZeppelin `TransparentUpgradeableProxy`; registry is proxy admin until
  *      `ProxyAdmin` ownership is transferred to each chamber.
  *
  *      Roles use OpenZeppelin 5.1.0 `AccessControlUpgradeable` (ERC-7201 namespace

--- a/contracts/src/interfaces/IFactory.sol
+++ b/contracts/src/interfaces/IFactory.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/**
+ * @title IFactory
+ * @author xhad, Loreum DAO LLC
+ * @notice Permissionless Chamber deploy path. Emits `ChamberCreated` for indexers / `getLogs`.
+ * @dev Does not store an enumerable world directory. Parent/child tables stay on the
+ *      deprecated {IRegistry} index for already-registered chambers.
+ */
+interface IFactory {
+    /**
+     * @notice Emitted when a new chamber proxy is deployed
+     * @param chamber The new chamber proxy
+     * @param asset Underlying ERC-20 (vault asset)
+     * @param nft Membership ERC-721
+     * @param seats Initial board seat count
+     * @param name Share token name passed to `Chamber.initialize`
+     * @param symbol Share token symbol passed to `Chamber.initialize`
+     * @param creator `msg.sender` that called `createChamber`
+     */
+    event ChamberCreated(
+        address indexed chamber,
+        address indexed asset,
+        address indexed nft,
+        uint256 seats,
+        string name,
+        string symbol,
+        address creator
+    );
+
+    /// @notice Emitted when the owner updates the Chamber implementation pointer used for future deploys
+    event ChamberImplementationUpdated(address indexed previousImplementation, address indexed newImplementation);
+
+    /**
+     * @notice Deploys a Chamber `TransparentUpgradeableProxy` and transfers its `ProxyAdmin` to the chamber.
+     * @param erc20Token Standard ERC-20 vault asset
+     * @param erc721Token Membership ERC-721
+     * @param seats Initial board seats (1–20)
+     * @param name Share token name
+     * @param symbol Share token symbol
+     * @return chamber The new chamber proxy
+     */
+    function createChamber(
+        address erc20Token,
+        address erc721Token,
+        uint256 seats,
+        string memory name,
+        string memory symbol
+    ) external returns (address payable chamber);
+
+    /**
+     * @notice Updates the Chamber implementation used for *future* `createChamber` calls only.
+     * @dev Does not upgrade existing chamber proxies.
+     * @param newImplementation The new Chamber implementation contract (non-zero)
+     */
+    function setImplementation(address newImplementation) external;
+
+    /// @notice Chamber implementation used for the next `createChamber`
+    function implementation() external view returns (address);
+}

--- a/contracts/src/interfaces/IRegistry.sol
+++ b/contracts/src/interfaces/IRegistry.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.30;
 /**
  * @title IRegistry
  * @author xhad, Loreum DAO LLC
- * @notice Minimal read API for chamber hierarchy links (parent / child chambers).
- * @dev `Registry` implements this interface plus deployment and indexing functions.
- *      Parent/child relationships are set in `createChamber` when `erc20Token` is itself a
- *      registered chamber, modelling sub-chambers that use another chamber's token as asset.
+ * @notice DEPRECATED index: minimal read API for chamber hierarchy links (parent / child).
+ * @dev Prefer {IFactory} for new deploys. `Registry` still implements this interface plus
+ *      the original deployment and indexing functions. Parent/child relationships are set
+ *      in `Registry.createChamber` when `erc20Token` is itself a registered chamber.
+ *      The Factory does not write this graph; existing links stay on this index only.
  */
 interface IRegistry {
     /**

--- a/contracts/test/unit/Factory.t.sol
+++ b/contracts/test/unit/Factory.t.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Factory} from "src/Factory.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+
+/// @dev Mock chamber that returns address(0) for getProxyAdmin() to trigger defensive check
+contract ZeroProxyAdminChamber {
+    function initialize(address, address, uint256, string calldata, string calldata) external {}
+
+    function getProxyAdmin() external pure returns (address) {
+        return address(0);
+    }
+}
+
+contract FactoryTest is Test {
+    event ChamberCreated(
+        address indexed chamber,
+        address indexed asset,
+        address indexed nft,
+        uint256 seats,
+        string name,
+        string symbol,
+        address creator
+    );
+
+    event ChamberImplementationUpdated(address indexed previousImplementation, address indexed newImplementation);
+
+    Factory public factory;
+    Chamber public implementation;
+    MockERC20 public token;
+    MockERC721 public nft;
+    address public admin = makeAddr("admin");
+
+    /// @dev ERC-1967 implementation slot (OpenZeppelin `ERC1967Utils.IMPLEMENTATION_SLOT`)
+    bytes32 internal constant _ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    function setUp() public {
+        token = new MockERC20("Test Token", "TEST", 1000000e18);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        implementation = new Chamber();
+        factory = new Factory(address(implementation), admin);
+    }
+
+    function _proxyImplementation(address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, _ERC1967_IMPL_SLOT))));
+    }
+
+    function test_Factory_Constructor_SetsImplementationAndOwner() public view {
+        assertEq(factory.implementation(), address(implementation));
+        assertEq(factory.owner(), admin);
+    }
+
+    function test_Factory_Constructor_ZeroImplementation_Reverts() public {
+        vm.expectRevert(Factory.ZeroAddress.selector);
+        new Factory(address(0), admin);
+    }
+
+    function test_Factory_Constructor_ZeroAdmin_Reverts() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
+        new Factory(address(implementation), address(0));
+    }
+
+    function test_Factory_CreateChamber() public {
+        address chamber = factory.createChamber(address(token), address(nft), 5, "Chamber Token", "CHMB");
+
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(chamber)
+        }
+        assertGt(codeSize, 0);
+
+        IChamber chamberContract = IChamber(chamber);
+        assertEq(chamberContract.name(), "Chamber Token");
+        assertEq(chamberContract.symbol(), "CHMB");
+        assertEq(chamberContract.getSeats(), 5);
+        assertEq(chamberContract.asset(), address(token));
+        assertEq(address(Chamber(payable(chamber)).nft()), address(nft));
+    }
+
+    function test_Factory_CreateChamber_EmitsChamberCreated() public {
+        uint64 nonce = vm.getNonce(address(factory));
+        address predicted = vm.computeCreateAddress(address(factory), nonce);
+
+        vm.expectEmit(true, true, true, true, address(factory));
+        emit ChamberCreated(predicted, address(token), address(nft), 5, "Chamber Token", "CHMB", address(this));
+
+        address chamber = factory.createChamber(address(token), address(nft), 5, "Chamber Token", "CHMB");
+        assertEq(chamber, predicted);
+    }
+
+    function test_Factory_CreateChamber_ProxyAdminOwnership() public {
+        address chamber = factory.createChamber(address(token), address(nft), 5, "Chamber Token", "CHMB");
+
+        address proxyAdminAddress = IChamber(chamber).getProxyAdmin();
+        assertNotEq(proxyAdminAddress, address(0));
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(proxyAdminAddress);
+        assertEq(proxyAdmin.owner(), chamber);
+    }
+
+    function test_Factory_CreateChamber_UsesCurrentImplementation() public {
+        address chamber = factory.createChamber(address(token), address(nft), 5, "Chamber Token", "CHMB");
+        assertEq(_proxyImplementation(chamber), address(implementation));
+    }
+
+    function test_Factory_CreateChamber_ZeroERC20_Reverts() public {
+        vm.expectRevert(Factory.ZeroAddress.selector);
+        factory.createChamber(address(0), address(nft), 5, "Chamber Token", "CHMB");
+    }
+
+    function test_Factory_CreateChamber_ZeroERC721_Reverts() public {
+        vm.expectRevert(Factory.ZeroAddress.selector);
+        factory.createChamber(address(token), address(0), 5, "Chamber Token", "CHMB");
+    }
+
+    function test_Factory_CreateChamber_ZeroSeats_Reverts() public {
+        vm.expectRevert(Factory.InvalidSeats.selector);
+        factory.createChamber(address(token), address(nft), 0, "Chamber Token", "CHMB");
+    }
+
+    function test_Factory_CreateChamber_TooManySeats_Reverts() public {
+        vm.expectRevert(Factory.InvalidSeats.selector);
+        factory.createChamber(address(token), address(nft), 21, "Chamber Token", "CHMB");
+    }
+
+    function test_Factory_CreateChamber_ZeroProxyAdmin_Reverts() public {
+        ZeroProxyAdminChamber badImpl = new ZeroProxyAdminChamber();
+        Factory badFactory = new Factory(address(badImpl), admin);
+
+        vm.expectRevert(Factory.ZeroAddress.selector);
+        badFactory.createChamber(address(token), address(nft), 5, "C", "C");
+    }
+
+    function test_Factory_SetImplementation_UpdatesPointer() public {
+        Chamber newImpl = new Chamber();
+        address prev = factory.implementation();
+
+        vm.expectEmit(true, true, false, false, address(factory));
+        emit ChamberImplementationUpdated(prev, address(newImpl));
+
+        vm.prank(admin);
+        factory.setImplementation(address(newImpl));
+
+        assertEq(factory.implementation(), address(newImpl));
+    }
+
+    function test_Factory_SetImplementation_FutureDeploysOnly() public {
+        address chamberBefore = factory.createChamber(address(token), address(nft), 5, "Before", "BEF");
+        address implBefore = _proxyImplementation(chamberBefore);
+
+        Chamber newImpl = new Chamber();
+        vm.prank(admin);
+        factory.setImplementation(address(newImpl));
+
+        address chamberAfter = factory.createChamber(address(token), address(nft), 3, "After", "AFT");
+
+        assertEq(_proxyImplementation(chamberBefore), implBefore);
+        assertEq(_proxyImplementation(chamberAfter), address(newImpl));
+        assertEq(IChamber(chamberBefore).getSeats(), 5);
+        assertEq(IChamber(chamberAfter).getSeats(), 3);
+    }
+
+    function test_Factory_SetImplementation_SameImplementation_NoEmit() public {
+        address curr = factory.implementation();
+        vm.recordLogs();
+
+        vm.prank(admin);
+        factory.setImplementation(curr);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0);
+    }
+
+    function test_Factory_SetImplementation_Zero_Reverts() public {
+        vm.prank(admin);
+        vm.expectRevert(Factory.ZeroAddress.selector);
+        factory.setImplementation(address(0));
+    }
+
+    function test_Factory_SetImplementation_NotOwner_Reverts() public {
+        Chamber newImpl = new Chamber();
+        address stranger = makeAddr("stranger");
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        factory.setImplementation(address(newImpl));
+    }
+
+    function test_Factory_CreateChamber_AnyoneCanDeploy() public {
+        address user = makeAddr("user");
+        vm.prank(user);
+        address chamber = factory.createChamber(address(token), address(nft), 5, "User Chamber", "USR");
+        assertEq(IChamber(chamber).name(), "User Chamber");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chamber does not need an on-chain world directory. This cut adds a thin Factory for deploys, leaves Registry as a deprecated index (not deleted, not migrated), and flips the app dashboard to **My chambers** first.

## Why

The dashboard was a phone book: it paged `Registry.getChambers` / `getChamberCount`, showed a global “active” count, then multicalled every chamber to derive “mine.” Organizations grouped the world list by `nft()`. That index is not the product. Users need **their** chambers (created, directed, or held), plus a way to open a known address.

## What Factory does

`Factory` is a **non-proxy** `Ownable` contract (v1 does not need a proxy factory; deploy scripts already treat Registry as the upgradeable piece).

- Deploys a Chamber `TransparentUpgradeableProxy` the same way Registry does today: current implementation, `initialize`, transfer `ProxyAdmin` ownership to the chamber.
- `setImplementation` is owner-gated and applies to **future** deploys only.
- Emits `ChamberCreated(chamber, asset, nft, seats, name, symbol, creator)` so an indexer or `getLogs` can find chambers.
- Does **not** store `getAllChambers` / `getChambersByAsset` / parent-child tables.

## What Registry still is

`Registry.sol` stays. NatSpec marks it deprecated as an index + old create path. Existing chambers remain valid. Live Registry storage is not migrated. Registry is not in-place-upgraded in this PR. Parent/child reads stay on Registry if they already work; no new graph UI.

## How the dashboard finds mine

1. `getLogs` of Factory `ChamberCreated` (and leftover Registry `ChamberCreated` for old deploys).
2. Keep addresses where the user is the creator, a director, or `balanceOf > 0` (plus explicit recents).
3. Recents in `localStorage` + an **Open address** field for cold start / unindexed chambers.
4. Organizations groups **the user’s** chambers by `nft()`, not `getChambersByAsset` over the world.
5. Hero metric is count of **mine**, not global active.

No Ponder/subgraph in this PR.

`useCreateChamber` / Deploy submit to Factory when `VITE_*_FACTORY` is set; Registry `createChamber` remains the fallback if factory is unset. Config is valid if factory **or** registry is set.

`useIsChamber` / detail gate probes the address (`VERSION` / `nft` / `getSeats`). Registry `isChamber` is a soft hint only.

## Outcomes → files

| Outcome | Files |
| --- | --- |
| Thin Factory + `IFactory` | `contracts/src/Factory.sol`, `contracts/src/interfaces/IFactory.sol` |
| Registry deprecated, not deleted | `contracts/src/Registry.sol`, `contracts/src/interfaces/IRegistry.sol` |
| Foundry tests: create, impl update, event, ProxyAdmin owner | `contracts/test/unit/Factory.t.sol` |
| Deploy / address types (factory next to registry) | `contracts/script/DeployAllAnvil.s.sol`, `contracts/script/Factory.s.sol`, `contracts/script/DeployFactory.s.sol`, `contracts/deployments.d.ts`, `app/contracts/deployments.d.ts`, `app/src/lib/wagmi.ts` |
| Factory ABI | `app/contracts/abis.ts`, `contracts/generated-abis.ts`, `contracts/script/sync-abis.js` |
| Create via Factory (Registry fallback) | `app/src/hooks/useRegistry.ts`, `app/src/hooks/useTransactionStatus.ts`, `app/src/hooks/useMyChambers.ts`, `app/src/pages/DeployChamber.tsx` |
| My chambers dashboard (logs + recents + open-by-address) | `app/src/pages/Dashboard.tsx`, `app/src/hooks/useMyChambers.ts`, `app/src/lib/recentChambers.ts` |
| Probe-based chamber gate | `app/src/hooks/useRegistry.ts` (`useIsChamber`), `app/src/pages/ChamberDetail.tsx`, `app/src/pages/TransactionQueue.tsx` |

Out of scope: deleting/migrating Registry, beacon proxies, loreum-subgraph / chamber-indexer, ERC-1271 / Safe module UI, Chamber board/wallet/vault logic.

## Test plan

- [x] `forge test --match-contract FactoryTest` — 18 passed (create, impl update for future deploys only, `ChamberCreated`, ProxyAdmin ownership)
- [x] Existing `RegistryTest` — 40 passed
- [x] `cd app && npx tsc --noEmit` — pass
- [ ] Create via Factory → new chamber appears under **Mine** (creator even with empty board) — needs a live wallet + deployed Factory
- [ ] Open-by-address opens `/chamber/:address` and lands in recents — UI path is in `Dashboard.tsx` / `ChamberDetail.tsx`; not exercised in a browser here
- [ ] Registry-only env (factory unset) still deploys via Registry `createChamber` — fallback is wired in `useCreateChamberTarget`
- [ ] Config warning accepts factory *or* registry; factory-only env does not spin forever on `useIsChamber`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-816982e4-fa56-420e-a0f5-c55078047571?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-816982e4-fa56-420e-a0f5-c55078047571&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

