### PR TITLE
Verify Sepolia Factory, Chamber impl, BoardLib, and WalletLib on Etherscan

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -232,6 +232,13 @@ verify :; forge verify-contract \
 	${address} \
 	src/${contract}.sol:${contract}
 
+# Sepolia Factory path (26 Aug 2026): BoardLib, WalletLib, Chamber impl, Factory.
+# Addresses + verify URLs: deployments/sepolia.txt
+# Requires ETHERSCAN_API_KEY (foundry.toml [etherscan].sepolia) and SEPOLIA_RPC_URL.
+# Usage: make verify-sepolia-factory
+# Print only: PRINT_ONLY=1 make verify-sepolia-factory
+verify-sepolia-factory :; bash script/etherscan-verify-sepolia-factory.sh
+
 
 call :; cast call ${address} ${method} ${args} \
 	--chain-id ${chain} \

--- a/contracts/deployments/sepolia.txt
+++ b/contracts/deployments/sepolia.txt
@@ -21,3 +21,14 @@
   BoardLib                  0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D
   WalletLib                 0x0320284b176657bb5048CF586DEef530F4B2499a
 
+  Etherscan verify
+  ====================================================================
+  Factory                   https://sepolia.etherscan.io/address/0x43aA92c8A26392f21F63cdA88B6BaB5031C40550#code
+  Chamber implementation    https://sepolia.etherscan.io/address/0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c#code
+  BoardLib                  https://sepolia.etherscan.io/address/0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D#code
+  WalletLib                 https://sepolia.etherscan.io/address/0x0320284b176657bb5048CF586DEef530F4B2499a#code
+
+  Re-run (from contracts/): make verify-sepolia-factory
+  Requires ETHERSCAN_API_KEY and SEPOLIA_RPC_URL (see foundry.toml).
+  Print commands only: PRINT_ONLY=1 make verify-sepolia-factory
+

--- a/contracts/script/etherscan-verify-cmd.sh
+++ b/contracts/script/etherscan-verify-cmd.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 # Print a forge verify-contract line that matches this repo's Foundry metadata (via_ir, solc commit, evm, runs).
-# Usage (from contracts/): bash script/etherscan-verify-cmd.sh Chamber 0xYourImpl... sepolia
+#
+# Usage (from contracts/):
+#   bash script/etherscan-verify-cmd.sh Chamber 0xYourImpl... sepolia
+#   bash script/etherscan-verify-cmd.sh Factory 0xYourFactory... sepolia
+#   bash script/etherscan-verify-cmd.sh BoardLib 0xYourLib... sepolia
+#   bash script/etherscan-verify-cmd.sh WalletLib 0xYourLib... sepolia
+#
+# Optional env (appended to the printed command):
+#   CONSTRUCTOR_ARGS  ABI-encoded constructor args (Factory)
+#   BOARD_LIB         linked BoardLib address (Chamber, Factory-path)
+#   WALLET_LIB        linked WalletLib address (Chamber, Factory-path)
+#
+# One-command Sepolia Factory path (26 Aug 2026 addresses in deployments/sepolia.txt):
+#   make verify-sepolia-factory
+#   # or: bash script/etherscan-verify-sepolia-factory.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -8,8 +22,8 @@ cd "$ROOT"
 
 forge build --quiet
 
-NAME="${1:?first arg: Chamber or Registry}"
-ADDR="${2:?second arg: implementation address}"
+NAME="${1:?first arg: Chamber, Registry, Factory, BoardLib, or WalletLib}"
+ADDR="${2:?second arg: deployed address}"
 CHAIN="${3:-sepolia}"
 
 # Forge verify-contract defaults --rpc-url to http://localhost:8545; without pointing at Sepolia/etc.,
@@ -32,8 +46,20 @@ Registry | registry)
 	SRC='src/Registry.sol:Registry'
 	JSON=out/Registry.sol/Registry.json
 	;;
+Factory | factory)
+	SRC='src/Factory.sol:Factory'
+	JSON=out/Factory.sol/Factory.json
+	;;
+BoardLib | boardlib)
+	SRC='src/libraries/BoardLib.sol:BoardLib'
+	JSON=out/BoardLib.sol/BoardLib.json
+	;;
+WalletLib | walletlib)
+	SRC='src/libraries/WalletLib.sol:WalletLib'
+	JSON=out/WalletLib.sol/WalletLib.json
+	;;
 *)
-	echo "First arg must be Chamber or Registry" >&2
+	echo "First arg must be Chamber, Registry, Factory, BoardLib, or WalletLib" >&2
 	exit 1
 	;;
 esac
@@ -44,10 +70,26 @@ if [[ ! -f "$JSON" ]]; then
 fi
 
 # --verifier etherscan: Forge default verifier is sourcify; etherscan expects exact bytecode match path we use below.
