### PR TITLE
Fix Delegation Member ID dropdown for owned membership NFTs

### DIFF
--- a/app/src/components/DelegationManager.tsx
+++ b/app/src/components/DelegationManager.tsx
@@ -51,7 +51,13 @@ export default function DelegationManager({
   const queryClient = useQueryClient()
   const [searchParams] = useSearchParams()
   const { address: userAddress, isConnected } = useAccount()
-  const { tokenIds: userNFTTokenIds } = useUserNFTs(nftToken, userAddress)
+  const {
+    tokenIds: userNFTTokenIds,
+    balance: nftBalance,
+    isLoading: nftsLoading,
+  } = useUserNFTs(nftToken, userAddress, { chamberAddress })
+  const ownsMembershipNft =
+    userNFTTokenIds.length > 0 || (nftBalance > 0n && nftsLoading)
   const [delegateTokenId, setDelegateTokenId] = useState('')
   const [delegateAmount, setDelegateAmount] = useState('')
   const [undelegateTokenId, setUndelegateTokenId] = useState('')
@@ -330,13 +336,18 @@ export default function DelegationManager({
               <label className="block text-slate-300 text-sm font-medium mb-2">
                 Member ID
               </label>
-              {userNFTTokenIds.length > 0 ? (
+              {ownsMembershipNft ? (
                 <select
                   className="input"
                   value={delegateTokenId}
                   onChange={(e) => setDelegateTokenId(e.target.value)}
+                  disabled={nftsLoading && userNFTTokenIds.length === 0}
                 >
-                  <option value="">Select your member token...</option>
+                  <option value="">
+                    {nftsLoading && userNFTTokenIds.length === 0
+                      ? 'Loading your member tokens...'
+                      : 'Select your member token...'}
+                  </option>
                   {userNFTTokenIds.map((id) => (
                     <option key={id.toString()} value={id.toString()}>
                       #{id.toString()} {members.find(m => m.tokenId === id) ? `(Rank #${members.find(m => m.tokenId === id)?.rank})` : ''}
@@ -353,7 +364,7 @@ export default function DelegationManager({
                   min="1"
                 />
               )}
-              {userNFTTokenIds.length > 0 && (
+              {ownsMembershipNft && (
                 <p className="text-slate-500 text-xs mt-1">
                   Select a member token you own to delegate voting power to it
                 </p>

--- a/app/src/components/SeatTheBoard.tsx
+++ b/app/src/components/SeatTheBoard.tsx
@@ -42,7 +42,11 @@ export default function SeatTheBoard({
   const [minting, setMinting] = useState(false)
 
   const { members, isPending, isFetched, refetch: refetchBoard } = useBoardMembers(chamberAddress, 1)
-  const { tokenIds, balance: nftBalance, isLoading: nftsLoading } = useUserNFTs(nftToken, userAddress)
+  const { tokenIds, balance: nftBalance, isLoading: nftsLoading, refetch: refetchNfts } = useUserNFTs(
+    nftToken,
+    userAddress,
+    { chamberAddress },
+  )
   const { balance: shareBalance, refetch: refetchShares } = useChamberBalance(chamberAddress, userAddress)
 
   const boardKnownEmpty = isFetched && !isPending && members.length === 0
@@ -81,6 +85,7 @@ export default function SeatTheBoard({
       })
       await writeContractAsync(request)
       toast.success('Founder membership NFT minted. Deposit shares, then delegate to seat the board.')
+      void refetchNfts()
       void refetchBoard()
       void refetchShares()
     } catch (e: unknown) {

--- a/app/src/hooks/useChamber.ts
+++ b/app/src/hooks/useChamber.ts
@@ -1,9 +1,12 @@
 import { useMemo } from 'react'
-import { useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt, useSimulateContract, useAccount, useBlockNumber } from 'wagmi'
+import { useQuery } from '@tanstack/react-query'
+import { useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt, useSimulateContract, useAccount, useBlockNumber, usePublicClient, useChainId } from 'wagmi'
 import { isAddress } from 'viem'
 import { chamberAbi, erc20Abi, erc721Abi } from '@/contracts/abis'
 import { chamberVersionBytes32ToLabel } from '@/lib/utils'
 import { isSeatingMature } from '@/lib/chamberGovernance'
+import { getAlchemyApiKeyFromEnv } from '@/lib/alchemy'
+import { listOwnedErc721TokenIds } from '@/lib/ownedErc721'
 import type { Transaction, BoardMember, SeatUpdate } from '@/types'
 
 /** Public RPC / long block times: retry eth_call simulation and refresh state after txs. */
@@ -389,43 +392,78 @@ export function useSeatUpdate(chamberAddress: `0x${string}` | undefined) {
 }
 
 /**
- * Fetches token IDs of NFTs owned by a user from an ERC721 contract.
- * Uses tokenOfOwnerByIndex (ERC721Enumerable). Falls back to empty array if not supported.
+ * Token IDs of membership NFTs held by `ownerAddress`.
+ * Enumerable is the fast path; non-enumerable 721s (Sepolia EXPLORERS) use
+ * `ownerOf` / Alchemy / Transfer logs — see `listOwnedErc721TokenIds`.
  */
-export function useUserNFTs(nftAddress: `0x${string}` | undefined, ownerAddress: `0x${string}` | undefined) {
-  const { data: balance } = useReadContract({
+export function useUserNFTs(
+  nftAddress: `0x${string}` | undefined,
+  ownerAddress: `0x${string}` | undefined,
+  opts?: { chamberAddress?: `0x${string}` }
+) {
+  const publicClient = usePublicClient()
+  const chainId = useChainId()
+  const alchemyApiKey = getAlchemyApiKeyFromEnv()
+  const chamberScope = (opts?.chamberAddress ?? '').toLowerCase()
+
+  const { data: balance, isPending: balancePending, refetch: refetchBalance } = useReadContract({
     address: nftAddress,
     abi: erc721Abi,
     functionName: 'balanceOf',
     args: ownerAddress ? [ownerAddress] : undefined,
-    query: { enabled: !!nftAddress && !!ownerAddress },
-  })
-
-  const balanceNum = balance ? Number(balance) : 0
-  const indices = Array.from({ length: Math.min(balanceNum, 50) }, (_, i) => i)
-
-  const { data: tokenIdsResults } = useReadContracts({
-    contracts: indices.map((i) => ({
-      address: nftAddress!,
-      abi: erc721Abi,
-      functionName: 'tokenOfOwnerByIndex',
-      args: [ownerAddress!, BigInt(i)],
-    })),
     query: {
-      enabled: !!nftAddress && !!ownerAddress && balanceNum > 0 && balanceNum <= 50,
+      enabled: !!nftAddress && !!ownerAddress,
+      staleTime: 0,
+      refetchOnMount: true,
     },
   })
 
-  const tokenIds: bigint[] = []
-  if (tokenIdsResults) {
-    for (const r of tokenIdsResults) {
-      if (r.status === 'success' && r.result !== undefined) {
-        tokenIds.push(BigInt(r.result as string | number | bigint))
-      }
-    }
-  }
+  const balanceKnown = balance !== undefined
+  const hasNfts = !!balance && balance > 0n
 
-  return { tokenIds, balance: balance ?? 0n, isLoading: balance === undefined }
+  const listQuery = useQuery({
+    queryKey: [
+      'user-nfts',
+      nftAddress?.toLowerCase() ?? '',
+      ownerAddress?.toLowerCase() ?? '',
+      chamberScope,
+      balance?.toString() ?? '',
+      chainId,
+    ],
+    enabled: !!publicClient && !!nftAddress && !!ownerAddress && hasNfts,
+    staleTime: 15_000,
+    refetchOnMount: 'always',
+    retry: 2,
+    retryDelay: (attemptIndex) => Math.min(1500 * 2 ** attemptIndex, 12_000),
+    queryFn: () =>
+      listOwnedErc721TokenIds({
+        client: publicClient!,
+        nft: nftAddress!,
+        owner: ownerAddress!,
+        expectedBalance: balance,
+        chainId,
+        alchemyApiKey,
+      }),
+  })
+
+  const tokenIds = useMemo(() => {
+    if (!hasNfts) return [] as bigint[]
+    return listQuery.data ?? []
+  }, [hasNfts, listQuery.data])
+
+  const isLoading =
+    (!!nftAddress && !!ownerAddress && (balancePending || !balanceKnown)) ||
+    (hasNfts && (listQuery.isPending || listQuery.isFetching) && tokenIds.length === 0)
+
+  return {
+    tokenIds,
+    balance: balance ?? 0n,
+    isLoading,
+    refetch: async () => {
+      await refetchBalance()
+      return listQuery.refetch()
+    },
+  }
 }
 
 export function useDelegations(chamberAddress: `0x${string}` | undefined, account: `0x${string}` | undefined) {

--- a/app/src/lib/alchemy.ts
+++ b/app/src/lib/alchemy.ts
@@ -197,6 +197,56 @@ async function fetchAllNftsForOwner(nftBase: string, owner: Address): Promise<Ch
   return out
 }
 
+function parseAlchemyTokenId(raw: string | undefined): bigint | null {
+  if (!raw) return null
+  try {
+    return BigInt(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Token IDs of `contract` held by `owner` via Alchemy NFT API (works for non-enumerable 721s).
+ * Returns `null` when the chain is unsupported so callers can fall through.
+ */
+export async function fetchOwnedNftTokenIdsForContract(opts: {
+  apiKey: string
+  chainId: number
+  owner: Address
+  contract: Address
+}): Promise<bigint[] | null> {
+  const nftBase = getAlchemyNftV3BaseUrl(opts.chainId, opts.apiKey)
+  if (!nftBase) return null
+
+  const ids: bigint[] = []
+  const seen = new Set<string>()
+  const owner = encodeURIComponent(opts.owner)
+  const contract = encodeURIComponent(opts.contract)
+  let url: string | null =
+    `${nftBase}/getNFTsForOwner?owner=${owner}&contractAddresses[]=${contract}&withMetadata=false&pageSize=100`
+
+  for (let guard = 0; guard < 50 && url; guard++) {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`Alchemy NFT API HTTP ${res.status}`)
+    const data = (await res.json()) as NftV3OwnerResponse
+    for (const row of data.ownedNfts ?? []) {
+      const id = parseAlchemyTokenId(row.tokenId)
+      if (id === null) continue
+      const key = id.toString()
+      if (seen.has(key)) continue
+      seen.add(key)
+      ids.push(id)
+    }
+    const pageKey = data.pageKey
+    url = pageKey
+      ? `${nftBase}/getNFTsForOwner?owner=${owner}&contractAddresses[]=${contract}&withMetadata=false&pageSize=100&pageKey=${encodeURIComponent(pageKey)}`
+      : null
+  }
+
+  return ids
+}
+
 export type FetchChamberPortfolioOptions = {
   apiKey: string
   /** Extra ERC-20 contracts to ensure are queried (merged into balance scan) */

--- a/app/src/lib/ownedErc721.ts
+++ b/app/src/lib/ownedErc721.ts
@@ -1,0 +1,314 @@
+/**
+ * List ERC-721 token IDs owned by an address.
+ *
+ * `tokenOfOwnerByIndex` (ERC-721 Enumerable) is the fast path. Sepolia demo
+ * membership (`MockERC721` / EXPLORERS) is plain ERC-721 — that call reverts and
+ * a `balanceOf > 0` wallet would otherwise look like it owns nothing.
+ *
+ * Public Sepolia RPCs cap `eth_getLogs` (often 10k–50k blocks) and drop watches,
+ * so logs are a last resort. Dense `ownerOf` scans cover sequential mint
+ * collections; Alchemy NFT API covers sparse IDs when a key is configured.
+ */
+
+import { parseAbiItem, type Address, type PublicClient } from 'viem'
+import { erc721Abi } from '@/contracts/abis'
+import {
+  alchemySupportsChain,
+  fetchOwnedNftTokenIdsForContract,
+} from '@/lib/alchemy'
+
+export const ERC721_TRANSFER_EVENT = parseAbiItem(
+  'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)',
+)
+
+/** Same cap the previous enumerable-only hook used. */
+export const MAX_OWNED_MEMBERSHIP_NFTS = 50
+
+/** Sequential membership collections stay well under this (EXPLORERS faucet). */
+const MAX_DENSE_TOKEN_ID = 4096n
+const OWNER_OF_BATCH = 128
+const LOG_LOOKBACK_BLOCKS = 100_000n
+const DEFAULT_LOG_CHUNK = 10_000n
+
+export type OwnedNftClient = Pick<
+  PublicClient,
+  'readContract' | 'multicall' | 'getLogs' | 'getBlockNumber'
+>
+
+export type ListOwnedErc721Options = {
+  client: OwnedNftClient
+  nft: Address
+  owner: Address
+  /** Skip a `balanceOf` read when the caller already has it. */
+  expectedBalance?: bigint
+  chainId?: number
+  alchemyApiKey?: string
+}
+
+function uniqSort(ids: bigint[]): bigint[] {
+  return [...new Set(ids.map((id) => id.toString()))]
+    .map((s) => BigInt(s))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+}
+
+function sameAddress(a: Address, b: Address): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+function maxRangeFromError(err: unknown, fallback: bigint): bigint {
+  const msg = errorMessage(err)
+  const match =
+    msg.match(/maximum block range:\s*(\d+)/i) ||
+    msg.match(/block range[^\d]{0,40}(\d{3,})/i)
+  if (!match) return fallback
+  const n = BigInt(match[1])
+  if (n <= 0n || n > 100_000n) return fallback
+  return n
+}
+
+async function multicallOrSerial<T>(
+  client: OwnedNftClient,
+  contracts: Parameters<OwnedNftClient['multicall']>[0]['contracts'],
+): Promise<{ status: 'success' | 'failure'; result?: T }[]> {
+  try {
+    return (await client.multicall({
+      contracts,
+      allowFailure: true,
+    })) as { status: 'success' | 'failure'; result?: T }[]
+  } catch {
+    const out: { status: 'success' | 'failure'; result?: T }[] = []
+    for (const c of contracts) {
+      try {
+        const result = (await client.readContract(c as never)) as T
+        out.push({ status: 'success', result })
+      } catch {
+        out.push({ status: 'failure' })
+      }
+    }
+    return out
+  }
+}
+
+async function readOwners(
+  client: OwnedNftClient,
+  nft: Address,
+  tokenIds: bigint[],
+): Promise<(Address | null)[]> {
+  if (tokenIds.length === 0) return []
+  const results = await multicallOrSerial<Address>(
+    client,
+    tokenIds.map((tokenId) => ({
+      address: nft,
+      abi: erc721Abi,
+      functionName: 'ownerOf' as const,
+      args: [tokenId] as const,
+    })),
+  )
+  return results.map((r) =>
+    r.status === 'success' && r.result ? r.result : null,
+  )
+}
+
+async function filterCurrentlyOwned(
+  client: OwnedNftClient,
+  nft: Address,
+  owner: Address,
+  tokenIds: bigint[],
+): Promise<bigint[]> {
+  const owners = await readOwners(client, nft, tokenIds)
+  const kept: bigint[] = []
+  for (let i = 0; i < tokenIds.length; i++) {
+    const current = owners[i]
+    if (current && sameAddress(current, owner)) kept.push(tokenIds[i]!)
+  }
+  return kept
+}
+
+async function listViaEnumerable(
+  client: OwnedNftClient,
+  nft: Address,
+  owner: Address,
+  want: number,
+): Promise<bigint[]> {
+  const results = await multicallOrSerial<bigint>(
+    client,
+    Array.from({ length: want }, (_, i) => ({
+      address: nft,
+      abi: erc721Abi,
+      functionName: 'tokenOfOwnerByIndex' as const,
+      args: [owner, BigInt(i)] as const,
+    })),
+  )
+  const ids: bigint[] = []
+  for (const r of results) {
+    if (r.status === 'success' && r.result !== undefined) ids.push(r.result)
+  }
+  return ids
+}
+
+/**
+ * Sequential collections (MockERC721 mint starts at 1). Skip when neither 0 nor 1 exists.
+ */
+async function listViaDenseOwnerOf(
+  client: OwnedNftClient,
+  nft: Address,
+  owner: Address,
+  want: number,
+): Promise<bigint[]> {
+  const [owner0, owner1] = await readOwners(client, nft, [0n, 1n])
+  if (!owner0 && !owner1) return []
+
+  const start = owner0 ? 0n : 1n
+  const owned: bigint[] = []
+  if (owner0 && sameAddress(owner0, owner)) owned.push(0n)
+  if (owner1 && sameAddress(owner1, owner) && start === 1n) owned.push(1n)
+  if (owned.length >= want) return owned
+
+  let next = start + 1n
+  while (next <= MAX_DENSE_TOKEN_ID && owned.length < want) {
+    const batch: bigint[] = []
+    for (let i = 0; i < OWNER_OF_BATCH && next <= MAX_DENSE_TOKEN_ID; i++) {
+      batch.push(next)
+      next += 1n
+    }
+    const owners = await readOwners(client, nft, batch)
+    let anyExist = false
+    for (let i = 0; i < batch.length; i++) {
+      const current = owners[i]
+      if (!current) continue
+      anyExist = true
+      if (sameAddress(current, owner)) owned.push(batch[i]!)
+      if (owned.length >= want) break
+    }
+    if (!anyExist) break
+  }
+
+  return owned
+}
+
+async function collectTransferTokenIds(
+  client: OwnedNftClient,
+  nft: Address,
+  owner: Address,
+  fromBlock: bigint,
+  toBlock: bigint | 'latest',
+): Promise<bigint[]> {
+  const logs = await client.getLogs({
+    address: nft,
+    event: ERC721_TRANSFER_EVENT,
+    args: { to: owner },
+    fromBlock,
+    toBlock,
+  })
+  const ids: bigint[] = []
+  for (const log of logs) {
+    if (log.args.tokenId !== undefined) ids.push(log.args.tokenId)
+  }
+  return ids
+}
+
+async function listViaTransferLogs(
+  client: OwnedNftClient,
+  nft: Address,
+  owner: Address,
+): Promise<bigint[]> {
+  try {
+    return await collectTransferTokenIds(client, nft, owner, 0n, 'latest')
+  } catch (fullErr) {
+    try {
+      const latest = await client.getBlockNumber()
+      const from =
+        latest > LOG_LOOKBACK_BLOCKS ? latest - LOG_LOOKBACK_BLOCKS : 0n
+      let chunk = maxRangeFromError(fullErr, DEFAULT_LOG_CHUNK)
+      const ids: bigint[] = []
+      let cursor = from
+      while (cursor <= latest) {
+        const end = cursor + chunk - 1n > latest ? latest : cursor + chunk - 1n
+        try {
+          ids.push(...(await collectTransferTokenIds(client, nft, owner, cursor, end)))
+          cursor = end + 1n
+        } catch (chunkErr) {
+          const next = maxRangeFromError(chunkErr, chunk / 2n)
+          if (next >= chunk || next === 0n) break
+          chunk = next
+        }
+      }
+      return ids
+    } catch {
+      return []
+    }
+  }
+}
+
+/**
+ * Owned token IDs for `nft` / `owner`, up to {@link MAX_OWNED_MEMBERSHIP_NFTS}.
+ */
+export async function listOwnedErc721TokenIds(
+  opts: ListOwnedErc721Options,
+): Promise<bigint[]> {
+  const { client, nft, owner, chainId, alchemyApiKey } = opts
+
+  const balance =
+    opts.expectedBalance !== undefined
+      ? opts.expectedBalance
+      : ((await client.readContract({
+          address: nft,
+          abi: erc721Abi,
+          functionName: 'balanceOf',
+          args: [owner],
+        })) as bigint)
+
+  if (balance === 0n) return []
+
+  const want = Number(balance > BigInt(MAX_OWNED_MEMBERSHIP_NFTS) ? MAX_OWNED_MEMBERSHIP_NFTS : balance)
+  const collected = new Set<string>()
+
+  const add = (ids: bigint[]) => {
+    for (const id of ids) collected.add(id.toString())
+  }
+
+  add(await listViaEnumerable(client, nft, owner, want))
+  if (collected.size >= want) {
+    return uniqSort([...collected].map((s) => BigInt(s))).slice(0, want)
+  }
+
+  add(await listViaDenseOwnerOf(client, nft, owner, want))
+  if (collected.size >= want) {
+    return uniqSort([...collected].map((s) => BigInt(s))).slice(0, want)
+  }
+
+  if (alchemyApiKey && chainId !== undefined && alchemySupportsChain(chainId)) {
+    try {
+      const alchemyIds = await fetchOwnedNftTokenIdsForContract({
+        apiKey: alchemyApiKey,
+        chainId,
+        owner,
+        contract: nft,
+      })
+      if (alchemyIds) {
+        add(await filterCurrentlyOwned(client, nft, owner, alchemyIds))
+      }
+    } catch {
+      // indexer optional
+    }
+    if (collected.size >= want) {
+      return uniqSort([...collected].map((s) => BigInt(s))).slice(0, want)
+    }
+  }
+
+  add(
+    await filterCurrentlyOwned(
+      client,
+      nft,
+      owner,
+      await listViaTransferLogs(client, nft, owner),
+    ),
+  )
+
+  return uniqSort([...collected].map((s) => BigInt(s))).slice(0, want)
+}

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -315,7 +315,9 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
   const { members, isFetched: boardFetched } = useBoardMembers(chamberAddress, chamberInfo.seats || 5)
   const boardEmpty = boardFetched && members.length === 0
   const { seatUpdate, refetch: refetchSeatUpdate } = useSeatUpdate(chamberAddress)
-  const { tokenIds: ownedTokenIds } = useUserNFTs(chamberInfo.nftToken, userAddress)
+  const { tokenIds: ownedTokenIds } = useUserNFTs(chamberInfo.nftToken, userAddress, {
+    chamberAddress,
+  })
   const directorGate = useDirectorActionGate(
     chamberAddress,
     userAddress,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #161.

## Problem

Delegation already switches Member ID to a `<select>` when `useUserNFTs` returns token IDs. That hook only called `tokenOfOwnerByIndex` (ERC-721 Enumerable).

Sepolia demo membership (`EXPLORERS` `0x03CBb0Bb72aeB043b0dc8B299FaCFe77f9159688`, `MockERC721`) is plain ERC-721. On a public Sepolia RPC:

- `balanceOf` is correct (holders have tokens)
- `tokenOfOwnerByIndex` reverts
- `tokenIds` stayed `[]`, so the UI kept the bare number field

`eth_getLogs` on publicnode is capped at 50k blocks, so a lookback-only Transfer-log list misses older faucet mints.

## Change (app only)

`listOwnedErc721TokenIds` + `useUserNFTs`:

1. **Enumerable** — keep `tokenOfOwnerByIndex` as the fast path
2. **Dense `ownerOf`** — sequential collections (EXPLORERS `mint()` from 1). This is the path that works on public Sepolia RPCs without an indexer
3. **Alchemy** `getNFTsForOwner` filtered to the membership contract, when `VITE_ALCHEMY_API_KEY` is set
4. **Transfer logs** — try full history, then a capped lookback with range chunking (watches are not used)

Delegation still shows a typed Member ID when `balanceOf == 0`. While a positive balance is loading, the select shows a loading placeholder. Empty-board prefill still uses the first owned id.

No Chamber contract changes. M-01 / #143 untouched.

## Verification

Live `eth_call` against EXPLORERS on `ethereum-sepolia-rpc.publicnode.com`:

| Wallet | `balanceOf` | Listed IDs |
| --- | --- | --- |
| Deployer `0x0C6F…19c9` | 2 | `#1`, `#2` |
| Holder `0x6209…2df7` | 5 | `#3`–`#7` |
| `0x0000…0001` | 0 | `[]` (typed Member ID path) |

`tokenOfOwnerByIndex(deployer, 0)` reverts, as hypothesized.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de494a81-09ce-421c-8a36-5c5ad5a9dc71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de494a81-09ce-421c-8a36-5c5ad5a9dc71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

