### PR TITLE
fix(landing): stop claiming audited contracts and EIP-1271 directors

### DIFF
--- a/landing/content/blog/2026-08-26-factory-my-chambers.md
+++ b/landing/content/blog/2026-08-26-factory-my-chambers.md
@@ -1,7 +1,7 @@
 ---
 title: Factory path on Sepolia
 date: 2026-08-26
-summary: Create uses Factory when the factory address is set. Mine / My Chambers is wallet-centric. Registry stays a leftover deprecated index.
+summary: Create uses the in-repo Sepolia Factory default. Mine / My Chambers is wallet-centric. Registry stays a leftover deprecated index.
 ---
 
 26 August 2026. Factory path on Sepolia.
@@ -9,7 +9,7 @@ summary: Create uses Factory when the factory address is set. Mine / My Chambers
 - Factory: `0x43aA92c8A26392f21F63cdA88B6BaB5031C40550`
 - Chamber implementation: `0xd441f1FDad2d3a447d2621DE4DE8b5738e02d39c`
 
-Create uses Factory when the factory address is set.
+Create uses Factory. The Sepolia Factory address is an in-repo default.
 
 Mine / My Chambers is wallet-centric (create events + membership / vault shares), not a global on-chain Registry crawl.
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Loreum Chamber: onchain governance for DAOs — delegated voting, director seats, quorum, and treasury execution in audited smart contracts."
+      content="Loreum Chamber: onchain governance for DAOs — factory-deployed ERC-4626 vault, liquid-delegated ranked board, and quorum wallet."
     />
     <title>Loreum — Chamber: onchain governance for DAOs</title>
   </head>

