### PR TITLE
feat(operator): Chamber SDK/CLI for board, delegate, submit, confirm, execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ For detailed documentation, visit [docs.loreum.org](https://docs.loreum.org)
 - Twitter: [@loreumdao](https://twitter.com/loreumdao)
 - GitHub: [loreum-org](https://github.com/loreum-org)
 
+## Operator SDK / CLI
+
+The React app is the human operator surface. Agents cannot click `TransactionQueue`. Use [`packages/operator`](./packages/operator) — same Chamber ABI as `contracts/generated-abis.ts`, no second contract API. See [#146](https://github.com/loreum-org/chamber/issues/146).
+
+```bash
+# Anvil end-to-end (Foundry: anvil + forge)
+cd packages/operator
+npm install
+npm run example:anvil
+```
+
+That run reads board + quorum, delegates, then `submitTransaction` / `confirm` / `execute`. Reverts for seating delay, pause, expired nonce, and not-a-director print the same copy as the app (`Your seat is not mature yet`, `This chamber is paused`, `This transaction has expired`, `You are not a director`).
+
+Library / CLI details: [`packages/operator/README.md`](./packages/operator/README.md).
+
 ## License
 
 MIT License

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -238,3 +238,16 @@ call :; cast call ${address} ${method} ${args} \
 	--rpc-url ${rpc} \
 	--private-key ${private}
 
+# Typed operator CLI (same Chamber ABI as the app). See packages/operator.
+# Example: make operator-board CHAMBER=0x...
+OPERATOR_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../packages/operator)
+OPERATOR_RPC ?= $(ANVIL_RPC)
+OPERATOR_KEY ?= 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+operator-board :
+	@test -n "$(CHAMBER)" || (echo 'Set CHAMBER=0x...'; exit 1)
+	cd $(OPERATOR_DIR) && npx --yes tsx src/cli.ts board --rpc $(OPERATOR_RPC) --chamber $(CHAMBER)
+
+operator-e2e :
+	cd $(OPERATOR_DIR) && npm run example:anvil
+

--- a/packages/operator/README.md
+++ b/packages/operator/README.md
@@ -1,0 +1,105 @@
+# `@loreum/chamber-operator`
+
+Typed operator surface for Chamber. Agents cannot click `TransactionQueue`; this package calls the same functions the React app already uses, through `contracts/generated-abis.ts`.
+
+Implements [loreum-org/chamber#146](https://github.com/loreum-org/chamber/issues/146).
+
+## What it does
+
+Given RPC + a signer + a chamber address:
+
+| Action | Chamber function |
+| --- | --- |
+| Read board + quorum | `getTop`, `getSeats`, `getQuorum`, `getDirectors`, `getSeatedAt`, `paused` |
+| Delegate | `delegate` |
+| Submit | `submitTransaction` |
+| Confirm | `confirmTransaction` |
+| Execute | `executeTransaction` |
+
+Signer is a private key, a viem `Account`, or a prebuilt `WalletClient` (including a 4337 smart-account client whose `writeContract` submits a user operation). This package does not ship a bundler or paymaster.
+
+Failures decode to the same copy the app already shows:
+
+| Revert | App copy |
+| --- | --- |
+| `DirectorNotSeated` | Your seat is not mature yet |
+| `EnforcedPause` | This chamber is paused |
+| `TransactionExpired` | This transaction has expired |
+| `NotDirector` | You are not a director |
+
+## Library
+
+```ts
+import { createOperator } from '@loreum/chamber-operator'
+
+const op = await createOperator({
+  rpcUrl: process.env.RPC_URL!,
+  chamber: '0x…',
+  signer: { type: 'privateKey', privateKey: process.env.PRIVATE_KEY as `0x${string}` },
+})
+
+const board = await op.getBoard()
+await op.delegate(1n, 10n ** 18n)
+const { nonce } = await op.submitTransaction({
+  tokenId: 1n,
+  target: '0x…',
+  value: 0n,
+  data: '0x',
+})
+await op.confirm(2n, nonce)
+await op.execute(1n, nonce, '0x')
+```
+
+4337 signer:
+
+```ts
+const op = await createOperator({
+  rpcUrl,
+  chamber,
+  signer: { type: 'walletClient', walletClient: smartAccountClient },
+})
+```
+
+## CLI
+
+```bash
+cd packages/operator && npm install
+
+export CHAMBER_RPC=http://127.0.0.1:8545
+export CHAMBER=0x…
+export PRIVATE_KEY=0x…
+
+npx chamber-operator board --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
+npx chamber-operator quorum --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
+npx chamber-operator delegate --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --amount 1ether
+npx chamber-operator submit --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --target 0x… --value 0 --data 0x
+npx chamber-operator confirm --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 2 --nonce 0
+npx chamber-operator execute --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --nonce 0 --data 0x
+```
+
+## Anvil end-to-end
+
+Requires Foundry (`anvil`, `forge`). From `packages/operator`:
+
+```bash
+npm install
+npm run example:anvil
+```
+
+That script starts Anvil if needed, runs `DeployAllAnvil`, creates a 3-seat chamber, then:
+
+1. Delegates from two directors and shows a pending board
+2. `submit` before the seating delay → `Your seat is not mature yet`
+3. Mines one block (`SEATING_DELAY = 1`)
+4. `submit` → `confirm` → `execute`
+5. A third key `confirm` → `You are not a director`
+6. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
+7. Board `pause()` then `execute` → `This chamber is paused`
+
+## Out of scope
+
+Sensor Hub, Agent Hub, a new subgraph, and a production agent runtime. No new Solidity.

--- a/packages/operator/bin/chamber-operator.mjs
+++ b/packages/operator/bin/chamber-operator.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { register } from 'tsx/esm/api'
+
+register()
+await import(new URL('../src/cli.ts', import.meta.url))

--- a/packages/operator/examples/anvil-e2e.ts
+++ b/packages/operator/examples/anvil-e2e.ts
@@ -1,0 +1,360 @@
+/**
+ * One-shot Anvil walkthrough of the operator surface.
+ *
+ * Prerequisites: `anvil` and `forge` on PATH (Foundry).
+ * From `packages/operator`: `npm run example:anvil`
+ *
+ * Spawns a fresh Anvil, deploys Registry/Factory/mocks, creates a 3-seat
+ * chamber, then exercises board/quorum/delegate/submit/confirm/execute and
+ * the four app-mapped failure strings.
+ */
+import { spawn, type ChildProcess } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  type Address,
+  type Hex,
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  encodeFunctionData,
+  http,
+  parseEther,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { chamberAbi, factoryAbi, mockERC20Abi, mockERC721Abi } from '../src/abi.ts'
+import { createOperator } from '../src/client.ts'
+import { CHAMBER_ERROR_MESSAGES, formatChamberError } from '../src/errors.ts'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const CONTRACTS = join(ROOT, 'contracts')
+const RPC = process.env.CHAMBER_RPC ?? 'http://127.0.0.1:8545'
+const ANVIL_KEY0 = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const
+const ANVIL_KEY1 = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' as const
+const ANVIL_KEY2 = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a' as const
+
+type Deployments = {
+  factory: Address
+  mockERC20: Address
+  mockERC721: Address
+}
+
+function log(step: string, extra?: unknown): void {
+  if (extra === undefined) {
+    console.log(`\n==> ${step}`)
+    return
+  }
+  console.log(`\n==> ${step}`)
+  console.log(typeof extra === 'string' ? extra : JSON.stringify(extra, (_k, v) => (typeof v === 'bigint' ? v.toString() : v), 2))
+}
+
+async function waitForRpc(url: string, timeoutMs = 20_000): Promise<void> {
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const client = createPublicClient({ transport: http(url) })
+      await client.getBlockNumber()
+      return
+    } catch {
+      await new Promise((r) => setTimeout(r, 200))
+    }
+  }
+  throw new Error(`RPC ${url} did not become ready`)
+}
+
+async function rpcReady(url: string): Promise<boolean> {
+  try {
+    const client = createPublicClient({ transport: http(url) })
+    await client.getBlockNumber()
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function startAnvil(): Promise<ChildProcess | undefined> {
+  if (await rpcReady(RPC)) {
+    log('Using existing Anvil', RPC)
+    return undefined
+  }
+  log('Starting Anvil')
+  const child = spawn(
+    'anvil',
+    ['--chain-id', '31337', '-m', 'test test test test test test test test test test test junk'],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+  child.stderr?.on('data', (buf: Buffer) => {
+    const text = buf.toString()
+    if (text.toLowerCase().includes('error')) process.stderr.write(text)
+  })
+  await waitForRpc(RPC)
+  return child
+}
+
+function run(cmd: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: 'inherit' })
+    child.on('exit', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}`))
+    })
+  })
+}
+
+async function readDeployments(): Promise<Deployments> {
+  const raw = JSON.parse(await readFile(join(CONTRACTS, 'deployments.json'), 'utf8')) as {
+    factory?: string
+    mockERC20?: string
+    mockERC721?: string
+  }
+  if (!raw.factory || !raw.mockERC20 || !raw.mockERC721) {
+    throw new Error('contracts/deployments.json missing factory/mockERC20/mockERC721 — run make setup-local')
+  }
+  return {
+    factory: raw.factory as Address,
+    mockERC20: raw.mockERC20 as Address,
+    mockERC721: raw.mockERC721 as Address,
+  }
+}
+
+async function expectMessage(label: string, expected: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn()
+    throw new Error(`${label}: expected failure "${expected}" but call succeeded`)
+  } catch (error) {
+    const message = formatChamberError(error)
+    if (message !== expected) {
+      throw new Error(`${label}: expected "${expected}", got "${message}"`)
+    }
+    log(`${label} → ${message}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const spawned = await startAnvil()
+  try {
+    log('Deploy Registry, Factory, mocks')
+    await run(
+      'forge',
+      [
+        'script',
+        'script/DeployAllAnvil.s.sol:DeployAllAnvil',
+        '--rpc-url',
+        RPC,
+        '--private-key',
+        ANVIL_KEY0,
+        '--broadcast',
+        '--slow',
+      ],
+      CONTRACTS,
+    )
+
+    const deployments = await readDeployments()
+    const publicClient = createPublicClient({ transport: http(RPC) })
+    const admin = privateKeyToAccount(ANVIL_KEY0)
+    const directorB = privateKeyToAccount(ANVIL_KEY1)
+    const outsider = privateKeyToAccount(ANVIL_KEY2)
+    const wallet = createWalletClient({ account: admin, transport: http(RPC) })
+
+    const createHash = await wallet.writeContract({
+      address: deployments.factory,
+      abi: factoryAbi,
+      functionName: 'createChamber',
+      args: [deployments.mockERC20, deployments.mockERC721, 3n, 'Operator Demo', 'OPDEMO'],
+      account: admin,
+      chain: null,
+    })
+    const createReceipt = await publicClient.waitForTransactionReceipt({ hash: createHash })
+    let chamber: Address | undefined
+    for (const logItem of createReceipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: factoryAbi,
+          data: logItem.data,
+          topics: logItem.topics,
+        })
+        if (decoded.eventName === 'ChamberCreated') {
+          chamber = (decoded.args as { chamber: Address }).chamber
+        }
+      } catch {
+        // skip
+      }
+    }
+    if (!chamber) throw new Error('ChamberCreated not found')
+    log('Chamber', chamber)
+
+    await wallet.writeContract({
+      address: deployments.mockERC721,
+      abi: mockERC721Abi,
+      functionName: 'mintWithTokenId',
+      args: [admin.address, 1n],
+      account: admin,
+      chain: null,
+    })
+    await wallet.writeContract({
+      address: deployments.mockERC721,
+      abi: mockERC721Abi,
+      functionName: 'mintWithTokenId',
+      args: [directorB.address, 2n],
+      account: admin,
+      chain: null,
+    })
+
+    const deposit = parseEther('1000')
+    for (const to of [admin.address, directorB.address] as const) {
+      await wallet.writeContract({
+        address: deployments.mockERC20,
+        abi: mockERC20Abi,
+        functionName: 'mint',
+        args: [to, deposit],
+        account: admin,
+        chain: null,
+      })
+    }
+
+    const opA = await createOperator({
+      rpcUrl: RPC,
+      chamber,
+      signer: { type: 'privateKey', privateKey: ANVIL_KEY0 },
+    })
+    const opB = await createOperator({
+      rpcUrl: RPC,
+      chamber,
+      signer: { type: 'privateKey', privateKey: ANVIL_KEY1 },
+    })
+    const opOutsider = await createOperator({
+      rpcUrl: RPC,
+      chamber,
+      signer: { type: 'privateKey', privateKey: ANVIL_KEY2 },
+    })
+
+    const asset = await publicClient.readContract({
+      address: chamber,
+      abi: chamberAbi,
+      functionName: 'asset',
+    })
+    for (const [key, who] of [
+      [ANVIL_KEY0, admin.address],
+      [ANVIL_KEY1, directorB.address],
+    ] as const) {
+      const account = privateKeyToAccount(key)
+      const w = createWalletClient({ account, transport: http(RPC) })
+      await w.writeContract({
+        address: asset,
+        abi: mockERC20Abi,
+        functionName: 'approve',
+        args: [chamber, deposit],
+        account,
+        chain: null,
+      })
+      await w.writeContract({
+        address: chamber,
+        abi: chamberAbi,
+        functionName: 'deposit',
+        args: [deposit, who],
+        account,
+        chain: null,
+      })
+    }
+
+    log('delegate (both directors)')
+    await opA.delegate(1n, deposit)
+    await opB.delegate(2n, deposit)
+
+    log('board immediately after delegate (seating pending)')
+    const pendingBoard = await opA.getBoard()
+    log('board', pendingBoard)
+    log('quorum', { quorum: (await opA.getQuorum()).toString() })
+
+    await expectMessage('seating delay on submit', CHAMBER_ERROR_MESSAGES.DirectorNotSeated, () =>
+      opA.submitTransaction({
+        tokenId: 1n,
+        target: outsider.address,
+        value: 0n,
+        data: '0x',
+      }),
+    )
+
+    log('mine one block (SEATING_DELAY = 1)')
+    await publicClient.request({ method: 'evm_mine' as never, params: [] as never })
+
+    const readyBoard = await opA.getBoard()
+    if (!readyBoard.members.every((m) => m.seatingMature)) {
+      throw new Error('expected seating to be mature after evm_mine')
+    }
+    log('board after seating', readyBoard)
+
+    const submitted = await opA.submitTransaction({
+      tokenId: 1n,
+      target: outsider.address,
+      value: 0n,
+      data: '0x',
+    })
+    log('submitTransaction', { nonce: submitted.nonce.toString(), hash: submitted.hash })
+
+    await expectMessage('not-a-director on confirm', CHAMBER_ERROR_MESSAGES.NotDirector, () =>
+      opOutsider.confirm(1n, submitted.nonce),
+    )
+
+    const confirmed = await opB.confirm(2n, submitted.nonce)
+    log('confirm', { hash: confirmed.hash })
+
+    const executed = await opA.execute(1n, submitted.nonce, '0x')
+    log('execute', { hash: executed.hash })
+
+    const now = await publicClient.getBlock().then((b) => b.timestamp)
+    const expiring = await opA.submitTransaction({
+      tokenId: 1n,
+      target: outsider.address,
+      value: 0n,
+      data: '0x',
+      deadline: now + 2n,
+    })
+    log('submit with short deadline', { nonce: expiring.nonce.toString(), deadline: (now + 2n).toString() })
+    await publicClient.request({
+      method: 'evm_increaseTime' as never,
+      params: [5] as never,
+    })
+    await publicClient.request({ method: 'evm_mine' as never, params: [] as never })
+    await expectMessage('expired nonce on confirm', CHAMBER_ERROR_MESSAGES.TransactionExpired, () =>
+      opB.confirm(2n, expiring.nonce),
+    )
+
+    const pauseData = encodeFunctionData({ abi: chamberAbi, functionName: 'pause' })
+    const pauseSubmit = await opA.submitTransaction({
+      tokenId: 1n,
+      target: chamber,
+      value: 0n,
+      data: pauseData as Hex,
+    })
+    await opB.confirm(2n, pauseSubmit.nonce)
+    await opA.execute(1n, pauseSubmit.nonce, pauseData)
+    log('executed pause()')
+
+    const afterPause = await opA.getBoard()
+    if (!afterPause.paused) throw new Error('expected chamber to be paused')
+
+    const pausedTx = await opA.submitTransaction({
+      tokenId: 1n,
+      target: outsider.address,
+      value: 0n,
+      data: '0x',
+    })
+    await opB.confirm(2n, pausedTx.nonce)
+    await expectMessage('pause on execute', CHAMBER_ERROR_MESSAGES.EnforcedPause, () =>
+      opA.execute(1n, pausedTx.nonce, '0x'),
+    )
+
+    log('done — board, quorum, delegate, submit, confirm, execute, and the four app error strings')
+  } finally {
+    if (spawned) {
+      spawned.kill('SIGTERM')
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : error)
+  process.exitCode = 1
+})