-jq -r --arg A "$ADDR" --arg C "$CHAIN" --arg S "$SRC" --arg R "$VERIFY_RPC_ALIAS" \
-	'"forge verify-contract " + $A + " " + $S + " --chain " + $C + " --rpc-url " + $R + " --verifier etherscan --compiler-version v" + .metadata.compiler.version + " --num-of-optimizations " + (.metadata.settings.optimizer.runs|tostring) + " --evm-version " + .metadata.settings.evmVersion + " --via-ir --watch"' \
-	"$JSON"
+cmd="$(
+	jq -r --arg A "$ADDR" --arg C "$CHAIN" --arg S "$SRC" --arg R "$VERIFY_RPC_ALIAS" \
+		'"forge verify-contract " + $A + " " + $S + " --chain " + $C + " --rpc-url " + $R + " --verifier etherscan --compiler-version v" + .metadata.compiler.version + " --num-of-optimizations " + (.metadata.settings.optimizer.runs|tostring) + " --evm-version " + .metadata.settings.evmVersion + " --via-ir --watch"' \
+		"$JSON"
+)"
+
+if [[ -n "${CONSTRUCTOR_ARGS:-}" ]]; then
+	cmd+=" --constructor-args ${CONSTRUCTOR_ARGS}"
+fi
+if [[ -n "${BOARD_LIB:-}" ]]; then
+	cmd+=" --libraries src/libraries/BoardLib.sol:BoardLib:${BOARD_LIB}"
+fi
+if [[ -n "${WALLET_LIB:-}" ]]; then
+	cmd+=" --libraries src/libraries/WalletLib.sol:WalletLib:${WALLET_LIB}"
+fi
+
+printf '%s\n' "$cmd"
 
 echo "" >&2
-echo "# Sanity: bash script/etherscan-diff-runtime-vs-artifact.sh \"$NAME\" \"$ADDR\" \"$CHAIN\"" >&2
+if [[ "$NAME" == "Chamber" || "$NAME" == "chamber" || "$NAME" == "Registry" || "$NAME" == "registry" ]]; then
+	echo "# Sanity: bash script/etherscan-diff-runtime-vs-artifact.sh \"$NAME\" \"$ADDR\" \"$CHAIN\"" >&2
+fi
 echo "# If verify still fails on *deployment* bytecode after runtime MATCH: forge verify-contract ... --show-standard-json-input → Etherscan Standard JSON (via IR)." >&2

--- a/contracts/script/etherscan-verify-sepolia-factory.sh
+++ b/contracts/script/etherscan-verify-sepolia-factory.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Verify the 26 Aug 2026 Sepolia Factory path on Etherscan:
+#   BoardLib, WalletLib, Chamber impl, Factory
+# Addresses must match contracts/deployments/sepolia.txt (Aug 26 section).
+#
+# One-command re-run (from contracts/):
+#   make verify-sepolia-factory
+#
+# Or:
+#   export ETHERSCAN_API_KEY=...
+#   export SEPOLIA_RPC_URL=...          # foundry.toml [rpc_endpoints].sepolia
+#   bash script/etherscan-verify-sepolia-factory.sh
+#
+# Print the four forge commands without submitting (no API key needed):
+#   PRINT_ONLY=1 bash script/etherscan-verify-sepolia-factory.sh
+#
+# Verify libraries first so the Chamber impl page can link BoardLib + WalletLib.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f .env ]]; then
+	set -a
+	# shellcheck disable=SC1091
+	source .env
+	set +a
+fi
+
+# Public fallback so --rpc-url sepolia resolves when a private RPC is unset.
+export SEPOLIA_RPC_URL="${SEPOLIA_RPC_URL:-https://ethereum-sepolia-rpc.publicnode.com}"
+
+# 26 Aug 2026 Factory path — keep in sync with deployments/sepolia.txt
+FACTORY=0x43aA92c8A26392f21F63cdA88B6BaB5031C40550
+CHAMBER=0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c
+BOARD_LIB=0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D
+WALLET_LIB=0x0320284b176657bb5048CF586DEef530F4B2499a
+ADMIN=0x5d45A213B2B6259F0b3c116a8907B56AB5E22095
+
+for addr in "$FACTORY" "$CHAMBER" "$BOARD_LIB" "$WALLET_LIB"; do
+	grep -q "$addr" "$ROOT/deployments/sepolia.txt" || {
+		echo "Address $addr is not in deployments/sepolia.txt — refuse to verify a drifted set." >&2
+		exit 1
+	}
+done
+
+FACTORY_CTOR_ARGS="$(cast abi-encode "constructor(address,address)" "$CHAMBER" "$ADMIN")"
+
+run_or_print() {
+	local name="$1" addr="$2"
+	local cmd
+	cmd="$(bash "$ROOT/script/etherscan-verify-cmd.sh" "$name" "$addr" sepolia)"
+	echo "+ $cmd"
+	if [[ "${PRINT_ONLY:-}" == "1" ]]; then
+		return 0
+	fi
+	eval "$cmd"
+}
+
+if [[ -z "${ETHERSCAN_API_KEY:-}" && "${PRINT_ONLY:-}" != "1" ]]; then
+	echo "ETHERSCAN_API_KEY is unset. Printing the four forge verify-contract commands." >&2
+	echo "Re-run with the key set: make verify-sepolia-factory" >&2
+	echo "" >&2
+	PRINT_ONLY=1
+	MISSING_KEY=1
+fi
+
+# Libraries first, then Chamber (so Etherscan can attach BoardLib + WalletLib), then Factory.
+run_or_print BoardLib "$BOARD_LIB"
+run_or_print WalletLib "$WALLET_LIB"
+BOARD_LIB="$BOARD_LIB" WALLET_LIB="$WALLET_LIB" run_or_print Chamber "$CHAMBER"
+CONSTRUCTOR_ARGS="$FACTORY_CTOR_ARGS" run_or_print Factory "$FACTORY"
+
+echo ""
+echo "# Sepolia Etherscan"
+echo "# Factory                 https://sepolia.etherscan.io/address/${FACTORY}#code"
+echo "# Chamber implementation  https://sepolia.etherscan.io/address/${CHAMBER}#code"
+echo "# BoardLib                https://sepolia.etherscan.io/address/${BOARD_LIB}#code"
+echo "# WalletLib               https://sepolia.etherscan.io/address/${WALLET_LIB}#code"
+
+if [[ "${MISSING_KEY:-}" == "1" ]]; then
+	exit 2
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #141.

