### PR TITLE
feat(app): My chambers via Ponder indexer or chunked getLogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ contracts/.anvil/
 .env
 .env*
 !.env.template
+!app/.env.template
 coverage
 coverage.json
 .DS_Store

--- a/app/.env.template
+++ b/app/.env.template
@@ -1,0 +1,10 @@
+# Optional Ponder GraphQL host (loreum-org/chamber-indexer).
+# “Mine” = chambers.creator OR chamberHolders.shares > 0.
+# Leave unset to use chunked Factory/Registry getLogs only.
+# VITE_INDEXER_URL=https://your-ponder-host.example
+# VITE_INDEXER_CHAIN_ID=11155111
+
+# Discovery start blocks (defaults: Sepolia 7453704, matching chamber-indexer).
+# Factory 0x43aA92c8A26392f21F63cdA88B6BaB5031C40550 was first coded at ~11571185.
+# VITE_SEPOLIA_FACTORY_START_BLOCK=11571185
+# VITE_SEPOLIA_REGISTRY_START_BLOCK=7453704

--- a/app/README.md
+++ b/app/README.md
@@ -4,7 +4,7 @@ A decentralized treasury governance application for Loreum Chambers. This applic
 
 ## Features
 
-- **Deploy Chambers**: Create new treasury governance instances via the Registry
+- **Deploy Chambers**: Create new treasury governance instances via the Factory (Registry fallback)
 - **Board Visualization**: Beautiful graphical representation of board members and their voting power
 - **Transaction Queue**: Submit, confirm, and execute multi-signature transactions
 - **Treasury Management**: Deposit/withdraw assets using ERC4626 vault mechanics
@@ -49,14 +49,21 @@ npm install
    ```bash
    VITE_ALCHEMY_API_KEY=your_key
    ```
-   Enable Ethereum, Sepolia, Base, and Arbitrum apps in the Alchemy dashboard. The same key powers **wagmi RPC** (read/write on those chains) and the **Chamber assets** panel.
+   Enable Ethereum, Sepolia, Base, and Arbitrum apps in the Alchemy dashboard. The same key powers **wagmi RPC** (read/write on those chains) and the **Chamber assets** panel. Production `eth_getLogs` pagination for **My chambers** also uses this RPC (not a single getLogs-from-0).
 