--- a/packages/operator/examples/anvil-e2e.ts
+++ b/packages/operator/examples/anvil-e2e.ts
@@ -118,6 +118,26 @@ async function readDeployments(): Promise<Deployments> {
   }
 }
 
+async function rpc(method: string, params: unknown[] = []): Promise<unknown> {
+  const res = await fetch(RPC, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  const json = (await res.json()) as { result?: unknown; error?: { message?: string } }
+  if (json.error?.message) throw new Error(`${method}: ${json.error.message}`)
+  return json.result
+}
+
+async function mine(blocks = 1): Promise<void> {
+  await rpc('anvil_mine', [`0x${blocks.toString(16)}`])
+}
+
+async function increaseTime(seconds: number): Promise<void> {
+  await rpc('evm_increaseTime', [seconds])
+  await mine(1)
+}
+
 async function expectMessage(label: string, expected: string, fn: () => Promise<unknown>): Promise<void> {
   try {
     await fn()
@@ -267,21 +287,29 @@ async function main(): Promise<void> {
     log('board', pendingBoard)
     log('quorum', { quorum: (await opA.getQuorum()).toString() })
 
+    const pending = pendingBoard.members.find((m) => !m.seatingMature)
+    if (!pending) {
+      throw new Error('expected at least one director to still be inside the seating delay')
+    }
+    const pendingOp = pending.tokenId === 2n ? opB : opA
     await expectMessage('seating delay on submit', CHAMBER_ERROR_MESSAGES.DirectorNotSeated, () =>
-      opA.submitTransaction({
-        tokenId: 1n,
+      pendingOp.submitTransaction({
+        tokenId: pending.tokenId,
         target: outsider.address,
         value: 0n,
         data: '0x',
       }),
     )
 
-    log('mine one block (SEATING_DELAY = 1)')
-    await publicClient.request({ method: 'evm_mine' as never, params: [] as never })
-
+    log('mine until seating is mature (SEATING_DELAY = 1)')
+    for (let i = 0; i < 4; i++) {
+      const board = await opA.getBoard()
+      if (board.members.every((m) => m.seatingMature)) break
+      await mine(1)
+    }
     const readyBoard = await opA.getBoard()
     if (!readyBoard.members.every((m) => m.seatingMature)) {
-      throw new Error('expected seating to be mature after evm_mine')
+      throw new Error('expected seating to be mature after mining')
     }
     log('board after seating', readyBoard)
 
@@ -312,11 +340,7 @@ async function main(): Promise<void> {
       deadline: now + 2n,
     })
     log('submit with short deadline', { nonce: expiring.nonce.toString(), deadline: (now + 2n).toString() })
-    await publicClient.request({
-      method: 'evm_increaseTime' as never,
-      params: [5] as never,
-    })
-    await publicClient.request({ method: 'evm_mine' as never, params: [] as never })
+    await increaseTime(5)
     await expectMessage('expired nonce on confirm', CHAMBER_ERROR_MESSAGES.TransactionExpired, () =>
       opB.confirm(2n, expiring.nonce),
     )

--- a/packages/operator/package-lock.json
+++ b/packages/operator/package-lock.json
@@ -1,0 +1,779 @@
+{
+  "name": "@loreum/chamber-operator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@loreum/chamber-operator",
+      "version": "0.1.0",
+      "dependencies": {
+        "viem": "^2.21.0"
+      },
+      "bin": {
+        "chamber-operator": "bin/chamber-operator.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.34",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.34.tgz",
+      "integrity": "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.56.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.56.0.tgz",
+      "integrity": "sha512-JmkgIk4jN+im4oguLxwPv19pwSaGH9kcGSq25Ilm55106ULBBMNR3eWKKA0wZoeyLPSHIiOwZ4sGceEYEIq7LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.34",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/operator/package.json
+++ b/packages/operator/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@loreum/chamber-operator",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Typed Chamber operator surface for agents: board, quorum, delegate, submit, confirm, execute.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "chamber-operator": "./bin/chamber-operator.mjs"
+  },
+  "scripts": {
+    "chamber-operator": "tsx src/cli.ts",
+    "test": "tsx --test test/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "example:anvil": "tsx examples/anvil-e2e.ts"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/operator/src/abi.ts
+++ b/packages/operator/src/abi.ts
@@ -1,0 +1,10 @@
+/**
+ * Re-export the generated Chamber ABI. Do not invent a second contract API.
+ * Source of truth: `contracts/generated-abis.ts` (`make sync-abis`).
+ */
+export {
+  chamberAbi,
+  factoryAbi,
+  mockERC20Abi,
+  mockERC721Abi,
+} from '../../../contracts/generated-abis.ts'

--- a/packages/operator/src/cli.ts
+++ b/packages/operator/src/cli.ts
@@ -1,0 +1,198 @@
+import { type Address, type Hex, isAddress, isHex, parseEther } from 'viem'
+import { createOperator } from './client.ts'
+import { ChamberOperatorError } from './errors.ts'
+
+const USAGE = `chamber-operator — typed Chamber board / queue actions (same ABI as the app)
+
+Usage:
+  chamber-operator <command> [options]
+
+Commands:
+  board                 Read board seats, quorum, pause, and seating
+  quorum                Read live quorum
+  tx --nonce <n>        Read one queued nonce
+  delegate              Delegate vault shares to a membership tokenId
+  submit                submitTransaction (director)
+  confirm               confirmTransaction (director)
+  execute               executeTransaction (director)
+
+Required (or env):
+  --rpc <url>           RPC_URL / CHAMBER_RPC
+  --chamber <addr>      CHAMBER
+  --key <hex>           PRIVATE_KEY / CHAMBER_KEY   (writes only)
+
+Writes:
+  --token-id <n>
+  --amount <wei|ether>  delegate amount (1ether or raw wei)
+  --target <addr>       submit target
+  --value <wei|ether>   submit ETH value (default 0)
+  --data <hex>          submit / execute calldata (default 0x)
+  --deadline <unix>     optional submit deadline
+  --nonce <n>           confirm / execute / tx
+
+A 4337 smart-account client is supported from the library API
+(createOperator({ signer: { type: 'walletClient', walletClient } })),
+not from this CLI.
+
+Exit status is non-zero on revert. Seating delay, pause, expired nonce,
+and not-a-director use the same copy as the React app.
+`
+
+type Flags = Record<string, string | boolean>
+
+function parseArgs(argv: string[]): { command: string; flags: Flags } {
+  const [command, ...rest] = argv
+  if (!command || command === '-h' || command === '--help') {
+    return { command: 'help', flags: {} }
+  }
+  const flags: Flags = {}
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i]
+    if (!token.startsWith('--')) {
+      throw new ChamberOperatorError(`Unexpected argument: ${token}`)
+    }
+    const key = token.slice(2)
+    const next = rest[i + 1]
+    if (next === undefined || next.startsWith('--')) {
+      flags[key] = true
+      continue
+    }
+    flags[key] = next
+    i++
+  }
+  return { command, flags }
+}
+
+function flag(flags: Flags, name: string, envNames: string[] = []): string | undefined {
+  const raw = flags[name]
+  if (typeof raw === 'string' && raw.length > 0) return raw
+  for (const envName of envNames) {
+    const value = process.env[envName]
+    if (value) return value
+  }
+  return undefined
+}
+
+function requireFlag(flags: Flags, name: string, envNames: string[] = []): string {
+  const value = flag(flags, name, envNames)
+  if (!value) {
+    throw new ChamberOperatorError(
+      `Missing --${name}${envNames.length ? ` (or ${envNames.join('/')})` : ''}`,
+    )
+  }
+  return value
+}
+
+function requireAddress(value: string, label: string): Address {
+  if (!isAddress(value)) throw new ChamberOperatorError(`Invalid ${label}: ${value}`)
+  return value
+}
+
+function parseAmount(raw: string): bigint {
+  const trimmed = raw.trim()
+  if (/^\d+$/.test(trimmed)) return BigInt(trimmed)
+  if (trimmed.endsWith('ether')) return parseEther(trimmed.slice(0, -5))
+  if (trimmed.endsWith('wei')) return BigInt(trimmed.slice(0, -3))
+  try {
+    return parseEther(trimmed)
+  } catch {
+    throw new ChamberOperatorError(`Invalid amount: ${raw}`)
+  }
+}
+
+function parseUint(raw: string, label: string): bigint {
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new ChamberOperatorError(`Invalid ${label}: ${raw}`)
+  }
+  return BigInt(raw.trim())
+}
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, jsonReplacer, 2)}\n`)
+}
+
+async function main(): Promise<void> {
+  const { command, flags } = parseArgs(process.argv.slice(2))
+  if (command === 'help') {
+    process.stdout.write(USAGE)
+    return
+  }
+
+  const rpcUrl = requireFlag(flags, 'rpc', ['CHAMBER_RPC', 'RPC_URL'])
+  const chamber = requireAddress(requireFlag(flags, 'chamber', ['CHAMBER']), 'chamber')
+  const key = flag(flags, 'key', ['CHAMBER_KEY', 'PRIVATE_KEY'])
+
+  const operator = await createOperator({
+    rpcUrl,
+    chamber,
+    signer: key
+      ? { type: 'privateKey', privateKey: (key.startsWith('0x') ? key : `0x${key}`) as Hex }
+      : undefined,
+  })
+
+  switch (command) {
+    case 'board': {
+      printJson(await operator.getBoard())
+      return
+    }
+    case 'quorum': {
+      printJson({ quorum: await operator.getQuorum() })
+      return
+    }
+    case 'tx': {
+      const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
+      printJson(await operator.getTransaction(nonce))
+      return
+    }
+    case 'delegate': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const amount = parseAmount(requireFlag(flags, 'amount'))
+      printJson(await operator.delegate(tokenId, amount))
+      return
+    }
+    case 'submit': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const target = requireAddress(requireFlag(flags, 'target'), 'target')
+      const valueRaw = flag(flags, 'value')
+      const data = flag(flags, 'data') ?? '0x'
+      if (!isHex(data)) throw new ChamberOperatorError(`Invalid --data: ${data}`)
+      const deadlineRaw = flag(flags, 'deadline')
+      printJson(
+        await operator.submitTransaction({
+          tokenId,
+          target,
+          value: valueRaw ? parseAmount(valueRaw) : 0n,
+          data,
+          deadline: deadlineRaw ? parseUint(deadlineRaw, 'deadline') : undefined,
+        }),
+      )
+      return
+    }
+    case 'confirm': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
+      printJson(await operator.confirm(tokenId, nonce))
+      return
+    }
+    case 'execute': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
+      const data = flag(flags, 'data') ?? '0x'
+      if (!isHex(data)) throw new ChamberOperatorError(`Invalid --data: ${data}`)
+      printJson(await operator.execute(tokenId, nonce, data))
+      return
+    }
+    default:
+      throw new ChamberOperatorError(`Unknown command: ${command}\n\n${USAGE}`)
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`${message}\n`)
+  process.exitCode = 1
+})

--- a/packages/operator/src/client.ts
+++ b/packages/operator/src/client.ts
@@ -128,6 +128,7 @@ export class ChamberOperator {
     const publicClient = createPublicClient({
       chain,
       transport: http(options.rpcUrl),
+      cacheTime: 0,
     })
 
     let account: Account | undefined

--- a/packages/operator/src/client.ts
+++ b/packages/operator/src/client.ts
@@ -1,0 +1,420 @@
+import {
+  type Account,
+  type Address,
+  type Chain,
+  type Hex,
+  type PublicClient,
+  type TransactionReceipt,
+  type WalletClient,
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  defineChain,
+  http,
+  isHex,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { chamberAbi } from './abi.ts'
+import { ChamberOperatorError, wrapChamberError } from './errors.ts'
+import { isSeatingMature } from './seating.ts'
+
+export type { Account, Address, Hex, PublicClient, WalletClient }
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const
+
+export type OperatorSigner =
+  | { type: 'privateKey'; privateKey: Hex }
+  | { type: 'account'; account: Account }
+  | { type: 'walletClient'; walletClient: WalletClient }
+
+export type CreateOperatorOptions = {
+  rpcUrl: string
+  chamber: Address
+  /** EOA key, viem Account, or a prebuilt wallet client (including a 4337 smart-account client). */
+  signer?: OperatorSigner
+  chain?: Chain
+}
+
+export type BoardMember = {
+  tokenId: bigint
+  amount: bigint
+  rank: number
+  director?: Address
+  seatedAt: bigint
+  seatingMature: boolean
+}
+
+export type BoardSnapshot = {
+  chamber: Address
+  name?: string
+  symbol?: string
+  seats: bigint
+  quorum: bigint
+  paused: boolean
+  blockNumber: bigint
+  members: BoardMember[]
+}
+
+export type TransactionSnapshot = {
+  nonce: bigint
+  executed: boolean
+  confirmations: number
+  target: Address
+  value: bigint
+  dataHash: Hex
+  expired: boolean
+  deadline: bigint
+  requiredQuorum: bigint
+}
+
+export type WriteResult = {
+  hash: Hex
+  receipt: TransactionReceipt
+}
+
+export type SubmitResult = WriteResult & { nonce: bigint }
+
+function assertAddress(value: string, label: string): Address {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
+    throw new ChamberOperatorError(`Invalid ${label} address: ${value}`)
+  }
+  return value as Address
+}
+
+function toHexData(data: string | Hex | undefined): Hex {
+  if (data == null || data === '') return '0x'
+  if (!isHex(data)) {
+    throw new ChamberOperatorError(`Invalid hex data: ${data}`)
+  }
+  return data
+}
+
+async function resolveChain(rpcUrl: string, explicit?: Chain): Promise<Chain> {
+  if (explicit) return explicit
+  const probe = createPublicClient({ transport: http(rpcUrl) })
+  const chainId = await probe.getChainId()
+  return defineChain({
+    id: chainId,
+    name: `chain-${chainId}`,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] } },
+  })
+}
+
+export class ChamberOperator {
+  readonly rpcUrl: string
+  readonly chamber: Address
+  readonly publicClient: PublicClient
+  readonly walletClient?: WalletClient
+  readonly account?: Account
+
+  private constructor(opts: {
+    rpcUrl: string
+    chamber: Address
+    publicClient: PublicClient
+    walletClient?: WalletClient
+    account?: Account
+  }) {
+    this.rpcUrl = opts.rpcUrl
+    this.chamber = opts.chamber
+    this.publicClient = opts.publicClient
+    this.walletClient = opts.walletClient
+    this.account = opts.account
+  }
+
+  static async create(options: CreateOperatorOptions): Promise<ChamberOperator> {
+    const chamber = assertAddress(options.chamber, 'chamber')
+    const chain = await resolveChain(options.rpcUrl, options.chain)
+    const publicClient = createPublicClient({
+      chain,
+      transport: http(options.rpcUrl),
+    })
+
+    let account: Account | undefined
+    let walletClient: WalletClient | undefined
+
+    if (options.signer?.type === 'walletClient') {
+      walletClient = options.signer.walletClient
+      account = walletClient.account
+    } else if (options.signer?.type === 'account') {
+      account = options.signer.account
+      walletClient = createWalletClient({
+        account,
+        chain,
+        transport: http(options.rpcUrl),
+      })
+    } else if (options.signer?.type === 'privateKey') {
+      account = privateKeyToAccount(options.signer.privateKey)
+      walletClient = createWalletClient({
+        account,
+        chain,
+        transport: http(options.rpcUrl),
+      })
+    }
+
+    return new ChamberOperator({
+      rpcUrl: options.rpcUrl,
+      chamber,
+      publicClient,
+      walletClient,
+      account,
+    })
+  }
+
+  private requireWallet(): { walletClient: WalletClient; account: Account } {
+    if (!this.walletClient || !this.account) {
+      throw new ChamberOperatorError(
+        'A signer is required for writes. Pass a private key, viem Account, or 4337 wallet client.',
+      )
+    }
+    return { walletClient: this.walletClient, account: this.account }
+  }
+
+  private async write<
+    TFunctionName extends
+      | 'delegate'
+      | 'confirmTransaction'
+      | 'executeTransaction'
+      | 'submitTransaction',
+  >(
+    functionName: TFunctionName,
+    args: readonly unknown[],
+  ): Promise<WriteResult> {
+    const { walletClient, account } = this.requireWallet()
+    try {
+      await this.publicClient.simulateContract({
+        address: this.chamber,
+        abi: chamberAbi,
+        functionName,
+        args: args as never,
+        account,
+      })
+      const hash = await walletClient.writeContract({
+        address: this.chamber,
+        abi: chamberAbi,
+        functionName,
+        args: args as never,
+        account,
+        chain: walletClient.chain ?? null,
+      } as never)
+      const receipt = await this.publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new ChamberOperatorError('Transaction failed')
+      }
+      return { hash, receipt }
+    } catch (error) {
+      throw wrapChamberError(error)
+    }
+  }
+
+  async getQuorum(): Promise<bigint> {
+    try {
+      return await this.publicClient.readContract({
+        address: this.chamber,
+        abi: chamberAbi,
+        functionName: 'getQuorum',
+      })
+    } catch (error) {
+      throw wrapChamberError(error, 'Failed to read quorum')
+    }
+  }
+
+  async getBoard(count?: bigint): Promise<BoardSnapshot> {
+    try {
+      const [seats, quorum, paused, blockNumber, name, symbol] = await Promise.all([
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getSeats',
+        }),
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getQuorum',
+        }),
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'paused',
+        }),
+        this.publicClient.getBlockNumber(),
+        this.publicClient
+          .readContract({
+            address: this.chamber,
+            abi: chamberAbi,
+            functionName: 'name',
+          })
+          .catch(() => undefined),
+        this.publicClient
+          .readContract({
+            address: this.chamber,
+            abi: chamberAbi,
+            functionName: 'symbol',
+          })
+          .catch(() => undefined),
+      ])
+
+      const topCount = count ?? (seats > 0n ? seats : 20n)
+      const [tokenIds, amounts] = await this.publicClient.readContract({
+        address: this.chamber,
+        abi: chamberAbi,
+        functionName: 'getTop',
+        args: [topCount],
+      })
+
+      let directors: readonly Address[] = []
+      try {
+        directors = await this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getDirectors',
+        })
+      } catch {
+        directors = []
+      }
+
+      const seatedAtList = await Promise.all(
+        tokenIds.map((tokenId) =>
+          this.publicClient.readContract({
+            address: this.chamber,
+            abi: chamberAbi,
+            functionName: 'getSeatedAt',
+            args: [tokenId],
+          }),
+        ),
+      )
+
+      const members: BoardMember[] = tokenIds.map((tokenId, i) => {
+        const seatedAt = seatedAtList[i] ?? 0n
+        const director = directors[i]
+        return {
+          tokenId,
+          amount: amounts[i] ?? 0n,
+          rank: i + 1,
+          director:
+            director && director.toLowerCase() !== ZERO_ADDRESS.toLowerCase()
+              ? director
+              : undefined,
+          seatedAt,
+          seatingMature: isSeatingMature(seatedAt, blockNumber),
+        }
+      })
+
+      return {
+        chamber: this.chamber,
+        name,
+        symbol,
+        seats,
+        quorum,
+        paused,
+        blockNumber,
+        members,
+      }
+    } catch (error) {
+      throw wrapChamberError(error, 'Failed to read board')
+    }
+  }
+
+  async getTransaction(nonce: bigint): Promise<TransactionSnapshot> {
+    try {
+      const [executed, confirmations, target, value, dataHash] =
+        await this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getTransaction',
+          args: [nonce],
+        })
+      const [expired, deadline, requiredQuorum] = await Promise.all([
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'isTransactionExpired',
+          args: [nonce],
+        }),
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getTransactionDeadline',
+          args: [nonce],
+        }),
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getTransactionRequiredQuorum',
+          args: [nonce],
+        }),
+      ])
+      return {
+        nonce,
+        executed,
+        confirmations,
+        target,
+        value,
+        dataHash,
+        expired,
+        deadline,
+        requiredQuorum,
+      }
+    } catch (error) {
+      throw wrapChamberError(error, 'Failed to read transaction')
+    }
+  }
+
+  async delegate(tokenId: bigint, amount: bigint): Promise<WriteResult> {
+    return this.write('delegate', [tokenId, amount])
+  }
+
+  async submitTransaction(args: {
+    tokenId: bigint
+    target: Address
+    value?: bigint
+    data?: Hex | string
+    deadline?: bigint
+  }): Promise<SubmitResult> {
+    const target = assertAddress(args.target, 'target')
+    const value = args.value ?? 0n
+    const data = toHexData(args.data)
+    const writeArgs =
+      args.deadline !== undefined
+        ? ([args.tokenId, target, value, data, args.deadline] as const)
+        : ([args.tokenId, target, value, data] as const)
+    const result = await this.write('submitTransaction', writeArgs)
+    return { ...result, nonce: nonceFromSubmitReceipt(result.receipt, this.chamber) }
+  }
+
+  async confirm(tokenId: bigint, nonce: bigint): Promise<WriteResult> {
+    return this.write('confirmTransaction', [tokenId, nonce])
+  }
+
+  async execute(tokenId: bigint, nonce: bigint, data: Hex | string = '0x'): Promise<WriteResult> {
+    return this.write('executeTransaction', [tokenId, nonce, toHexData(data)])
+  }
+}
+
+function nonceFromSubmitReceipt(receipt: TransactionReceipt, chamber: Address): bigint {
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== chamber.toLowerCase()) continue
+    try {
+      const decoded = decodeEventLog({
+        abi: chamberAbi,
+        data: log.data,
+        topics: log.topics,
+      })
+      if (decoded.eventName === 'TransactionSubmitted') {
+        const args = decoded.args as { transactionId?: bigint }
+        if (args.transactionId !== undefined) return args.transactionId
+      }
+      if (decoded.eventName === 'SubmitTransaction') {
+        const args = decoded.args as { nonce?: bigint }
+        if (args.nonce !== undefined) return args.nonce
+      }
+    } catch {
+      // not a matching event
+    }
+  }
+  throw new ChamberOperatorError('Submit succeeded but no TransactionSubmitted event was found')
+}
+
+export async function createOperator(options: CreateOperatorOptions): Promise<ChamberOperator> {
+  return ChamberOperator.create(options)
+}

--- a/packages/operator/src/errors.ts
+++ b/packages/operator/src/errors.ts
@@ -1,3 +1,6 @@
+import { decodeErrorResult, isHex } from 'viem'
+import { chamberAbi } from './abi.ts'
+
 /**
  * Human-readable Chamber revert copy.
  *
@@ -30,6 +33,18 @@ export const DIRECTOR_SEATING_NOT_MATURE = 'Director seating is not mature yet'
 
 const CUSTOM_ERROR_RE = /reverted with custom error '([^']+)'/
 const REASON_STRING_RE = /reverted with reason string '([^']+)'/
+const SOLIDITY_ERROR_CALL_RE = /\b([A-Z][A-Za-z0-9_]+)\(\)/
+const GENERIC_ERROR_NAMES = new Set([
+  'Error',
+  'TypeError',
+  'BaseError',
+  'CallExecutionError',
+  'ContractFunctionExecutionError',
+  'ContractFunctionRevertedError',
+  'RpcRequestError',
+  'TransactionExecutionError',
+  'UnknownRpcError',
+])
 
 function collectErrorText(error: unknown): string {
   const parts: string[] = []
@@ -47,6 +62,8 @@ function collectErrorText(error: unknown): string {
       message?: unknown
       shortMessage?: unknown
       details?: unknown
+      metaMessages?: unknown
+      data?: unknown
       walk?: (fn?: (err: unknown) => unknown) => unknown
       cause?: unknown
     }
@@ -60,14 +77,43 @@ function collectErrorText(error: unknown): string {
         // ignore walk failures; fall through to fields
       }
     }
-    if (typeof o.name === 'string') parts.push(o.name)
+    if (typeof o.name === 'string' && !GENERIC_ERROR_NAMES.has(o.name)) parts.push(o.name)
     if (typeof o.shortMessage === 'string') parts.push(o.shortMessage)
     if (typeof o.message === 'string') parts.push(o.message)
     if (typeof o.details === 'string') parts.push(o.details)
+    if (Array.isArray(o.metaMessages)) {
+      for (const line of o.metaMessages) {
+        if (typeof line === 'string') parts.push(line)
+      }
+    }
+    if (typeof o.data === 'string') parts.push(o.data)
     walk(o.cause)
   }
   walk(error)
   return parts.join('\n')
+}
+
+function decodeRevertData(error: unknown): string | undefined {
+  const seen = new Set<unknown>()
+  const walk = (value: unknown): string | undefined => {
+    if (value == null || seen.has(value)) return undefined
+    seen.add(value)
+    if (typeof value === 'string' && isHex(value) && value.length >= 10) {
+      try {
+        return decodeErrorResult({ abi: chamberAbi, data: value }).errorName
+      } catch {
+        return undefined
+      }
+    }
+    if (typeof value !== 'object') return undefined
+    const o = value as { data?: unknown; cause?: unknown }
+    if (typeof o.data === 'string') {
+      const named = walk(o.data)
+      if (named) return named
+    }
+    return walk(o.cause)
+  }
+  return walk(error)
 }
 
 function errorNameFromUnknown(error: unknown): string | undefined {
@@ -104,7 +150,7 @@ function errorNameFromUnknown(error: unknown): string | undefined {
 }
 
 export function formatChamberError(error: unknown, fallback = 'Transaction failed'): string {
-  const named = errorNameFromUnknown(error)
+  const named = errorNameFromUnknown(error) ?? decodeRevertData(error)
   if (named && named in CHAMBER_ERROR_MESSAGES) {
     return CHAMBER_ERROR_MESSAGES[named as ChamberErrorName]
   }
@@ -114,6 +160,11 @@ export function formatChamberError(error: unknown, fallback = 'Transaction faile
 
   for (const [errorName, friendly] of Object.entries(CHAMBER_ERROR_MESSAGES)) {
     if (message.includes(errorName)) return friendly
+  }
+
+  const solidityCall = message.match(SOLIDITY_ERROR_CALL_RE)
+  if (solidityCall && solidityCall[1] in CHAMBER_ERROR_MESSAGES) {
+    return CHAMBER_ERROR_MESSAGES[solidityCall[1] as ChamberErrorName]
   }
 
   const revertMatch = message.match(REASON_STRING_RE)
@@ -133,7 +184,11 @@ export function formatChamberError(error: unknown, fallback = 'Transaction faile
   if (message.includes('exceeds balance')) return 'Amount exceeds balance'
   if (message.includes('not owner')) return 'You do not own this member token'
 
-  const firstLine = message.split('\n').find((line) => line.trim().length > 0) ?? fallback
+  const firstLine =
+    message
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !GENERIC_ERROR_NAMES.has(line)) ?? fallback
   return firstLine.length > 100 ? `${firstLine.slice(0, 100)}...` : firstLine
 }
 

--- a/packages/operator/src/errors.ts
+++ b/packages/operator/src/errors.ts
@@ -1,0 +1,157 @@
+/**
+ * Human-readable Chamber revert copy.
+ *
+ * Strings match the React app so agents see the same failures TransactionQueue
+ * and DelegationManager already surface:
+ * - `DelegationManager.getErrorMessage` (`app/src/components/DelegationManager.tsx`)
+ * - `TreasuryOverview.getErrorMessage` (`app/src/components/TreasuryOverview.tsx`)
+ * - `TransactionQueue` expired / seating toasts
+ */
+export const CHAMBER_ERROR_MESSAGES = {
+  InsufficientChamberBalance: "You don't have enough shares to delegate this amount",
+  InsufficientDelegatedAmount: "You haven't delegated this much to this member",
+  ZeroTokenId: 'Token ID cannot be zero',
+  ZeroAmount: 'Amount cannot be zero',
+  InvalidTokenId: 'This member ID does not exist',
+  NotDirector: 'You are not a director',
+  DirectorNotSeated: 'Your seat is not mature yet',
+  ExceedsDelegatedAmount: 'Amount exceeds your delegated balance',
+  AssetAmountMismatch: 'Fee-on-transfer or rebasing tokens are not supported',
+  EnforcedPause: 'This chamber is paused',
+  TransactionExpired: 'This transaction has expired',
+  ERC20InsufficientAllowance: 'Token approval required',
+  ERC20InsufficientBalance: 'Insufficient token balance',
+} as const
+
+export type ChamberErrorName = keyof typeof CHAMBER_ERROR_MESSAGES
+
+/** H-02 seating copy from TransactionQueue when a live seat is not yet mature. */
+export const DIRECTOR_SEATING_NOT_MATURE = 'Director seating is not mature yet'
+
+const CUSTOM_ERROR_RE = /reverted with custom error '([^']+)'/
+const REASON_STRING_RE = /reverted with reason string '([^']+)'/
+
+function collectErrorText(error: unknown): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  const walk = (value: unknown) => {
+    if (value == null || seen.has(value)) return
+    seen.add(value)
+    if (typeof value === 'string') {
+      parts.push(value)
+      return
+    }
+    if (typeof value !== 'object') return
+    const o = value as {
+      name?: unknown
+      message?: unknown
+      shortMessage?: unknown
+      details?: unknown
+      walk?: (fn?: (err: unknown) => unknown) => unknown
+      cause?: unknown
+    }
+    if (typeof o.walk === 'function') {
+      try {
+        o.walk((err) => {
+          walk(err)
+          return undefined
+        })
+      } catch {
+        // ignore walk failures; fall through to fields
+      }
+    }
+    if (typeof o.name === 'string') parts.push(o.name)
+    if (typeof o.shortMessage === 'string') parts.push(o.shortMessage)
+    if (typeof o.message === 'string') parts.push(o.message)
+    if (typeof o.details === 'string') parts.push(o.details)
+    walk(o.cause)
+  }
+  walk(error)
+  return parts.join('\n')
+}
+
+function errorNameFromUnknown(error: unknown): string | undefined {
+  const seen = new Set<unknown>()
+  const walk = (value: unknown): string | undefined => {
+    if (value == null || seen.has(value)) return undefined
+    seen.add(value)
+    if (typeof value !== 'object') return undefined
+    const o = value as {
+      name?: unknown
+      errorName?: unknown
+      data?: { errorName?: unknown }
+      cause?: unknown
+      walk?: (fn?: (err: unknown) => unknown) => unknown
+    }
+    if (typeof o.errorName === 'string' && o.errorName) return o.errorName
+    if (typeof o.data?.errorName === 'string' && o.data.errorName) return o.data.errorName
+    if (typeof o.name === 'string' && o.name in CHAMBER_ERROR_MESSAGES) return o.name
+    if (typeof o.walk === 'function') {
+      let found: string | undefined
+      try {
+        o.walk((err) => {
+          found ??= walk(err)
+          return undefined
+        })
+      } catch {
+        // ignore
+      }
+      if (found) return found
+    }
+    return walk(o.cause)
+  }
+  return walk(error)
+}
+
+export function formatChamberError(error: unknown, fallback = 'Transaction failed'): string {
+  const named = errorNameFromUnknown(error)
+  if (named && named in CHAMBER_ERROR_MESSAGES) {
+    return CHAMBER_ERROR_MESSAGES[named as ChamberErrorName]
+  }
+
+  const message = collectErrorText(error)
+  if (!message) return fallback
+
+  for (const [errorName, friendly] of Object.entries(CHAMBER_ERROR_MESSAGES)) {
+    if (message.includes(errorName)) return friendly
+  }
+
+  const revertMatch = message.match(REASON_STRING_RE)
+  if (revertMatch) return revertMatch[1]
+
+  const customErrorMatch = message.match(CUSTOM_ERROR_RE)
+  if (customErrorMatch) {
+    const errorName = customErrorMatch[1]
+    return CHAMBER_ERROR_MESSAGES[errorName as ChamberErrorName] ?? errorName
+  }
+
+  // Same selector fallbacks as DelegationManager.
+  if (message.includes('0x1fed7fc5')) return CHAMBER_ERROR_MESSAGES.InvalidTokenId
+  if (message.includes('0xf4844814')) return "You don't have enough shares"
+
+  if (message.includes('insufficient balance')) return 'Insufficient balance'
+  if (message.includes('exceeds balance')) return 'Amount exceeds balance'
+  if (message.includes('not owner')) return 'You do not own this member token'
+
+  const firstLine = message.split('\n').find((line) => line.trim().length > 0) ?? fallback
+  return firstLine.length > 100 ? `${firstLine.slice(0, 100)}...` : firstLine
+}
+
+export class ChamberOperatorError extends Error {
+  readonly errorName?: string
+
+  constructor(message: string, options?: { cause?: unknown; errorName?: string }) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined)
+    this.name = 'ChamberOperatorError'
+    this.errorName = options?.errorName
+  }
+}
+
+export function wrapChamberError(error: unknown, fallback = 'Transaction failed'): ChamberOperatorError {
+  if (error instanceof ChamberOperatorError) return error
+  const errorName = errorNameFromUnknown(error)
+  return new ChamberOperatorError(formatChamberError(error, fallback), {
+    cause: error,
+    errorName,
+  })
+}

--- a/packages/operator/src/index.ts
+++ b/packages/operator/src/index.ts
@@ -1,0 +1,20 @@
+export { chamberAbi, factoryAbi, mockERC20Abi, mockERC721Abi } from './abi.ts'
+export {
+  ChamberOperator,
+  createOperator,
+  type BoardMember,
+  type BoardSnapshot,
+  type CreateOperatorOptions,
+  type OperatorSigner,
+  type SubmitResult,
+  type TransactionSnapshot,
+  type WriteResult,
+} from './client.ts'
+export {
+  CHAMBER_ERROR_MESSAGES,
+  ChamberOperatorError,
+  DIRECTOR_SEATING_NOT_MATURE,
+  formatChamberError,
+  wrapChamberError,
+} from './errors.ts'
+export { isSeatingMature } from './seating.ts'

--- a/packages/operator/src/seating.ts
+++ b/packages/operator/src/seating.ts
@@ -1,0 +1,17 @@
+/**
+ * H-02: seating is mature when `block.number >= seatedAt`.
+ * `seatedAt == 0` is the on-chain grandfather for pre-upgrade incumbents
+ * (`Board._isSeatingMature`) — treat those seats as mature.
+ *
+ * Copied from `app/src/lib/chamberGovernance.ts` so the operator does not
+ * depend on the React app.
+ */
+export function isSeatingMature(
+  seatedAt: bigint | undefined,
+  blockNumber: bigint | undefined,
+): boolean {
+  if (seatedAt === undefined) return false
+  if (seatedAt === 0n) return true
+  if (blockNumber === undefined) return false
+  return blockNumber >= seatedAt
+}

--- a/packages/operator/test/app-error-parity.test.ts
+++ b/packages/operator/test/app-error-parity.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { CHAMBER_ERROR_MESSAGES } from '../src/errors.ts'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+async function readApp(rel: string): Promise<string> {
+  return readFile(join(ROOT, rel), 'utf8')
+}
+
+test('operator error copy stays aligned with the React app', async () => {
+  const delegation = await readApp('app/src/components/DelegationManager.tsx')
+  const treasury = await readApp('app/src/components/TreasuryOverview.tsx')
+  const queue = await readApp('app/src/pages/TransactionQueue.tsx')
+
+  assert.match(delegation, /'NotDirector': 'You are not a director'/)
+  assert.match(delegation, /'DirectorNotSeated': 'Your seat is not mature yet'/)
+  assert.match(delegation, /'EnforcedPause': 'This chamber is paused'/)
+  assert.match(treasury, /'EnforcedPause': 'This chamber is paused'/)
+  assert.match(queue, /This transaction has expired/)
+  assert.match(queue, /Director seating is not mature yet/)
+
+  assert.equal(CHAMBER_ERROR_MESSAGES.NotDirector, 'You are not a director')
+  assert.equal(CHAMBER_ERROR_MESSAGES.DirectorNotSeated, 'Your seat is not mature yet')
+  assert.equal(CHAMBER_ERROR_MESSAGES.EnforcedPause, 'This chamber is paused')
+  assert.equal(CHAMBER_ERROR_MESSAGES.TransactionExpired, 'This transaction has expired')
+})

--- a/packages/operator/test/errors.test.ts
+++ b/packages/operator/test/errors.test.ts
@@ -36,6 +36,17 @@ test('maps expired nonce the same way TransactionQueue does', () => {
   assert.equal(formatChamberError(error), 'This transaction has expired')
 })
 
+test('maps viem DirectorNotSeated() short messages', () => {
+  const error = new Error('The contract function "submitTransaction" reverted.\n\nError: DirectorNotSeated()')
+  assert.equal(formatChamberError(error), 'Your seat is not mature yet')
+})
+
+test('decodes raw revert data via the Chamber ABI', () => {
+  const data = encoded('EnforcedPause')
+  const error = { message: 'execution reverted', data }
+  assert.equal(formatChamberError(error), 'This chamber is paused')
+})
+
 test('reads viem-style errorName on the cause', () => {
   const cause = { errorName: 'DirectorNotSeated', message: 'execution reverted' }
   const error = new Error('Internal JSON-RPC error')

--- a/packages/operator/test/errors.test.ts
+++ b/packages/operator/test/errors.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { encodeErrorResult } from 'viem'
+import { chamberAbi } from '../src/abi.ts'
+import {
+  CHAMBER_ERROR_MESSAGES,
+  formatChamberError,
+  wrapChamberError,
+} from '../src/errors.ts'
+
+function encoded(name: 'NotDirector' | 'DirectorNotSeated' | 'EnforcedPause' | 'TransactionExpired') {
+  return encodeErrorResult({ abi: chamberAbi, errorName: name })
+}
+
+test('maps not-a-director the same way DelegationManager does', () => {
+  const error = new Error(`The contract function reverted with custom error 'NotDirector'`)
+  assert.equal(formatChamberError(error), CHAMBER_ERROR_MESSAGES.NotDirector)
+  assert.equal(formatChamberError(error), 'You are not a director')
+})
+
+test('maps seating delay the same way DelegationManager does', () => {
+  const error = new Error(`The contract function reverted with custom error 'DirectorNotSeated'`)
+  assert.equal(formatChamberError(error), CHAMBER_ERROR_MESSAGES.DirectorNotSeated)
+  assert.equal(formatChamberError(error), 'Your seat is not mature yet')
+})
+
+test('maps pause the same way DelegationManager and TreasuryOverview do', () => {
+  const error = new Error(`The contract function reverted with custom error 'EnforcedPause'`)
+  assert.equal(formatChamberError(error), CHAMBER_ERROR_MESSAGES.EnforcedPause)
+  assert.equal(formatChamberError(error), 'This chamber is paused')
+})
+
+test('maps expired nonce the same way TransactionQueue does', () => {
+  const error = new Error(`The contract function reverted with custom error 'TransactionExpired'`)
+  assert.equal(formatChamberError(error), CHAMBER_ERROR_MESSAGES.TransactionExpired)
+  assert.equal(formatChamberError(error), 'This transaction has expired')
+})
+
+test('reads viem-style errorName on the cause', () => {
+  const cause = { errorName: 'DirectorNotSeated', message: 'execution reverted' }
+  const error = new Error('Internal JSON-RPC error')
+  ;(error as Error & { cause: unknown }).cause = cause
+  assert.equal(formatChamberError(error), 'Your seat is not mature yet')
+})
+
+test('reads encoded selectors via message fallback', () => {
+  const data = encoded('NotDirector')
+  const error = new Error(`reverted with data ${data}`)
+  // Selector-only messages still contain the error name after viem decode;
+  // if only the raw hex is present, wrap still returns a useful string.
+  const wrapped = wrapChamberError(error)
+  assert.equal(typeof wrapped.message, 'string')
+  assert.ok(wrapped.message.length > 0)
+})
+
+test('unknown custom error name is surfaced as the name', () => {
+  const error = new Error(`The contract function reverted with custom error 'NotEnoughConfirmations'`)
+  assert.equal(formatChamberError(error), 'NotEnoughConfirmations')
+})

--- a/packages/operator/test/seating.test.ts
+++ b/packages/operator/test/seating.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { isSeatingMature } from '../src/seating.ts'
+
+test('grandfathered seats (seatedAt == 0) are mature', () => {
+  assert.equal(isSeatingMature(0n, 1n), true)
+})
+
+test('undefined seatedAt is not mature', () => {
+  assert.equal(isSeatingMature(undefined, 10n), false)
+})
+
+test('seat is pending until block.number >= seatedAt', () => {
+  assert.equal(isSeatingMature(10n, 9n), false)
+  assert.equal(isSeatingMature(10n, 10n), true)
+  assert.equal(isSeatingMature(10n, 11n), true)
+})

--- a/packages/operator/tsconfig.json
+++ b/packages/operator/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test", "examples"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #146.

The only human operator surface is the React app. Agents cannot click `TransactionQueue`. This PR adds a small TypeScript package that talks to the **existing** Chamber ABI in `contracts/generated-abis.ts` — no second contract API, no new production Solidity.

## What

`packages/operator` (`@loreum/chamber-operator`):

- Given RPC + key (or a viem / 4337 `WalletClient`) + chamber address, can:
  - read board + quorum (`getTop`, `getSeats`, `getQuorum`, `getDirectors`, `getSeatedAt`, `paused`)
  - `delegate`
  - `submitTransaction`
  - `confirmTransaction`
  - `executeTransaction`
- CLI: `npx chamber-operator board|quorum|delegate|submit|confirm|execute`
- Makefile pointers: `make operator-board`, `make operator-e2e`

## Errors (same copy as the app)

| Revert | App copy |
| --- | --- |
| `DirectorNotSeated` | Your seat is not mature yet |
| `EnforcedPause` | This chamber is paused |
| `TransactionExpired` | This transaction has expired |
| `NotDirector` | You are not a director |

Parity is locked by `test/app-error-parity.test.ts` against `DelegationManager` / `TreasuryOverview` / `TransactionQueue`.

## Anvil example

```bash
cd packages/operator
npm install
npm run example:anvil
```

Root README has the same snippet.

## Testing

- `cd packages/operator && npm test` — 13 passing (error map + seating + app-copy parity)
- `npm run example:anvil` — live Anvil: board/quorum, delegate, seating-delay revert, submit, outsider confirm, director confirm, execute, expired nonce, pause-then-execute

## Out of scope

Sensor Hub, Agent Hub, new subgraph, production agent runtime. No new Solidity (#143 stays a separate PR).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9217c38-1a75-4d6d-be19-ef8b9e658eb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9217c38-1a75-4d6d-be19-ef8b9e658eb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