## Why

The 26 Aug Sepolia Factory path is live but BoardLib and WalletLib were unverified, so Chamber’s linked-library source is unreadable on Etherscan.

## What

- Extend `contracts/script/etherscan-verify-cmd.sh` to print `forge verify-contract` for Factory, BoardLib, and WalletLib (and Chamber `--libraries` when `BOARD_LIB` / `WALLET_LIB` are set).
- Add `contracts/script/etherscan-verify-sepolia-factory.sh` and `make verify-sepolia-factory` so a re-run is one command.
- Append Sepolia Etherscan `#code` URLs to `contracts/deployments/sepolia.txt`.

## Verify status (27 Aug 2026)

`ETHERSCAN_API_KEY` is not available in this environment, so submit was not run. `make verify-sepolia-factory` printed the four commands and exited 2.

| Contract | Address | Etherscan (page fetch) |
| --- | --- | --- |
| Factory | `0x43aA92c8A26392f21F63cdA88B6BaB5031C40550` | Already **Verified Exact Match** |
| Chamber impl | `0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c` | Already **Verified Exact Match**; page notes unverified libraries BoardLib, WalletLib |
| BoardLib | `0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D` | **Unverified** |
| WalletLib | `0x0320284b176657bb5048CF586DEef530F4B2499a` | **Unverified** |

Chamber on-chain runtime contains the sepolia.txt link addresses:

- BoardLib `0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D`
- WalletLib `0x0320284b176657bb5048CF586DEef530F4B2499a`

## One-command re-run

```bash
cd contracts
export ETHERSCAN_API_KEY=...
export SEPOLIA_RPC_URL=...   # optional; script falls back to publicnode
make verify-sepolia-factory
```

Print commands only (no API key):

```bash
PRINT_ONLY=1 make verify-sepolia-factory
```

Exact commands printed in this run:

```bash
forge verify-contract 0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D src/libraries/BoardLib.sol:BoardLib --chain sepolia --rpc-url sepolia --verifier etherscan --compiler-version v0.8.30+commit.73712a01 --num-of-optimizations 200 --evm-version cancun --via-ir --watch

forge verify-contract 0x0320284b176657bb5048CF586DEef530F4B2499a src/libraries/WalletLib.sol:WalletLib --chain sepolia --rpc-url sepolia --verifier etherscan --compiler-version v0.8.30+commit.73712a01 --num-of-optimizations 200 --evm-version cancun --via-ir --watch

forge verify-contract 0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c src/Chamber.sol:Chamber --chain sepolia --rpc-url sepolia --verifier etherscan --compiler-version v0.8.30+commit.73712a01 --num-of-optimizations 200 --evm-version cancun --via-ir --watch --libraries src/libraries/BoardLib.sol:BoardLib:0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D --libraries src/libraries/WalletLib.sol:WalletLib:0x0320284b176657bb5048CF586DEef530F4B2499a

forge verify-contract 0x43aA92c8A26392f21F63cdA88B6BaB5031C40550 src/Factory.sol:Factory --chain sepolia --rpc-url sepolia --verifier etherscan --compiler-version v0.8.30+commit.73712a01 --num-of-optimizations 200 --evm-version cancun --via-ir --watch --constructor-args 0x000000000000000000000000d441f1fdad2d3a447d2621de4de8b5738e02d39c0000000000000000000000005d45a213b2b6259f0b3c116a8907b56ab5e22095
```

Verify URLs (in `contracts/deployments/sepolia.txt`):

- https://sepolia.etherscan.io/address/0x43aA92c8A26392f21F63cdA88B6BaB5031C40550#code
- https://sepolia.etherscan.io/address/0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c#code
- https://sepolia.etherscan.io/address/0xC3E0Fe4e89e01ca69e384bd61DA78a5a6379762D#code
- https://sepolia.etherscan.io/address/0x0320284b176657bb5048CF586DEef530F4B2499a#code

Out of scope: mainnet verify, bytecode changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c5ef54a-2f79-421b-a6b9-59cdd55dbea5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c5ef54a-2f79-421b-a6b9-59cdd55dbea5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