--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -90,10 +90,11 @@ function App() {
             transition={{ duration: 0.8, delay: 0.4 }}
             className="text-lg md:text-xl text-gray-400 max-w-2xl mx-auto mb-12 font-light leading-relaxed break-words"
           >
-            Loreum Chamber is protocol infrastructure for real DAOs: delegated voting,
-            a ranked board of directors, quorum, and treasury flows enforced by
-            <span className="text-space-accent"> audited smart contracts</span> — verifiable
-            by your community, compatible with humans, multisigs, and agents.
+            Loreum Chamber is protocol infrastructure for real DAOs: a
+            factory-deployed ERC-4626 vault, a liquid-delegated ranked board of
+            membership NFTs, and a
+            <span className="text-space-accent"> quorum wallet</span> — onchain
+            and verifiable by your community.
           </motion.p>
 
           <motion.div 
@@ -182,21 +183,21 @@ function App() {
                 icon: <Eye className="w-7 h-7 text-amber-300" />,
                 tag: "§ 104(c)(2)(D)",
                 title: "Transparent & Programmatic",
-                desc: "The Act requires a system that operates and enforces decisions solely from pre-established, transparent rules encoded in source code. Chamber executes every governance action — proposal, vote, and treasury transfer — through audited onchain logic.",
+                desc: "The Act requires a system that operates and enforces decisions solely from pre-established, transparent rules encoded in source code. Chamber executes proposal, vote, and treasury transfer through published onchain contracts — not Discord polls or hidden admin keys.",
                 glow: "bg-amber-400/10"
               },
               {
                 icon: <Shield className="w-7 h-7 text-purple-300" />,
                 tag: "§ 104(c)(2)(E)",
                 title: "No Unilateral Control",
-                desc: "No party may direct, alter, or aggregate more than 20% of effective voting power. Chamber's liquid delegation, sorted leaderboard of directors, and quorum-based execution make concentration of authority structurally impossible.",
+                desc: "The Act targets concentrated voting power. Chamber ships liquid delegation to a ranked board of membership NFTs and quorum-gated execution — so treasury and upgrades move through those onchain rules, not admin keys.",
                 glow: "bg-purple-500/10"
               },
               {
                 icon: <Network className="w-7 h-7 text-emerald-300" />,
                 tag: "§ 104(c)(2)(F–G)",
                 title: "Distributed & Impartial",
-                desc: "Authority must be distributed and the system impartial. Chamber's Sub-Chamber architecture splits authority across specialized bodies, while NFT-based directorship and EIP-1271 signatures let humans, multisigs, and AI agents participate as equals.",
+                desc: "Authority must be distributed and the system impartial. Chamber seats directors from liquid delegation to membership NFTs. Director actions require the caller to be that NFT's owner; a quorum of directors then executes.",
                 glow: "bg-emerald-500/10"
               }
             ].map((item, i) => (
@@ -264,30 +265,30 @@ function App() {
           <FadeIn className="mb-20 max-w-2xl">
             <h2 className="text-3xl sm:text-4xl md:text-5xl font-display mb-6 break-words text-balance">Autonomous Architecture</h2>
             <p className="text-gray-400 text-lg font-light leading-relaxed break-words">
-              Each Chamber primitive is designed to satisfy a specific clause of CLARITY Act § 104 —
-              not as compliance theater, but as the structural property that makes
-              autonomous, agent-driven governance possible.
+              The shipped Chamber is a factory-deployed ERC-4626 vault with a
+              liquid-delegated ranked board of membership NFTs and a quorum wallet —
+              the onchain object that Create deploys today.
             </p>
           </FadeIn>
 
           <div className="grid md:grid-cols-3 gap-8">
             {[
               {
-                icon: <Cpu className="w-8 h-8 text-blue-400" />,
-                title: "Agent Directors",
-                desc: "Smart contracts that propose, vote, and execute onchain through pre-established rules — humans, multisigs, and AI agents seated as equal directors via NFT-based delegation and EIP-1271 signatures.",
+                icon: <Layers className="w-8 h-8 text-blue-400" />,
+                title: "Factory",
+                desc: "Create deploys each Chamber from a Factory as an upgradeable proxy. On Sepolia the Factory address is an in-repo default — not a leftover Registry crawl, and not gated on a local env var.",
                 glow: "bg-blue-500/20"
               },
               {
                 icon: <Shield className="w-8 h-8 text-purple-400" />,
-                title: "Policy Modules",
-                desc: "Modular guardrails that enforce voting caps, quorum thresholds, and execution limits — preventing any single party from accruing the unilateral or 20% effective control disqualified by the Act.",
+                title: "ERC-4626 Vault",
+                desc: "Each Chamber is a tokenized vault: deposit the Chamber asset, receive shares, and keep treasury flows onchain and redeemable. Shares back liquid delegation to the board.",
                 glow: "bg-purple-500/20"
               },
               {
-                icon: <Layers className="w-8 h-8 text-emerald-400" />,
-                title: "Sub-Chambers",
-                desc: "Fractal organizational units that distribute authority across specialized bodies — Treasury, Ops, R&D — so power, capital, and decision rights are dispersed by design rather than concentrated in a founding team.",
+                icon: <Cpu className="w-8 h-8 text-emerald-400" />,
+                title: "Ranked Board & Quorum Wallet",
+                desc: "Membership NFTs form a liquid-delegated ranked board. Directors submit and confirm; a quorum of seats executes. The caller must be the NFT owner — an EIP-1271 agent-director path is not shipped.",
                 glow: "bg-emerald-500/20"
               }
             ].map((feature, i) => (
@@ -319,10 +320,10 @@ function App() {
           <FadeIn className="text-center mb-20">
             <h2 className="text-3xl sm:text-4xl md:text-5xl font-display mb-6 px-2 break-words text-balance">Ecosystem Governance</h2>
             <p className="text-gray-400 max-w-2xl mx-auto px-2 text-lg font-light leading-relaxed break-words">
-              Chambers and Sub-Chambers compose into a verifiable
-              <span className="text-space-accent"> Decentralized Governance System</span> —
-              a transparent, rules-based topology where authority is distributed by structure,
-              not by promise.
+              Each Chamber is a factory-deployed vault, ranked board, and
+              <span className="text-space-accent"> quorum wallet</span> —
+              a transparent, rules-based object where authority is exercised onchain,
+              not by admin keys.
             </p>
           </FadeIn>
 
@@ -332,27 +333,27 @@ function App() {
                 <div className="relative p-6 sm:p-8 border border-white/10 rounded-2xl bg-white/5 backdrop-blur-sm min-h-0 w-full max-w-full min-w-0 flex flex-col items-center justify-center gap-8 md:aspect-[4/3] overflow-hidden">
                    {/* Main Chamber */}
                   <div className="relative z-10 p-6 bg-space-800 border border-space-accent/50 rounded-xl max-w-[12rem] w-full sm:w-48 text-center shadow-[0_0_30px_rgba(208,214,249,0.1)]">
-                      <div className="text-space-accent font-display text-xl mb-1">Root Chamber</div>
-                      <div className="text-xs text-gray-400">Global Consensus</div>
+                      <div className="text-space-accent font-display text-xl mb-1">Chamber</div>
+                      <div className="text-xs text-gray-400">Factory Deploy</div>
                       
                       {/* Connection Lines */}
                       <div className="absolute top-full left-1/2 -translate-x-1/2 h-8 w-px bg-gradient-to-b from-space-accent/50 to-transparent" />
                       <div className="absolute top-full left-1/2 -translate-x-1/2 w-[min(18rem,calc(100vw-8rem))] sm:w-48 h-8 border-x border-t border-space-accent/20 rounded-t-xl translate-y-8" />
                    </div>
 
-                   {/* Sub Chambers — stack on narrow viewports, row + wrap on sm+ */}
+                   {/* Chamber primitives — stack on narrow viewports, row + wrap on sm+ */}
                    <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:gap-4 mt-8 pt-4 w-full max-w-full min-w-0 px-2 sm:px-0 justify-center items-center sm:items-stretch">
                       <div className="p-4 bg-space-800/50 border border-white/10 rounded-lg w-[8.5rem] max-w-full shrink-0 sm:w-28 text-center backdrop-blur-md">
-                         <div className="text-white font-display mb-1">Treasury</div>
-                         <div className="text-[10px] text-gray-500">Asset Mgmt</div>
+                         <div className="text-white font-display mb-1">Vault</div>
+                         <div className="text-[10px] text-gray-500">ERC-4626</div>
                       </div>
                       <div className="p-4 bg-space-800/50 border border-white/10 rounded-lg w-[8.5rem] max-w-full shrink-0 sm:w-28 text-center backdrop-blur-md">
-                         <div className="text-white font-display mb-1">Ops</div>
-                         <div className="text-[10px] text-gray-500">Coordination</div>
+                         <div className="text-white font-display mb-1">Board</div>
+                         <div className="text-[10px] text-gray-500">Ranked NFTs</div>
                       </div>
                       <div className="p-4 bg-space-800/50 border border-white/10 rounded-lg w-[8.5rem] max-w-full shrink-0 sm:w-28 text-center backdrop-blur-md">
-                         <div className="text-white font-display mb-1">R&D</div>
-                         <div className="text-[10px] text-gray-500">Innovation</div>
+                         <div className="text-white font-display mb-1">Wallet</div>
+                         <div className="text-[10px] text-gray-500">Quorum</div>
                       </div>
                    </div>
                 </div>
@@ -360,22 +361,19 @@ function App() {
 
              <FadeIn delay={0.4} className="space-y-12 w-full min-w-0">
                 <div className="group min-w-0">
-                   <h3 className="text-2xl font-display mb-3 text-white group-hover:text-space-accent transition-colors">The Chamber</h3>
+                   <h3 className="text-2xl font-display mb-3 text-white group-hover:text-space-accent transition-colors">Vault & Board</h3>
                    <p className="text-gray-400 leading-relaxed font-light break-words">
-                      The root governing body where global policies are set, the main treasury is
-                      held, and consensus is formed. Authority is exercised exclusively through
-                      onchain rules — never through admin keys or offchain channels — so the
-                      system remains transparent and rules-based as the Act requires.
+                      The Chamber holds the ERC-4626 treasury and seats a ranked board from
+                      liquid delegation to membership NFTs. Authority is exercised through
+                      those onchain rules — never through admin keys or offchain channels.
                    </p>
                 </div>
 
                 <div className="group min-w-0">
-                   <h3 className="text-2xl font-display mb-3 text-white group-hover:text-space-accent transition-colors">Sub-Chambers</h3>
+                   <h3 className="text-2xl font-display mb-3 text-white group-hover:text-space-accent transition-colors">Quorum Wallet</h3>
                    <p className="text-gray-400 leading-relaxed font-light break-words">
-                      Specialized bodies with delegated mandates and independent budgets. By
-                      splitting authority across Treasury, Ops, R&D, and beyond, no single seat or
-                      coalition can unilaterally direct the protocol — closing the
-                      common-control loophole that disqualifies most legacy DAOs.
+                      Directors submit and confirm transactions; execution requires quorum.
+                      The caller must own the membership NFT for that seat.
                    </p>
                 </div>
              </FadeIn>

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -85,7 +85,9 @@ function Whitepaper() {
                 first-class directors.
               </p>
               <p className="text-gray-300 leading-relaxed">
-                Technical contributions include: (1) NFT-based directorship with EIP-1271 validation for contract agents,
+                Technical contributions include: (1) NFT-based directorship (live auth is the
+                membership NFT owner as <code className="text-space-accent">msg.sender</code>;
+                EIP-1271 contract-agent directors remain a design path, not shipped),
                 (2) liquid delegation without governance lockups, subject to solvency checks on delegated balances, 
                 (3) circuit-safe linked list repositioning for the governance leaderboard, and (4) self-sovereign
                 upgrade paths executed only through quorum-approved transactions. We provide specifications, security
@@ -132,11 +134,12 @@ function Whitepaper() {
               <p className="text-gray-300 leading-relaxed mb-4">
                 Mapping from requirement to mechanism (non-exhaustive): <strong className="text-space-accent font-normal">
                 Transparent &amp; programmatic operation</strong> (cf. § 104(c)(2)(D)) — every material action flows through
-                Chamber&apos;s audited solidity; <strong className="text-space-accent font-normal">dispersed authority</strong>{" "}
+                Chamber&apos;s published solidity; <strong className="text-space-accent font-normal">dispersed authority</strong>{" "}
                 (cf. § 104(c)(2)(E–G)) — liquid delegation to a ranked board plus majority quorum on execution resists
                 single-actor capture when parameters and seat counts are tuned to policy; <strong className="text-space-accent font-normal">
-                agent parity</strong> — EIP-1271 allows smart contract directors to participate under the same validation
-                rules as EOAs, supporting autonomous but rule-bound participants rather than offchain AI promises.
+                agent parity</strong> — a designed EIP-1271 path would let smart-contract directors participate under the
+                same validation rules as EOAs. That path is not shipped; live director auth requires
+                {" "}<code className="text-space-accent">msg.sender</code> to be the membership NFT owner.
               </p>
 
               <h3 className="text-2xl font-display mb-4 mt-10 text-white">1.2 Chamber as protocol response</h3>
@@ -308,11 +311,18 @@ function Whitepaper() {
           <FadeIn delay={0.5}>
             <section className="mb-16">
               <h2 className="text-3xl font-display mb-6 text-space-accent">4. Agent Integration</h2>
+              <p className="text-gray-400 leading-relaxed mb-4 text-sm md:text-base">
+                This section is a design specification for contract-agent directors, not the live
+                authorization path. Shipped Chamber requires{" "}
+                <code className="text-space-accent">msg.sender</code> to be the membership NFT
+                owner. EIP-1271 agent directors are research; they are not a Chamber capability
+                until that path ships.
+              </p>
               
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.1 EIP-1271 Signature Validation</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                The Chamber Protocol enables smart contract agents to act as directors through EIP-1271 signature 
-                validation. When a director function is called, the contract checks:
+                The design would enable smart contract agents to act as directors through EIP-1271
+                signature validation. When a director function is called, the specified check is:
               </p>
               
               <ol className="list-decimal list-inside text-gray-300 space-y-2 mb-4 ml-4">
@@ -596,7 +606,7 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
 
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">8.3 Hierarchical Organizations</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                Chambers can be nested through Sub-Chamber patterns:
+                A contemplated pattern — not the live architecture — would nest Chambers:
               </p>
               <ul className="list-disc list-inside text-gray-300 space-y-2 mb-4 ml-4">
                 <li>A root Chamber manages global policies and main treasury</li>
@@ -644,10 +654,10 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
                 while keeping control legible and diffuse — not dependent on informal social layers for enforcement.
               </p>
               <p className="text-gray-300 leading-relaxed mb-4">
-                Key innovations include the sorted linked list delegation mechanism, EIP-1271 agent integration,
-                liquid delegation patterns, and self-sovereign upgradeability gated by the same transaction flow as
-                other chamber actions. The modular design supports Sub-Chamber topologies that further distribute
-                authority across specialized bodies.
+                Key innovations include the sorted linked list delegation mechanism, liquid
+                delegation patterns, and self-sovereign upgradeability gated by the same transaction
+                flow as other chamber actions. EIP-1271 agent directors and Sub-Chamber topologies
+                remain design work — not the live Factory, vault, ranked board, and quorum wallet.
               </p>
               <p className="text-gray-300 leading-relaxed">
                 Future work will explore multi-asset support, advanced governance strategies, and cross-chain

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -366,9 +366,9 @@ if (IERC1271(owner).isValidSignature(hash, abi.encode(msg.sender))
                 <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
                   <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 2: Delegated Authority</h4>
                   <p className="text-gray-300 text-sm">
-                    An agent contract holds an NFT but authorizes another contract (via EIP-1271) to act as director. 
-                    This enables separation of concerns: the NFT holder manages identity, while the authorized contract 
-                    executes governance actions.
+                    Design only: an agent contract would hold an NFT and authorize another contract
+                    (via EIP-1271) to act as director. This would separate identity from the
+                    authorized caller. It is not the live path.
                   </p>
                 </div>
                 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #158.

Live loreum.org over-claimed vs what Chamber ships. This is a `landing/` copy fix only — not a protocol change, not #143, not a marketing redesign.

## What a visitor can no longer read as live
- **Audited** smart contracts / onchain logic / solidity — there is no public audit report, so that language is gone from the hero, meta description, CLARITY cards, and whitepaper intro.
- **EIP-1271 agent directors** as a shipped equal path. Homepage architecture now states the live rule (`msg.sender` is the membership NFT owner) and that 1271 is not shipped. The whitepaper still contains the 1271 spec; it is framed as design/research, including Pattern 2.
- **Policy Modules, Sub-Chambers, and a Chamber-enforced 20% voting-power cap** as the live architecture.

## What the page now says
Shipped object: factory-deployed ERC-4626 vault + liquid-delegated ranked board (membership NFTs) + quorum wallet.

Starter blog (`2026-08-26-factory-my-chambers.md`) no longer says Create uses Factory only “when the factory address is set.” Sepolia Factory `0x43aA92c8A26392f21F63cdA88B6BaB5031C40550` stays; the line now matches #147 (in-repo default).

Left alone: footer/nav “CLARITY” as a section name; “Auditing…” animation labels; `docs.loreum.org`.

## Out of scope
- Reopening M-01 or implementing #143
- Inventing audit, CLARITY-compliance, or mainnet status
- Rewriting the whitepaper or the rest of the marketing site

## Verified
Walked homepage, `/whitepaper`, and `/blog/2026-08-26-factory-my-chambers` on a local production build. Hero, CLARITY, architecture, governance, whitepaper §4, and the starter post no longer present audited contracts or EIP-1271 agent directors as live Chamber capabilities.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6be3e27d-0a83-466f-a491-6e68ce8cdd59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be3e27d-0a83-466f-a491-6e68ce8cdd59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

