### PR TITLE
fix(landing): stop selling unshipped agent fleet and fake APY

### DIFF
--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -388,13 +388,13 @@ function App() {
             <FadeIn>
               <h2 className="text-3xl sm:text-4xl md:text-5xl font-display mb-8 break-words text-balance">
                 Command Your <br />
-                <span className="text-gradient">Digital Fleet</span>
+                <span className="text-gradient">Chamber</span>
               </h2>
               <div className="space-y-6">
                 {[
-                  "Deploy fleets of autonomous agents.",
-                  "Monitor real-time treasury analytics.",
-                  "Execute complex cross-chain strategies."
+                  "Deploy a Chamber from the Factory.",
+                  "Hold treasury in an ERC-4626 vault.",
+                  "Execute through a ranked board and quorum."
                 ].map((item, i) => (
                   <div key={i} className="flex items-center gap-4 text-gray-300">
                     <div className="w-2 h-2 bg-space-accent rounded-full" />
@@ -430,8 +430,8 @@ function App() {
                 </div>
               </div>
               
-              {/* Floating Elements - Fleet Agents (Desktop Only) */}
-              {/* Yield Miner */}
+              {/* Floating Elements - Chamber primitives (Desktop Only) */}
+              {/* Vault */}
               <motion.div 
                 animate={{ y: [0, -15, 0] }}
                 transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
@@ -441,12 +441,12 @@ function App() {
                   <TrendingUp className="w-4 h-4 text-blue-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Yield Miner</div>
-                  <div className="text-white text-xs font-mono">+12.4% APY</div>
+                  <div className="text-xs text-gray-400">Vault</div>
+                  <div className="text-white text-xs font-mono">ERC-4626</div>
                 </div>
               </motion.div>
 
-              {/* Risk Agent */}
+              {/* Board */}
               <motion.div 
                 animate={{ y: [0, 20, 0] }}
                 transition={{ duration: 5, repeat: Infinity, ease: "easeInOut", delay: 1 }}
@@ -456,12 +456,12 @@ function App() {
                    <ShieldAlert className="w-4 h-4 text-red-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Risk Agent</div>
-                  <div className="text-white text-xs font-mono">Auditing...</div>
+                  <div className="text-xs text-gray-400">Board</div>
+                  <div className="text-white text-xs font-mono">Ranked NFTs</div>
                 </div>
               </motion.div>
 
-              {/* Research Agent */}
+              {/* Factory */}
               <motion.div 
                 animate={{ x: [0, 10, 0], y: [0, -10, 0] }}
                 transition={{ duration: 6, repeat: Infinity, ease: "easeInOut", delay: 2 }}
@@ -471,12 +471,12 @@ function App() {
                    <Search className="w-4 h-4 text-purple-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Research Agent</div>
-                  <div className="text-white text-xs font-mono">Analyzing Proposals</div>
+                  <div className="text-xs text-gray-400">Factory</div>
+                  <div className="text-white text-xs font-mono">Deploy</div>
                 </div>
               </motion.div>
 
-              {/* Media Agent */}
+              {/* Wallet */}
               <motion.div 
                 animate={{ x: [0, -10, 0], y: [0, 10, 0] }}
                 transition={{ duration: 7, repeat: Infinity, ease: "easeInOut", delay: 3 }}
@@ -486,14 +486,14 @@ function App() {
                    <Radio className="w-4 h-4 text-pink-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Media Agent</div>
-                  <div className="text-white text-xs font-mono">Broadcasting</div>
+                  <div className="text-xs text-gray-400">Wallet</div>
+                  <div className="text-white text-xs font-mono">Quorum</div>
                 </div>
               </motion.div>
 
             </motion.div>
 
-            {/* Mobile Agent Cards Grid */}
+            {/* Mobile Chamber primitive cards */}
             <div className="grid grid-cols-2 gap-4 md:hidden mt-8">
               <motion.div 
                 initial={{ opacity: 0, y: 20 }}
@@ -506,8 +506,8 @@ function App() {
                   <TrendingUp className="w-4 h-4 text-blue-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Yield Miner</div>
-                  <div className="text-white text-xs font-mono">+12.4% APY</div>
+                  <div className="text-xs text-gray-400">Vault</div>
+                  <div className="text-white text-xs font-mono">ERC-4626</div>
                 </div>
               </motion.div>
 
@@ -522,8 +522,8 @@ function App() {
                   <ShieldAlert className="w-4 h-4 text-red-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Risk Agent</div>
-                  <div className="text-white text-xs font-mono">Auditing...</div>
+                  <div className="text-xs text-gray-400">Board</div>
+                  <div className="text-white text-xs font-mono">Ranked NFTs</div>
                 </div>
               </motion.div>
 
@@ -538,8 +538,8 @@ function App() {
                   <Search className="w-4 h-4 text-purple-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Research Agent</div>
-                  <div className="text-white text-xs font-mono">Analyzing</div>
+                  <div className="text-xs text-gray-400">Factory</div>
+                  <div className="text-white text-xs font-mono">Deploy</div>
                 </div>
               </motion.div>
 
@@ -554,8 +554,8 @@ function App() {
                   <Radio className="w-4 h-4 text-pink-400" />
                 </div>
                 <div>
-                  <div className="text-xs text-gray-400">Media Agent</div>
-                  <div className="text-white text-xs font-mono">Broadcasting</div>
+                  <div className="text-xs text-gray-400">Wallet</div>
+                  <div className="text-white text-xs font-mono">Quorum</div>
                 </div>
               </motion.div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #163.

Post-#158 the hero and architecture cards match the shipped Chamber. The homepage still ended with **Command Your Digital Fleet**: fake yield miners at +12.4% APY, Risk Agent “Auditing…”, and copy about deploying fleets of autonomous agents / complex cross-chain strategies. A visitor could read that as live product. It is not.

This is a `landing/` copy fix only — not a protocol change, not #143, not a marketing redesign.

## What a visitor can no longer read as live
- An **autonomous agent fleet** (“Command Your Digital Fleet”, “Deploy fleets of autonomous agents”)
- A **live yield APY** (Yield Miner +12.4% APY)
- **Cross-chain strategy execution**
- **“Auditing…”** as a loading label on a fake Risk Agent (easy to misread as an audit)

## What the block now says
Same visual language (orb, floating cards, mobile 2×2). Headline is **Command Your Chamber**. Bullets and cards are the shipped object: Factory deploy, ERC-4626 vault, ranked NFT board, quorum wallet.

Left alone: rest of the marketing site, whitepaper, mission/footer “agent” language, `docs.loreum.org`.

## Out of scope
- Solidity
- Implementing agent directors / #143 session-key UI
- Claiming Sensor Hub, Agent Hub, or cross-chain execution
- CCA / GTM

## Verified
Walked the homepage on a local `npm run build` + `vite preview` (desktop and 390×844). Showcase headline, bullets, floating cards, and mobile 2×2 now name Factory / vault / board / quorum only. Production bundle has zero matches for Digital Fleet, Yield Miner, +12.4%, Auditing…, Risk Agent, Sensor Hub, or Agent Hub.

[Desktop Command Your Chamber showcase](https://cursor.com/agents/bc-4673d365-33f0-44e1-8dc7-66dce0a851f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_command_your_chamber_desktop.webp)
[Mobile Command Your Chamber 2x2 cards](https://cursor.com/agents/bc-4673d365-33f0-44e1-8dc7-66dce0a851f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_command_your_chamber_mobile.webp)
[homepage_command_your_chamber_walkthrough.mp4](https://cursor.com/agents/bc-4673d365-33f0-44e1-8dc7-66dce0a851f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_command_your_chamber_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4673d365-33f0-44e1-8dc7-66dce0a851f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4673d365-33f0-44e1-8dc7-66dce0a851f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