-2. Update the WalletConnect Project ID in `src/lib/wagmi.ts`:
+2. Optional — **Ponder indexer** ([loreum-org/chamber-indexer](https://github.com/loreum-org/chamber-indexer)) for **My chambers** that survive public-RPC log truncation and a new browser (no `localStorage` recents). Dual discovery: Factory `ChamberCreated` (when `PONDER_FACTORY_ADDRESS` is set on the indexer) plus leftover Registry creates. GraphQL `chambers` / `chamberHolders` = creator OR current share balance.
+   ```bash
+   VITE_INDEXER_URL=https://your-ponder-host.example
+   # VITE_INDEXER_CHAIN_ID=11155111
+   ```
+   The app POSTs to `{VITE_INDEXER_URL}/graphql` (`MyChambers`). If the host is unset or down, discovery falls back to chunked Factory/Registry `getLogs` from the configured start block (Sepolia default `7453704`, same as the indexer). A live Ponder host is not required. See `app/.env.template`.
+
+3. Update the WalletConnect Project ID in `src/lib/wagmi.ts`:
    ```typescript
    projectId: 'YOUR_WALLETCONNECT_PROJECT_ID'
    ```
 
-3. Sepolia Factory / Registry / demo ERC-20 / membership ERC-721 come from
+4. Sepolia Factory / Registry / demo ERC-20 / membership ERC-721 come from
    `contracts/deployments/sepolia.txt` (parsed by `getContractAddresses(11155111)`).
    Env vars (`VITE_SEPOLIA_*`) still override. Other networks: set `VITE_*` in `.env`.
 
@@ -111,7 +118,7 @@ app/
 ## Key Functionality
 
 ### Chamber Management
-- View all deployed chambers
+- **My chambers** via Ponder (`VITE_INDEXER_URL`) or chunked Factory/Registry `ChamberCreated` logs, plus recents and open-by-address
 - Deploy new chambers with custom parameters
 - View chamber details (assets, board, transactions)
 
@@ -143,7 +150,8 @@ app/
 
 The app integrates with the following contracts:
 
-- **Registry**: Factory for deploying new Chambers
+- **Factory**: Permissionless create path; `ChamberCreated` is the discovery event (no world list)
+- **Registry**: Deprecated index + leftover create path; still scanned for legacy chambers
 - **Chamber**: Main contract combining:
   - ERC4626 vault for asset management
   - Board governance for director elections

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
     "prebuild": "node ./scripts/sync-contracts.mjs",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:discovery": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts"
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.1.0",

--- a/app/scripts/verify-chamber-discovery.ts
+++ b/app/scripts/verify-chamber-discovery.ts
@@ -1,0 +1,116 @@
+/**
+ * Offline checks for indexer parsing + chunked getLogs (no live Ponder host).
+ * Run: npx tsx scripts/verify-chamber-discovery.ts
+ */
+import assert from 'node:assert/strict'
+import { parseIndexerMyChambers } from '../src/lib/indexer.ts'
+import {
+  INDEXER_CATCHUP_BLOCKS,
+  UNBOUNDED_LOOKBACK_BLOCKS,
+  clampDiscoveryFromBlock,
+  getEventLogsPaged,
+  parseStartBlock,
+  SEPOLIA_DISCOVERY_START_BLOCK,
+  factoryCreatedEvent,
+} from '../src/lib/chamberDiscovery.ts'
+import type { PublicClient } from 'viem'
+
+function testParseIndexer() {
+  const parsed = parseIndexerMyChambers({
+    data: {
+      created: {
+        items: [
+          {
+            id: '0x1111111111111111111111111111111111111111',
+            address: '0x1111111111111111111111111111111111111111',
+            creator: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            source: 'factory',
+          },
+        ],
+      },
+      held: {
+        items: [
+          {
+            shares: '1',
+            chamber: {
+              id: '0x2222222222222222222222222222222222222222',
+              creator: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              source: 'registry',
+            },
+          },
+          { chamber: { address: '0x0' } },
+        ],
+      },
+    },
+  })
+  assert.equal(parsed.created.length, 1)
+  assert.equal(parsed.created[0]?.address, '0x1111111111111111111111111111111111111111')
+  assert.equal(parsed.created[0]?.creator, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+  assert.equal(parsed.held.length, 1)
+  assert.equal(parsed.held[0]?.address, '0x2222222222222222222222222222222222222222')
+}
+
+function testStartBlocks() {
+  assert.equal(parseStartBlock('7453704'), 7453704n)
+  assert.equal(parseStartBlock(''), undefined)
+  assert.equal(parseStartBlock('nope'), undefined)
+  assert.equal(SEPOLIA_DISCOVERY_START_BLOCK, 7453704n)
+
+  const latest = 8_000_000n
+  assert.equal(clampDiscoveryFromBlock(7453704n, latest, false), 7453704n)
+  const catchup = clampDiscoveryFromBlock(7453704n, latest, true)
+  assert.equal(catchup, latest - INDEXER_CATCHUP_BLOCKS)
+  assert.ok(latest - catchup > 14_400n, 'catch-up window exceeds ~48h of 12s blocks')
+
+  const unbounded = clampDiscoveryFromBlock(0n, 5_000_000n, false)
+  assert.equal(unbounded, 5_000_000n - UNBOUNDED_LOOKBACK_BLOCKS)
+}
+
+async function testPagedLogs() {
+  const calls: Array<{ from: bigint; to: bigint }> = []
+  const client = {
+    getLogs: async ({ fromBlock, toBlock }: { fromBlock: bigint; toBlock: bigint }) => {
+      calls.push({ from: fromBlock, to: toBlock })
+      if (toBlock - fromBlock + 1n > 2_000n) {
+        throw new Error('block range too large')
+      }
+      if (fromBlock <= 3_500n && toBlock >= 3_500n) {
+        return [
+          {
+            args: {
+              chamber: '0x3333333333333333333333333333333333333333',
+              creator: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            },
+          },
+        ]
+      }
+      return []
+    },
+  } as unknown as PublicClient
+
+  const logs = await getEventLogsPaged(client, {
+    address: '0x43aa92c8a26392f21f63cda88b6bab5031c40550',
+    event: factoryCreatedEvent,
+    fromBlock: 0n,
+    toBlock: 10_000n,
+  })
+
+  assert.ok(
+    calls[0] && calls[0].to - calls[0].from + 1n > 2_000n,
+    'first attempt is the full range (not getLogs-from-0-only success path)',
+  )
+  assert.ok(
+    calls.some((c) => c.to - c.from + 1n <= 2_000n),
+    'fallback pages into RPC-legal chunks',
+  )
+  assert.equal(logs.length, 1)
+  assert.equal(
+    (logs[0] as { args: { chamber: string } }).args.chamber,
+    '0x3333333333333333333333333333333333333333',
+  )
+}
+
+testParseIndexer()
+testStartBlocks()
+await testPagedLogs()
+console.log('verify-chamber-discovery: ok')

--- a/app/scripts/verify-sepolia-discovery.ts
+++ b/app/scripts/verify-sepolia-discovery.ts
@@ -1,0 +1,101 @@
+/**
+ * Live Sepolia check: a Registry chamber older than 48h is found via
+ * production-style RPC getLogs (and a range-limited pagination path),
+ * without localStorage. Factory-unset still works. Open-by-address is unchanged.
+ *
+ * Run: npx tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts
+ */
+import assert from 'node:assert/strict'
+import { createPublicClient, http, type PublicClient } from 'viem'
+import { sepolia } from 'viem/chains'
+import { addRecentChamber, getRecentChambers } from '../src/lib/recentChambers.ts'
+import { discoverChambers, getEventLogsPaged, registryCreatedEvent } from '../src/lib/chamberDiscovery.ts'
+
+const REGISTRY = '0xB028110234375A368Aa0b5fFB138ae1dDfb0b4cc' as const
+const FACTORY = '0x43aA92c8A26392f21F63cdA88B6BaB5031C40550' as const
+const KNOWN_OLD = '0x0ad3205ecfa76cdb52be5ebe099b990c35489888'
+const KNOWN_OLD_BLOCK = 7453727n
+const RPC = 'https://sepolia.gateway.tenderly.co'
+
+const inner = createPublicClient({ chain: sepolia, transport: http(RPC) })
+
+function rangeLimitedClient(maxSpan: bigint): PublicClient {
+  return {
+    ...inner,
+    getBlockNumber: () => inner.getBlockNumber(),
+    getTransaction: (args: Parameters<PublicClient['getTransaction']>[0]) => inner.getTransaction(args),
+    getLogs: async (args: Parameters<PublicClient['getLogs']>[0]) => {
+      const from = args.fromBlock
+      const to = args.toBlock
+      if (typeof from === 'bigint' && typeof to === 'bigint' && to - from + 1n > maxSpan) {
+        throw new Error(`block range too large (${(to - from + 1n).toString()} > ${maxSpan})`)
+      }
+      return inner.getLogs(args)
+    },
+  } as PublicClient
+}
+
+const latest = await inner.getBlockNumber()
+const ageBlocks = latest - KNOWN_OLD_BLOCK
+assert.ok(ageBlocks > 14_400n, `known chamber is only ${ageBlocks} blocks old (~48h)`)
+
+const windowFrom = KNOWN_OLD_BLOCK - 500n
+const windowTo = KNOWN_OLD_BLOCK + 1_500n
+const limited = rangeLimitedClient(800n)
+const paged = await getEventLogsPaged(limited, {
+  address: REGISTRY,
+  event: registryCreatedEvent,
+  fromBlock: windowFrom,
+  toBlock: windowTo,
+})
+const found = paged.map((log) => log.args.chamber?.toLowerCase())
+assert.ok(found.includes(KNOWN_OLD), `paged getLogs missed ${KNOWN_OLD}: ${found.join(',')}`)
+
+const registryOnly = await discoverChambers({
+  client: inner as PublicClient,
+  chainId: 11155111,
+  userAddress: '0x0000000000000000000000000000000000000001',
+  registryAddress: REGISTRY,
+})
+assert.ok(
+  registryOnly.addresses.includes(KNOWN_OLD),
+  'Factory-unset / Registry-only still lists Registry-created chambers',
+)
+
+const factorySet = await discoverChambers({
+  client: inner as PublicClient,
+  chainId: 11155111,
+  userAddress: '0x0000000000000000000000000000000000000001',
+  factoryAddress: FACTORY,
+  registryAddress: REGISTRY,
+})
+assert.ok(factorySet.addresses.includes(KNOWN_OLD), 'Factory set still includes leftover Registry chambers')
+
+const openAddr = '0x1234567890123456789012345678901234567890' as const
+const prev = globalThis.window
+;(globalThis as { window?: { localStorage: Storage } }).window = {
+  localStorage: (() => {
+    const store = new Map<string, string>()
+    return {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size
+      },
+    } as Storage
+  })(),
+}
+addRecentChamber(11155111, openAddr)
+assert.deepEqual(getRecentChambers(11155111), [openAddr])
+if (prev === undefined) delete (globalThis as { window?: unknown }).window
+else (globalThis as { window?: unknown }).window = prev
+
+console.log('verify-sepolia-discovery: ok', {
+  latest: latest.toString(),
+  ageBlocks: ageBlocks.toString(),
+  registryChambers: registryOnly.addresses,
+  creators: [...registryOnly.creators.entries()],
+})

--- a/app/src/docs/guides/app-routes.md
+++ b/app/src/docs/guides/app-routes.md
@@ -6,7 +6,7 @@ This is a **map of screens** in the Chamber web app. Pair it with **[Getting sta
 
 | Path | What you do here |
 |------|------------------|
-| **`/`** | **Dashboard** — list Chambers from the Registry |
+| **`/`** | **Dashboard** — **My chambers** (indexer and/or Factory/Registry `ChamberCreated` logs + recents + open-by-address) |
 | **`/deploy`** | **Create** a new Chamber |
 | **`/chamber/:address`** | **Overview** — summary, tabs, balances |
 | **`/chamber/:address/staking`** | **Deposit / withdraw** underlying tokens |

--- a/app/src/docs/guides/deployment.md
+++ b/app/src/docs/guides/deployment.md
@@ -2,7 +2,7 @@
 
 > **Audience:** developers and operators running Foundry scripts. End users normally create Chambers through the app’s **Deploy** page — see **[Getting started](../introduction/getting-started.md)**.
 
-Contracts live in **`contracts/`**. Production-shaped deploys use the **Registry**, which pins a Chamber **implementation** and exposes **`createChamber`**.
+Contracts live in **`contracts/`**. New deploys go through the **Factory**. The **Registry** remains as a deprecated index + leftover create path.
 
 ## Prerequisites
 
@@ -84,6 +84,8 @@ Sepolia Factory, Registry, Chamber implementation, and demo ERC-20 / membership 
 are read from **`contracts/deployments/sepolia.txt`**. Optional env overrides:
 `VITE_SEPOLIA_REGISTRY`, `VITE_SEPOLIA_FACTORY`, `VITE_SEPOLIA_CHAMBER_IMPL`,
 `VITE_SEPOLIA_MOCK_ERC20`, `VITE_SEPOLIA_MOCK_ERC721`.
+
+Optional **My chambers** indexer: `VITE_INDEXER_URL` → [loreum-org/chamber-indexer](https://github.com/loreum-org/chamber-indexer) GraphQL. Unset → chunked Factory/Registry `getLogs`.
 
 See **`app/README.md`** and repo deployment docs under **`docs/guides/deployment.md`**.
 

--- a/app/src/docs/introduction/getting-started.md
+++ b/app/src/docs/introduction/getting-started.md
@@ -21,7 +21,7 @@ Skim **[What is a Chamber?](./overview.md)** first if the ideas are new.
 
 **Go to:** **Deploy** (`/deploy`)
 
-You are launching a new treasury + governance ruleset through the **Registry**.
+You are launching a new treasury + governance ruleset through the **Factory** (Registry if Factory is unset).
 
 | Field | What it means |
 |--------|----------------|

--- a/app/src/hooks/useMyChambers.ts
+++ b/app/src/hooks/useMyChambers.ts
@@ -2,21 +2,12 @@ import { useCallback, useEffect, useState } from 'react'
 import { useAccount, useChainId, usePublicClient } from 'wagmi'
 import { useQuery } from '@tanstack/react-query'
 import { multicall } from 'viem/actions'
-import { parseAbiItem, type AbiEvent, type Address, type PublicClient } from 'viem'
 import { chamberAbi, factoryAbi, registryAbi } from '@/contracts/abis'
+import { discoverChambers } from '@/lib/chamberDiscovery'
+import { getIndexerUrl, indexerAppliesToChain } from '@/lib/indexer'
 import { addRecentChamber, getRecentChambers } from '@/lib/recentChambers'
 import { isNonZeroAddress } from '@/lib/wagmi'
 import { useFactoryAddress, useRegistryAddress } from './useRegistry'
-
-const factoryCreatedEvent = parseAbiItem(
-  'event ChamberCreated(address indexed chamber, address indexed asset, address indexed nft, uint256 seats, string name, string symbol, address creator)',
-)
-
-const registryCreatedEvent = parseAbiItem(
-  'event ChamberCreated(address indexed chamber, uint256 seats, string name, string symbol, address erc20Token, address erc721Token)',
-)
-
-const LOG_LOOKBACK_BLOCKS = 100_000n
 
 export function useRecentChambers() {
   const chainId = useChainId()
@@ -36,66 +27,6 @@ export function useRecentChambers() {
   return { recents, remember }
 }
 
-async function getCreatedLogs<TEvent extends AbiEvent>(
-  client: PublicClient,
-  address: `0x${string}`,
-  event: TEvent,
-) {
-  try {
-    return await client.getLogs({ address, event, fromBlock: 0n, toBlock: 'latest' })
-  } catch {
-    const latest = await client.getBlockNumber()
-    const from = latest > LOG_LOOKBACK_BLOCKS ? latest - LOG_LOOKBACK_BLOCKS : 0n
-    return client.getLogs({ address, event, fromBlock: from, toBlock: 'latest' })
-  }
-}
-
-async function fetchCreatedChambers(
-  client: PublicClient,
-  factoryAddress: `0x${string}` | undefined,
-  registryAddress: `0x${string}` | undefined,
-): Promise<{ addresses: `0x${string}`[]; creators: Map<string, `0x${string}`> }> {
-  const creators = new Map<string, `0x${string}`>()
-  const addresses: `0x${string}`[] = []
-  const seen = new Set<string>()
-
-  const push = (chamber: Address | undefined, creator?: Address) => {
-    if (!chamber || !isNonZeroAddress(chamber)) return
-    const key = chamber.toLowerCase() as `0x${string}`
-    if (!seen.has(key)) {
-      seen.add(key)
-      addresses.push(key)
-    }
-    if (creator && isNonZeroAddress(creator) && !creators.has(key)) {
-      creators.set(key, creator.toLowerCase() as `0x${string}`)
-    }
-  }
-
-  if (isNonZeroAddress(factoryAddress)) {
-    try {
-      const logs = await getCreatedLogs(client, factoryAddress, factoryCreatedEvent)
-      for (const log of logs) {
-        push(log.args.chamber, log.args.creator)
-      }
-    } catch {
-      // RPC getLogs limits — recents / open-address still work
-    }
-  }
-
-  if (isNonZeroAddress(registryAddress)) {
-    try {
-      const logs = await getCreatedLogs(client, registryAddress, registryCreatedEvent)
-      for (const log of logs) {
-        push(log.args.chamber)
-      }
-    } catch {
-      // leftover Registry index is best-effort
-    }
-  }
-
-  return { addresses, creators }
-}
-
 export type MyChamberEntry = {
   address: `0x${string}`
   isDirector: boolean
@@ -104,8 +35,9 @@ export type MyChamberEntry = {
 }
 
 /**
- * Chambers the connected user participates in: Factory/Registry `ChamberCreated`
- * logs plus local recents, kept when the user is creator, a director, or holds shares.
+ * Chambers the connected user participates in: Ponder indexer (optional) +
+ * Factory/Registry `ChamberCreated` logs plus local recents, kept when the user
+ * is creator, a director, or holds shares.
  */
 export function useMyChambers() {
   const { address: userAddress } = useAccount()
@@ -117,6 +49,7 @@ export function useMyChambers() {
 
   const factoryOk = isNonZeroAddress(factoryAddress)
   const registryOk = isNonZeroAddress(registryAddress)
+  const indexerUrl = indexerAppliesToChain(chainId) ? getIndexerUrl() ?? '' : ''
 
   const query = useQuery({
     queryKey: [
@@ -125,22 +58,28 @@ export function useMyChambers() {
       userAddress,
       factoryOk ? factoryAddress : '0x0',
       registryOk ? registryAddress : '0x0',
+      indexerUrl,
       recents.join(),
     ],
-    enabled: !!publicClient && !!userAddress && (factoryOk || registryOk || recents.length > 0),
+    enabled:
+      !!publicClient &&
+      !!userAddress &&
+      (factoryOk || registryOk || recents.length > 0 || !!indexerUrl),
     staleTime: 15_000,
     queryFn: async () => {
       if (!publicClient || !userAddress) return [] as MyChamberEntry[]
 
-      const { addresses: fromLogs, creators } = await fetchCreatedChambers(
-        publicClient,
-        factoryOk ? factoryAddress : undefined,
-        registryOk ? registryAddress : undefined,
-      )
+      const { addresses: discovered, creators } = await discoverChambers({
+        client: publicClient,
+        chainId,
+        userAddress,
+        factoryAddress: factoryOk ? factoryAddress : undefined,
+        registryAddress: registryOk ? registryAddress : undefined,
+      })
 
       const candidates: `0x${string}`[] = []
       const seen = new Set<string>()
-      for (const addr of [...fromLogs, ...recents]) {
+      for (const addr of [...discovered, ...recents]) {
         const key = addr.toLowerCase()
         if (seen.has(key)) continue
         seen.add(key)

--- a/app/src/lib/address.ts
+++ b/app/src/lib/address.ts
@@ -1,0 +1,5 @@
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`
+
+export function isNonZeroAddress(addr: string | undefined): addr is `0x${string}` {
+  return !!addr && addr !== ZERO_ADDRESS && addr.startsWith('0x') && addr.length === 42
+}

--- a/app/src/lib/chamberDiscovery.ts
+++ b/app/src/lib/chamberDiscovery.ts
@@ -1,0 +1,335 @@
+/**
+ * Discover chambers the user created or might hold — no on-chain world directory.
+ *
+ * Order:
+ * 1. Ponder GraphQL (`VITE_INDEXER_URL`) — loreum-org/chamber-indexer `chambers` /
+ *    `chamberHolders` (creator OR share balance). Sepolia by default.
+ * 2. Factory / Registry `ChamberCreated` via chunked `eth_getLogs` (not one
+ *    getLogs-from-0). Factory remains the source of creation events; Registry
+ *    logs are leftover legacy deploys only.
+ *
+ * Public Sepolia RPCs often reject or truncate a single from-0 `getLogs`.
+ * Production RPC (Alchemy when `VITE_ALCHEMY_API_KEY` is set) can page history
+ * older than 48h. A live Ponder host is optional.
+ */
+
+import { parseAbiItem, type AbiEvent, type Address, type GetLogsReturnType, type PublicClient } from 'viem'
+import { isNonZeroAddress } from '@/lib/address'
+import {
+  fetchIndexerMyChambers,
+  getIndexerUrl,
+  indexerAppliesToChain,
+  type IndexerChamber,
+} from '@/lib/indexer'
+
+export const factoryCreatedEvent = parseAbiItem(
+  'event ChamberCreated(address indexed chamber, address indexed asset, address indexed nft, uint256 seats, string name, string symbol, address creator)',
+)
+
+export const registryCreatedEvent = parseAbiItem(
+  'event ChamberCreated(address indexed chamber, uint256 seats, string name, string symbol, address erc20Token, address erc721Token)',
+)
+
+/** chamber-indexer `REGISTRY_START_BLOCK` — Factory default matches when unset. */
+export const SEPOLIA_DISCOVERY_START_BLOCK = 7453704n
+
+/** Catch-up window after a successful indexer query (~2 days on 12s Sepolia). */
+export const INDEXER_CATCHUP_BLOCKS = 16_384n
+
+/** When no start block is configured, walk back far enough to survive >48h. */
+export const UNBOUNDED_LOOKBACK_BLOCKS = 2_000_000n
+
+const DEFAULT_LOG_CHUNK = 10_000n
+const MIN_LOG_CHUNK = 200n
+const LOG_CONCURRENCY = 4
+const TX_CONCURRENCY = 4
+
+export type DiscoveredChambers = {
+  addresses: `0x${string}`[]
+  creators: Map<string, `0x${string}`>
+}
+
+export function parseStartBlock(raw: string | undefined): bigint | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  if (trimmed === '') return undefined
+  try {
+    const value = BigInt(trimmed)
+    return value >= 0n ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function discoveryStartBlock(chainId: number, kind: 'factory' | 'registry'): bigint {
+  const env =
+    kind === 'factory'
+      ? {
+          1: import.meta.env?.VITE_MAINNET_FACTORY_START_BLOCK,
+          11155111: import.meta.env?.VITE_SEPOLIA_FACTORY_START_BLOCK,
+          8453: import.meta.env?.VITE_BASE_FACTORY_START_BLOCK,
+          42161: import.meta.env?.VITE_ARBITRUM_FACTORY_START_BLOCK,
+        }[chainId]
+      : {
+          1: import.meta.env?.VITE_MAINNET_REGISTRY_START_BLOCK,
+          11155111: import.meta.env?.VITE_SEPOLIA_REGISTRY_START_BLOCK,
+          8453: import.meta.env?.VITE_BASE_REGISTRY_START_BLOCK,
+          42161: import.meta.env?.VITE_ARBITRUM_REGISTRY_START_BLOCK,
+        }[chainId]
+
+  const parsed = parseStartBlock(env)
+  if (parsed !== undefined) return parsed
+  if (chainId === 11155111) return SEPOLIA_DISCOVERY_START_BLOCK
+  return 0n
+}
+
+export function clampDiscoveryFromBlock(fromBlock: bigint, latest: bigint, catchupOnly: boolean): bigint {
+  if (catchupOnly) {
+    const catchup = latest > INDEXER_CATCHUP_BLOCKS ? latest - INDEXER_CATCHUP_BLOCKS : 0n
+    return fromBlock > catchup ? fromBlock : catchup
+  }
+  if (fromBlock > 0n) return fromBlock
+  if (latest > UNBOUNDED_LOOKBACK_BLOCKS) return latest - UNBOUNDED_LOOKBACK_BLOCKS
+  return 0n
+}
+
+function pushChamber(
+  addresses: `0x${string}`[],
+  seen: Set<string>,
+  creators: Map<string, `0x${string}`>,
+  chamber: Address | undefined,
+  creator?: Address,
+) {
+  if (!chamber || !isNonZeroAddress(chamber)) return
+  const key = chamber.toLowerCase() as `0x${string}`
+  if (!seen.has(key)) {
+    seen.add(key)
+    addresses.push(key)
+  }
+  if (creator && isNonZeroAddress(creator) && !creators.has(key)) {
+    creators.set(key, creator.toLowerCase() as `0x${string}`)
+  }
+}
+
+function mergeIndexerRows(
+  addresses: `0x${string}`[],
+  seen: Set<string>,
+  creators: Map<string, `0x${string}`>,
+  rows: IndexerChamber[],
+) {
+  for (const row of rows) {
+    pushChamber(addresses, seen, creators, row.address, row.creator)
+  }
+}
+
+async function mapPool<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  if (items.length === 0) return []
+  const out: R[] = new Array(items.length)
+  let next = 0
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (next < items.length) {
+      const i = next++
+      out[i] = await fn(items[i]!)
+    }
+  })
+  await Promise.all(workers)
+  return out
+}
+
+type EventLogs<TEvent extends AbiEvent> = GetLogsReturnType<TEvent>
+
+async function probeLogChunk<TEvent extends AbiEvent>(
+  client: PublicClient,
+  args: { address: `0x${string}`; event: TEvent },
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<bigint> {
+  let chunk = DEFAULT_LOG_CHUNK
+  while (chunk >= MIN_LOG_CHUNK) {
+    const probeFrom = toBlock + 1n > chunk ? toBlock - chunk + 1n : fromBlock
+    try {
+      await client.getLogs({
+        address: args.address,
+        event: args.event,
+        fromBlock: probeFrom,
+        toBlock,
+      })
+      return chunk
+    } catch {
+      chunk = chunk / 2n
+    }
+  }
+  return MIN_LOG_CHUNK
+}
+
+export async function getEventLogsPaged<TEvent extends AbiEvent>(
+  client: PublicClient,
+  args: { address: `0x${string}`; event: TEvent; fromBlock: bigint; toBlock: bigint },
+): Promise<EventLogs<TEvent>> {
+  try {
+    return await client.getLogs({
+      address: args.address,
+      event: args.event,
+      fromBlock: args.fromBlock,
+      toBlock: args.toBlock,
+    })
+  } catch {
+    const chunk = await probeLogChunk(client, args, args.fromBlock, args.toBlock)
+    return collectLogs(client, args, args.fromBlock, args.toBlock, chunk)
+  }
+}
+
+async function collectLogs<TEvent extends AbiEvent>(
+  client: PublicClient,
+  args: { address: `0x${string}`; event: TEvent },
+  fromBlock: bigint,
+  toBlock: bigint,
+  chunk: bigint,
+): Promise<EventLogs<TEvent>> {
+  if (toBlock < fromBlock) return [] as EventLogs<TEvent>
+
+  const span = toBlock - fromBlock + 1n
+  if (span <= chunk) {
+    try {
+      return await client.getLogs({
+        address: args.address,
+        event: args.event,
+        fromBlock,
+        toBlock,
+      })
+    } catch {
+      if (span <= MIN_LOG_CHUNK) return [] as EventLogs<TEvent>
+      const mid = fromBlock + span / 2n - 1n
+      const [left, right] = await Promise.all([
+        collectLogs(client, args, fromBlock, mid, chunk),
+        collectLogs(client, args, mid + 1n, toBlock, chunk),
+      ])
+      return [...left, ...right]
+    }
+  }
+
+  const windows: Array<[bigint, bigint]> = []
+  for (let start = fromBlock; start <= toBlock; start += chunk) {
+    const end = start + chunk - 1n > toBlock ? toBlock : start + chunk - 1n
+    windows.push([start, end])
+  }
+
+  const batches = await mapPool(windows, LOG_CONCURRENCY, ([start, end]) =>
+    collectLogs(client, args, start, end, chunk),
+  )
+  return batches.flat()
+}
+
+async function recoverRegistryCreators(
+  client: PublicClient,
+  logs: readonly { transactionHash?: `0x${string}` | null; args?: { chamber?: Address } }[],
+  creators: Map<string, `0x${string}`>,
+) {
+  const needed: { hash: `0x${string}`; chamber: `0x${string}` }[] = []
+  const seenTx = new Set<string>()
+  for (const log of logs) {
+    const chamber = log.args?.chamber
+    const hash = log.transactionHash
+    if (!chamber || !isNonZeroAddress(chamber) || !hash) continue
+    const key = chamber.toLowerCase()
+    if (creators.has(key) || seenTx.has(hash)) continue
+    seenTx.add(hash)
+    needed.push({ hash, chamber: key as `0x${string}` })
+  }
+
+  await mapPool(needed, TX_CONCURRENCY, async ({ hash, chamber }) => {
+    try {
+      const tx = await client.getTransaction({ hash })
+      if (tx.from && isNonZeroAddress(tx.from) && !creators.has(chamber)) {
+        creators.set(chamber, tx.from.toLowerCase() as `0x${string}`)
+      }
+    } catch {
+      // creator badge is best-effort for leftover Registry events
+    }
+  })
+}
+
+export async function discoverChambers(options: {
+  client: PublicClient
+  chainId: number
+  userAddress: Address
+  factoryAddress?: `0x${string}`
+  registryAddress?: `0x${string}`
+}): Promise<DiscoveredChambers> {
+  const { client, chainId, userAddress, factoryAddress, registryAddress } = options
+  const addresses: `0x${string}`[] = []
+  const seen = new Set<string>()
+  const creators = new Map<string, `0x${string}`>()
+
+  const factoryOk = isNonZeroAddress(factoryAddress)
+  const registryOk = isNonZeroAddress(registryAddress)
+  const indexerUrl = indexerAppliesToChain(chainId) ? getIndexerUrl() : undefined
+
+  let indexerOk = false
+  if (indexerUrl) {
+    try {
+      const mine = await fetchIndexerMyChambers(indexerUrl, userAddress)
+      mergeIndexerRows(addresses, seen, creators, mine.created)
+      mergeIndexerRows(addresses, seen, creators, mine.held)
+      indexerOk = true
+    } catch {
+      // fall through to chunked getLogs
+    }
+  }
+
+  if (!factoryOk && !registryOk) {
+    return { addresses, creators }
+  }
+
+  const latest = await client.getBlockNumber()
+
+  const collectFactory = async () => {
+    if (!factoryOk || !factoryAddress) return
+    try {
+      const fromBlock = clampDiscoveryFromBlock(
+        discoveryStartBlock(chainId, 'factory'),
+        latest,
+        indexerOk,
+      )
+      const logs = await getEventLogsPaged(client, {
+        address: factoryAddress,
+        event: factoryCreatedEvent,
+        fromBlock,
+        toBlock: latest,
+      })
+      for (const log of logs) {
+        pushChamber(addresses, seen, creators, log.args.chamber, log.args.creator)
+      }
+    } catch {
+      // RPC getLogs limits — indexer / recents / open-address still work
+    }
+  }
+
+  const collectRegistry = async () => {
+    if (!registryOk || !registryAddress) return
+    try {
+      const fromBlock = clampDiscoveryFromBlock(
+        discoveryStartBlock(chainId, 'registry'),
+        latest,
+        indexerOk,
+      )
+      const logs = await getEventLogsPaged(client, {
+        address: registryAddress,
+        event: registryCreatedEvent,
+        fromBlock,
+        toBlock: latest,
+      })
+      for (const log of logs) {
+        pushChamber(addresses, seen, creators, log.args.chamber)
+      }
+      if (!indexerOk) {
+        await recoverRegistryCreators(client, logs, creators)
+      }
+    } catch {
+      // leftover Registry index is best-effort
+    }
+  }
+
+  await Promise.all([collectFactory(), collectRegistry()])
+  return { addresses, creators }
+}

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -1,2 +1,4 @@
 export * from './wagmi'
 export * from './chamberGovernance'
+export * from './indexer'
+export * from './chamberDiscovery'

--- a/app/src/lib/indexer.ts
+++ b/app/src/lib/indexer.ts
@@ -1,0 +1,142 @@
+/**
+ * Ponder GraphQL client for loreum-org/chamber-indexer.
+ *
+ * Dual discovery: Registry (legacy) + Factory when PONDER_FACTORY_ADDRESS is set.
+ * “Mine” = chamber.creator OR chamberHolder.shares > 0. Directors stay on-chain
+ * (`getDirectors`); the indexer does not reconstruct the board.
+ *
+ * Host the indexer and set `VITE_INDEXER_URL` (e.g. https://indexer.example.com).
+ * A live host is not required — `discoverChambers` falls back to chunked getLogs.
+ */
+
+import type { Address } from 'viem'
+import { isNonZeroAddress } from '@/lib/address'
+
+/** Sepolia-only today (chamber-indexer `ponder.config.ts`). Override with `VITE_INDEXER_CHAIN_ID`. */
+export const DEFAULT_INDEXER_CHAIN_ID = 11155111
+
+const MY_CHAMBERS_QUERY = /* GraphQL */ `
+  query MyChambers($account: String!) {
+    created: chambers(where: { creator: $account }, orderBy: "createdBlock", orderDirection: "desc") {
+      items {
+        id
+        address
+        creator
+        source
+      }
+    }
+    held: chamberHolders(where: { account: $account, shares_gt: "0" }) {
+      items {
+        shares
+        chamber {
+          id
+          address
+          creator
+          source
+        }
+      }
+    }
+  }
+`
+
+export type IndexerChamber = {
+  address: `0x${string}`
+  creator?: `0x${string}`
+  source?: string
+}
+
+export type IndexerMyChambers = {
+  created: IndexerChamber[]
+  held: IndexerChamber[]
+}
+
+export function getIndexerUrl(): string | undefined {
+  const raw = import.meta.env?.VITE_INDEXER_URL
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim().replace(/\/+$/, '')
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export function getIndexerChainId(): number {
+  const raw = import.meta.env?.VITE_INDEXER_CHAIN_ID
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const parsed = Number(raw.trim())
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_INDEXER_CHAIN_ID
+}
+
+export function indexerAppliesToChain(chainId: number): boolean {
+  return !!getIndexerUrl() && chainId === getIndexerChainId()
+}
+
+export function indexerGraphqlUrl(base: string): string {
+  const trimmed = base.trim().replace(/\/+$/, '')
+  return trimmed.endsWith('/graphql') ? trimmed : `${trimmed}/graphql`
+}
+
+function asAddress(value: unknown): `0x${string}` | undefined {
+  if (typeof value !== 'string') return undefined
+  const lower = value.trim().toLowerCase()
+  return isNonZeroAddress(lower) ? (lower as `0x${string}`) : undefined
+}
+
+function chamberFromPayload(value: unknown): IndexerChamber | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const row = value as { id?: unknown; address?: unknown; creator?: unknown; source?: unknown }
+  const address = asAddress(row.address) ?? asAddress(row.id)
+  if (!address) return undefined
+  const creator = asAddress(row.creator)
+  const source = typeof row.source === 'string' ? row.source : undefined
+  return { address, creator, source }
+}
+
+export function parseIndexerMyChambers(payload: unknown): IndexerMyChambers {
+  const data =
+    payload && typeof payload === 'object' && 'data' in payload
+      ? (payload as { data: unknown }).data
+      : payload
+  const root = data && typeof data === 'object' ? (data as Record<string, unknown>) : {}
+  const createdItems = (root.created as { items?: unknown } | undefined)?.items
+  const heldItems = (root.held as { items?: unknown } | undefined)?.items
+
+  const created: IndexerChamber[] = []
+  if (Array.isArray(createdItems)) {
+    for (const item of createdItems) {
+      const chamber = chamberFromPayload(item)
+      if (chamber) created.push(chamber)
+    }
+  }
+
+  const held: IndexerChamber[] = []
+  if (Array.isArray(heldItems)) {
+    for (const item of heldItems) {
+      const row = item && typeof item === 'object' ? (item as { chamber?: unknown }) : undefined
+      const chamber = chamberFromPayload(row?.chamber)
+      if (chamber) held.push(chamber)
+    }
+  }
+
+  return { created, held }
+}
+
+export async function fetchIndexerMyChambers(
+  url: string,
+  account: Address,
+): Promise<IndexerMyChambers> {
+  const endpoint = indexerGraphqlUrl(url)
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: MY_CHAMBERS_QUERY,
+      variables: { account: account.toLowerCase() },
+    }),
+  })
+  if (!res.ok) throw new Error(`Indexer HTTP ${res.status}`)
+  const json = (await res.json()) as { errors?: { message?: string }[]; data?: unknown }
+  if (json.errors?.length) {
+    throw new Error(json.errors[0]?.message || 'Indexer GraphQL error')
+  }
+  return parseIndexerMyChambers(json)
+}

--- a/app/src/lib/wagmi.ts
+++ b/app/src/lib/wagmi.ts
@@ -3,11 +3,12 @@ import { fallback, http } from 'wagmi'
 import { mainnet, sepolia, base, arbitrum, Chain } from 'wagmi/chains'
 import localDeployments from '@/contracts/deployments.json'
 import { alchemySupportsChain, getAlchemyApiKeyFromEnv, getAlchemyV2RpcUrl } from '@/lib/alchemy'
+import { ZERO_ADDRESS, isNonZeroAddress } from '@/lib/address'
 import { sepoliaDeploymentAddresses } from '@/lib/sepoliaDeployments'
 
-const productionApp = import.meta.env.PROD
+export { isNonZeroAddress, ZERO_ADDRESS }
 
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`
+const productionApp = import.meta.env.PROD
 
 function envAddress(raw: string | undefined): string {
   return raw?.trim() ?? ''
@@ -231,10 +232,6 @@ export function getContractAddresses(chainId: number) {
     default:
       return null
   }
-}
-
-export function isNonZeroAddress(addr: string | undefined): addr is `0x${string}` {
-  return !!addr && addr !== ZERO_ADDRESS && addr.startsWith('0x') && addr.length === 42
 }
 
 // Helper to check if we have valid addresses configured (factory or registry)

--- a/app/src/pages/DeployChamber.tsx
+++ b/app/src/pages/DeployChamber.tsx
@@ -81,7 +81,7 @@ export default function DeployChamber() {
           setDeployedChamber(chamber)
         }
       } catch {
-        // receipt may omit decoded logs; dashboard getLogs / recents still pick it up
+        // receipt may omit decoded logs; dashboard indexer / getLogs / recents still pick it up
       }
       setDeployedTxHash(hash)
       setStep('success')

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -4,3 +4,16 @@ declare module '*.txt?raw' {
   const content: string
   export default content
 }
+
+interface ImportMetaEnv {
+  readonly VITE_INDEXER_URL?: string
+  readonly VITE_INDEXER_CHAIN_ID?: string
+  readonly VITE_SEPOLIA_FACTORY_START_BLOCK?: string
+  readonly VITE_SEPOLIA_REGISTRY_START_BLOCK?: string
+  readonly VITE_MAINNET_FACTORY_START_BLOCK?: string
+  readonly VITE_MAINNET_REGISTRY_START_BLOCK?: string
+  readonly VITE_BASE_FACTORY_START_BLOCK?: string
+  readonly VITE_BASE_REGISTRY_START_BLOCK?: string
+  readonly VITE_ARBITRUM_FACTORY_START_BLOCK?: string
+  readonly VITE_ARBITRUM_REGISTRY_START_BLOCK?: string
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #144.

Public Sepolia RPCs truncate or rate-limit a single Factory/Registry `eth_getLogs` from block 0. Recents in `localStorage` die on a new browser. A creator who deployed yesterday could open the app and see an empty Mine list.

Rebased onto `main` (through #157). Still relevant: #144 is open, and `useMyChambers` on `main` is still getLogs-from-0 + 100k lookback + recents.

## Chosen indexer

**[loreum-org/chamber-indexer](https://github.com/loreum-org/chamber-indexer)** (Ponder 0.8). Dual discovery is already on that repo’s `main`: Registry always, Factory when `PONDER_FACTORY_ADDRESS` is set. GraphQL `chambers` / `chamberHolders` = creator **OR** current share balance.

Set on the app host:

```bash
VITE_INDEXER_URL=https://your-ponder-host.example
# optional; default 11155111 (Sepolia-only indexer today)
# VITE_INDEXER_CHAIN_ID=11155111
```

The app POSTs `MyChambers` to `{VITE_INDEXER_URL}/graphql`. A live Ponder host is **not** required to merge this PR.

## Fallback (no host / indexer down)

Chunked Factory / Registry `ChamberCreated` `eth_getLogs` on the production RPC (Alchemy when `VITE_ALCHEMY_API_KEY` is set):

1. Try the full start→latest range once (works on archive RPCs when the result set is small).
2. On range errors, probe a legal chunk size and page with bounded concurrency. **Not** one getLogs-from-0.
3. Sepolia start defaults to **7453704** (same as the indexer). Override with `VITE_SEPOLIA_FACTORY_START_BLOCK` / `VITE_SEPOLIA_REGISTRY_START_BLOCK`.
4. After a successful indexer query, only a ~2 day catch-up window is scanned for lag.
5. Registry leftover events have no creator field; the fallback recovers `tx.from` so creators still match after clearing recents.

Factory remains the source of **creation events**. Registry `getChambers` / world-list is not used.

## What still works

- **Open-by-address** + recents (`localStorage`) unchanged.
- **Factory-unset / Registry-only** still lists Registry-created chambers (indexer and/or Registry logs).
- Directors stay on-chain (`getDirectors` multicall). The indexer does not reconstruct the board.

## Verify

```bash
cd app
npx tsc --noEmit
npm run test:discovery
```

Live Sepolia check (Tenderly public RPC, no `localStorage`, range-limited pagination around the known log): Registry chamber `0x0Ad3205eCfA76cDb52bE5EbE099b990c35489888` created at block **7453727** (~4.1M blocks / well over 48h ago) is still discovered. Factory-unset still returns it.

## Out of scope

- Hosting Ponder
- Deleting or in-place-upgrading Registry
- Beacon proxies
- New on-chain world directory

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5797f15-31b9-4283-8f71-e84e7f3b3fb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5797f15-31b9-4283-8f71-e84e7f3b3fb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

