### PR TITLE
docs: Factory architecture; Sub-Chambers as contemplated (#164)

### DIFF
--- a/app/src/docs/README.md
+++ b/app/src/docs/README.md
@@ -9,7 +9,7 @@ Open the docs in the app at **`/docs`**. Start here:
 1. **[What is a Chamber?](./introduction/overview.md)** — the idea in one sitting  
 2. **[Why not just a multisig?](./introduction/why-not-multisig.md)** — Chamber vs a classic treasury wallet  
 3. **[Founder exit via Chamber](./introduction/founder-exit.md)** — gradual operational handoff while retaining token stake  
-4. **[Chambers and Sub-Chambers](./introduction/chamber-and-sub-chambers.md)** — one treasury, many specialized groups  
+4. **[Chambers and Sub-Chambers](./introduction/chamber-and-sub-chambers.md)** — what Create deploys; nested chambers as a contemplated pattern  
 5. **[Getting started](./introduction/getting-started.md)** — connect a wallet and use the app  
 
 Then, as you need detail:
@@ -26,7 +26,7 @@ Then, as you need detail:
 | Topic | Page |
 |--------|------|
 | Design goals | **[Vision](./protocol/vision.md)** |
-| Contracts and Registry | **[Architecture](./protocol/architecture.md)** |
+| Contracts and Factory | **[Architecture](./protocol/architecture.md)** |
 | Limits and implementation notes | **[Design notes](./protocol/design-notes.md)** |
 | Who may act for a director NFT | **[Director authorization](./protocol/director-authorization.md)** |
 | Deploy with Foundry | **[Deployment](./guides/deployment.md)** |

--- a/app/src/docs/guides/app-routes.md
+++ b/app/src/docs/guides/app-routes.md
@@ -21,7 +21,7 @@ This is a **map of screens** in the Chamber web app. Pair it with **[Getting sta
 |--------|-----|
 | Deposit, withdraw, delegate | Anyone with tokens and shares |
 | Submit / confirm / execute proposals | **Directors** only (top-seat NFT controllers) |
-| Deploy a Chamber | Anyone on a network where Registry is configured |
+| Deploy a Chamber | Anyone on a network where Factory is configured |
 
 The app checks **onchain** whether your wallet controls a seated NFT before showing director controls.
 

--- a/app/src/docs/guides/deployment.md
+++ b/app/src/docs/guides/deployment.md
@@ -15,20 +15,46 @@ cd contracts
 forge install
 ```
 
-## What Registry deploy does
+## What Factory deploy does
 
-`script/Registry.s.sol` (via `DeployRegistry` helper):
+`script/Factory.s.sol` (`DeployFactory`):
+
+1. Deploy or reuse a **Chamber** implementation (`CHAMBER_IMPLEMENTATION`, or a new `Chamber`).  
+2. Deploy **Factory** with that implementation and an **owner** (`ADMIN`, or `msg.sender`).  
+3. Return the **Factory address** the app should use (`VITE_*_FACTORY` env vars).
+
+Each **`Factory.createChamber`** then:
+
+- Spawns a **Chamber proxy** initialized with your ERC‑20, ERC‑721, seats, name, symbol.  
+- Transfers **ProxyAdmin ownership** to the Chamber (upgrades go through director queue).  
+- Emits **`ChamberCreated`** for indexers / `getLogs`. It does **not** write parent/child tables.
+
+Example:
+
+```bash
+cd contracts
+forge script script/Factory.s.sol:DeployFactory \
+  --rpc-url "$RPC_URL" \
+  --broadcast \
+  --private-key "$PRIVATE_KEY"
+```
+
+Set **`ADMIN`** in the environment if the owner should not be `msg.sender`.
+
+## What leftover Registry deploy does
+
+`script/Registry.s.sol` (via `DeployRegistry` helper) is the **deprecated** factory + index. It is not what Create uses when Factory is configured.
 
 1. Deploy **Registry** implementation.  
 2. Deploy **Chamber** implementation.  
 3. Deploy **Registry proxy** with `initialize(chamberImplementation, admin)`.  
-4. Return the **Registry address** your app should use (`VITE_*_REGISTRY` env vars).
+4. Return the **Registry address** (`VITE_*_REGISTRY` env vars).
 
-Each **`createChamber`** then:
+Each leftover **`Registry.createChamber`** then:
 
 - Spawns a **Chamber proxy** initialized with your ERC‑20, ERC‑721, seats, name, symbol.  
-- Transfers **ProxyAdmin ownership** to the Chamber (upgrades go through director queue).  
-- Optionally links **parent/child** if the asset token is another registered Chamber.
+- Transfers **ProxyAdmin ownership** to the Chamber.  
+- Optionally links **parent/child** if the asset token is another registered Chamber. That nested wiring is leftover — not the live architecture.
 
 Example:
 
@@ -44,7 +70,7 @@ Set **`ADMIN`** in the environment if the admin should not be `msg.sender`.
 
 ## Standalone Chamber script (local only)
 
-`script/Chamber.s.sol` deploys a Chamber proxy **without** Registry semantics (ProxyAdmin may stay with a separate admin EOA). Prefer **Registry** for production documentation and the app.
+`script/Chamber.s.sol` deploys a Chamber proxy **without** Factory semantics (ProxyAdmin may stay with a separate admin EOA). Prefer **Factory** for production documentation and the app. Registry remains a leftover index + create path.
 
 ## Post-create board bootstrap (Anvil or Sepolia)
 

--- a/app/src/docs/introduction/chamber-and-sub-chambers.md
+++ b/app/src/docs/introduction/chamber-and-sub-chambers.md
@@ -1,57 +1,61 @@
 # Chambers and Sub-Chambers
 
-Large communities rarely want **one wallet** for everything. Chambers let you split responsibility while keeping rules **visible onchain**.
+Create deploys **one Chamber**: a Factory-built ERC‑4626 vault, a liquid-delegated ranked board of membership NFTs, and a quorum wallet. That object is **standalone**. It is not a child of another Chamber, and it does not open a parent↔child tree.
 
-## Root Chamber — the main group
+**Sub-Chambers** — nested treasuries with Registry parent↔child wiring — are a **contemplated pattern**, not what Create deploys today. The leftover Registry can still record those links for older deployments. They are not the live architecture.
 
-A **root Chamber** is the primary treasury for your project:
+## What you get from Create
 
-- Holds the **main vault** (the shared pot of tokens).  
-- Runs the **main board** (who leads by delegation).  
-- Uses the **main transaction queue** for big outbound actions.
+A new Chamber is one proxy address that combines:
 
-Think of it as the **city council** for your protocol or DAO — cross-cutting decisions and the flagship treasury live here.
+- **Vault** — the shared ERC‑4626 pot (deposit the configured token, receive shares).
+- **Board** — a ranked leaderboard of membership NFT token IDs; the top seats are directors.
+- **Quorum wallet** — directors submit, confirm, and execute outbound actions.
 
-## Sub-Chamber — a focused working group
+Think of it as the **city council** for your protocol or DAO — cross-cutting decisions and the flagship treasury live on this one object.
 
-A **Sub-Chamber** is another Chamber deployment with its **own vault, board, and queue**, usually tied to a **narrow mandate**:
+## Nested chambers (contemplated)
 
-| Example Sub-Chamber | Typical mandate |
-|---------------------|-----------------|
+Large communities sometimes want **more than one wallet**. A contemplated pattern would split responsibility across several Chamber deployments while keeping the same rules **visible onchain**:
+
+| Example mandate | Why a separate Chamber |
+|-----------------|------------------------|
 | **Treasury** | Grants, payroll, stablecoin policy |
 | **Operations** | Vendor payments, infrastructure |
 | **R&D** | Experiments, smaller budgets |
 
-Each Sub-Chamber still follows the same rules: **deposit → delegate → directors → quorum → execute**. Contributors can see **which pot** and **which directors** own which decisions.
+Each deployment would still follow **deposit → delegate → directors → quorum → execute**. That structure is **not** what Create wires today. You can deploy more than one Chamber if you want separate pots, but the app does not treat them as parent and child.
 
-## Why split instead of one multisig?
+## Why people talk about splitting
 
 With a single multisig, every committee shares **one signer list** and **one approval flow**. That encourages either:
 
-- **Too many signers** on one Safe (slow, cluttered), or  
+- **Too many signers** on one Safe (slow, cluttered), or
 - **Hidden committees** that “just use the founder keys” off the record.
 
-Sub-Chambers make **structure explicit**: different vaults, different seats, different queues — without pretending one informal council represents everyone.
+Multiple Chambers would make **structure explicit**: different vaults, different seats, different queues — without pretending one informal council represents everyone. Until that nested pattern ships, the live product is **one Factory-deployed Chamber per Create**.
 
-## How Sub-Chambers connect (conceptually)
+## Registry leftover (not the factory)
 
-The **Registry** can record **parent ↔ child** relationships when a new Chamber uses **another Chamber’s share token** as its underlying asset. That models organizations where a sub-group’s treasury is denominated in the parent Chamber’s shares.
+An earlier model used the **Registry** as a factory (`createChamber()`, `getAllChambers()`) and recorded **parent ↔ child** when a new Chamber used another Chamber’s share token as its asset.
 
-You do not need to master that wiring to use the app — it matters when you **design** how treasury flows between layers. Builders: **[Architecture](../protocol/architecture.md)**.
+Create today calls **Factory** `createChamber()`. The Factory does **not** index a world list, does **not** write parent/child tables, and does **not** expose `createAgent()` — that API was never shipped.
 
-## Directors can be people, multisigs, or agents
+You do not need that leftover wiring to use the app. Builders: **[Architecture](../protocol/architecture.md)**.
 
-A **director** is whoever controls a **membership NFT token ID** in a **top seat**:
+## Directors can be people, contract wallets, or agents
 
-- **Individual** — wallet holds the NFT.  
-- **Multisig** — the NFT sits in a Safe; directors act through **EIP‑1271** signatures the Chamber understands.  
-- **Agent (future-facing)** — automated systems that still must pass the same **submit / confirm / execute** gates.
+A **director** is whoever is authorized for a **membership NFT token ID** in a **top seat**:
 
-The point is **one rulebook** for every seat type, not a special admin lane.
+- **Individual** — an EOA holds the NFT and calls as `msg.sender`.
+- **Contract wallet** — a Safe or similar holds the NFT and calls as itself; it may register a **session key** so an operator can act for that token.
+- **Agent** — same submit / confirm / execute gates as everyone else. Live auth is the NFT owner as `msg.sender`, or a session key the contract owner registered. Chamber never uses EIP‑1271.
+
+See **[Director authorization](../protocol/director-authorization.md)**. The point is **one rulebook** for every seat type, not a special admin lane.
 
 ## Read next
 
-- **[Why not just a multisig?](./why-not-multisig.md)**  
-- **[Getting started](./getting-started.md)**  
-- **[Governance](../protocol/governance.md)**  
-- **[Vision](../protocol/vision.md)** — why the design uses three primitives (vault, board, queue)  
+- **[Why not just a multisig?](./why-not-multisig.md)**
+- **[Getting started](./getting-started.md)**
+- **[Governance](../protocol/governance.md)**
+- **[Vision](../protocol/vision.md)** — why the design uses three primitives (vault, board, queue)

--- a/app/src/docs/introduction/getting-started.md
+++ b/app/src/docs/introduction/getting-started.md
@@ -21,7 +21,7 @@ Skim **[What is a Chamber?](./overview.md)** first if the ideas are new.
 
 **Go to:** **Deploy** (`/deploy`)
 
-You are launching a new treasury + governance ruleset through the **Factory** (Registry if Factory is unset).
+You are launching a new treasury + governance ruleset through the **Factory**. A leftover Registry create path may still exist if Factory is unset — that is not the live default.
 
 | Field | What it means |
 |--------|----------------|

--- a/app/src/docs/introduction/overview.md
+++ b/app/src/docs/introduction/overview.md
@@ -56,9 +56,9 @@ flowchart LR
 - **Board** — delegation ranks **NFT token IDs**; top **N** seats are directors.  
 - **Wallet** — directors queue **transactions** (send ETH, call contracts) with **quorum**.
 
-## Sub-Chambers (bigger organizations)
+## Nested chambers (contemplated)
 
-One **root Chamber** can anchor the main treasury. **Sub-Chambers** are additional Chambers with their own vault and directors for focused mandates (treasury committee, operations, experiments). See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
+Create deploys **one standalone Chamber** — vault, ranked board, quorum wallet. Nested **Sub-Chambers** (a root treasury with child Chambers, Registry parent↔child links) are a **contemplated pattern**, not what Create wires today. You can still deploy more than one Chamber if you want separate pots. See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
 
 ## Where to go next
 

--- a/app/src/docs/introduction/why-not-multisig.md
+++ b/app/src/docs/introduction/why-not-multisig.md
@@ -84,11 +84,11 @@ Consider a Chamber if:
 - **Many people** deposit into a shared treasury and need **transparent share accounting**.  
 - Leadership should **track delegation**, not a one-time signer CSV.  
 - You want **proposal → quorum → execution** entirely **onchain** for major outbound actions.  
-- You may grow into **Sub-Chambers** (treasury vs ops vs R&D) without one Safe holding everything.
+- You may deploy **more than one Chamber** for separate mandates. Nested Sub-Chambers (parent↔child) are a contemplated pattern, not what Create wires.
 
 ## Can you use both?
 
-Yes. A **multisig contract** can **own a membership NFT** and act as one **director seat** on the board. Humans might still use Safe internally; Chamber sees one **seat** with one voting path on the queue. See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
+Yes. A **multisig contract** can **own a membership NFT** and act as one **director seat** on the board. Humans might still use Safe internally; Chamber sees one **seat** with one voting path on the queue. See **[Director authorization](../protocol/director-authorization.md)**.
 
 ## Read next
 

--- a/app/src/docs/protocol/architecture.md
+++ b/app/src/docs/protocol/architecture.md
@@ -9,40 +9,50 @@ A Chamber is **one proxy address** that combines:
 | **Vault** | ERC‑4626 in `Chamber` | Share accounting |
 | **Board** | `Board` mixin | Delegation leaderboard + seats |
 | **Wallet** | `Wallet` mixin | Proposal queue |
-| **Registry** | `Registry` | Deploy new Chamber proxies |
+| **Factory** | `Factory` | Deploy new Chamber proxies |
 
 ```mermaid
 flowchart TB
-  R[Registry]
-  R -->|createChamber| P[Chamber proxy]
+  F[Factory]
+  F -->|createChamber| P[Chamber proxy]
   P --> V[ERC-4626 vault]
   P --> B[Board storage]
   P --> W[Wallet storage]
 ```
 
+Create deploys that standalone object. Nested Sub-Chambers and Registry parent↔child wiring are a **contemplated pattern**, not the live architecture.
+
 ## Chamber proxy
 
-- Initialized with **underlying ERC‑20**, **membership ERC‑721**, **seat count**, and share **name/symbol**.  
-- **Upgradeable** — logic changes go through **`upgradeImplementation`**, normally as a queued transaction.  
-- **`ProxyAdmin` ownership** is transferred to the Chamber itself after Registry deploy (so upgrades are also director-gated).
+- Initialized with **underlying ERC‑20**, **membership ERC‑721**, **seat count**, and share **name/symbol**.
+- **Upgradeable** — logic changes go through **`upgradeImplementation`**, normally as a queued transaction.
+- **`ProxyAdmin` ownership** is transferred to the Chamber itself after Factory deploy (so upgrades are also director-gated).
 
-## Registry
+## Factory
 
-- Stores the **implementation** used for new Chambers.  
-- **`createChamber`** deploys a new transparent proxy, initializes it, indexes it, and wires optional **parent/child** links.  
-- **`ADMIN_ROLE`** can update the implementation pointer for **future** deploys (does not auto-upgrade existing Chambers).
+- Stores the **implementation** used for new Chambers.
+- **`createChamber`** deploys a new transparent proxy, initializes it, and transfers **ProxyAdmin** to the Chamber.
+- Does **not** store an enumerable world list, asset index, or parent/child tables. Discover chambers via **`ChamberCreated`** logs (indexer or `getLogs`).
+- **Owner** can update the implementation pointer for **future** deploys (does not auto-upgrade existing Chambers).
+- There is no **`createAgent()`**.
+
+## Registry (leftover)
+
+- Historical factory + enumerable index. Create does **not** use it when Factory is configured.
+- May still record **parent/child** for older Registry-created chambers. That is **not** the live architecture.
+- **`getAllChambers()`** and parent↔child getters live here. They are leftover, not what Create writes.
 
 ## Offchain app
 
-The web app (`app/`) reads Registry and Chamber state and sends transactions users sign in their wallet — deposit, delegate, queue actions.
+The web app (`app/`) reads Factory `ChamberCreated` logs (and leftover Registry if configured) and Chamber state, then sends transactions users sign in their wallet — deposit, delegate, queue actions.
 
-## Registry vs lab deploy scripts
+## Factory vs lab deploy scripts
 
-Production-shaped flows use **`Registry.createChamber`**. Standalone Chamber deploy scripts in `contracts/script/` may leave **ProxyAdmin** with a different owner — fine for local experiments; **not** the product default.
+Production-shaped flows use **`Factory.createChamber`**. Standalone Chamber deploy scripts in `contracts/script/` may leave **ProxyAdmin** with a different owner — fine for local experiments; **not** the product default.
 
 ## Read next
 
-- **[Governance](./governance.md)** — behavior in plain language  
-- **[Design notes](./design-notes.md)** — storage layout and limits  
-- **[Deployment](../guides/deployment.md)** — Foundry commands  
-- **[API reference](../reference/api-reference.md)**  
+- **[Governance](./governance.md)** — behavior in plain language
+- **[Design notes](./design-notes.md)** — storage layout and limits
+- **[Deployment](../guides/deployment.md)** — Foundry commands
+- **[API reference](../reference/api-reference.md)**

--- a/app/src/docs/protocol/governance.md
+++ b/app/src/docs/protocol/governance.md
@@ -78,9 +78,9 @@ This stops a quick flash of votes from resizing the board without giving the com
 
 Directors can **vote to cancel** a queued transaction. If cancel votes reach **quorum**, the proposal is dead — it cannot be confirmed or executed afterward.
 
-## Sub-Chambers
+## Nested chambers (contemplated)
 
-If a Chamber’s vault asset is **another Chamber’s share token**, the Registry can record **parent / child** links. Each child still has its **own** board and queue. See **[Chambers and Sub-Chambers](../introduction/chamber-and-sub-chambers.md)**.
+A leftover Registry can record **parent / child** links when a Chamber’s vault asset is **another Chamber’s share token**. That is **not** what Factory Create writes. Nested Sub-Chambers remain a contemplated pattern. See **[Chambers and Sub-Chambers](../introduction/chamber-and-sub-chambers.md)**.
 
 ## Read next
 

--- a/app/src/docs/protocol/vision.md
+++ b/app/src/docs/protocol/vision.md
@@ -38,7 +38,7 @@ flowchart TB
 - **Legibility** — an outsider can read seats, quorum, and queued proposals from chain data.  
 - **Liquidity of influence** — delegation changes without redeploying a Safe.  
 - **Enforced execution** — approvals are **confirmations on a nonce**, not a separate offchain vote.  
-- **Composable orgs** — Sub-Chambers and Registry indexing for teams that outgrow one pot.  
+- **Composable orgs (contemplated)** — nested Sub-Chambers and leftover Registry indexing for teams that outgrow one pot. Create today deploys one standalone Chamber.  
 
 Agents, analytics, and dashboards sit **around** these interfaces. They do not replace onchain quorum or vault accounting.
 
@@ -46,5 +46,5 @@ Agents, analytics, and dashboards sit **around** these interfaces. They do not r
 
 - **[What is a Chamber?](../introduction/overview.md)**  
 - **[Why not just a multisig?](../introduction/why-not-multisig.md)**  
-- **[Architecture](./architecture.md)** — contracts and Registry (builders)  
+- **[Architecture](./architecture.md)** — contracts and Factory (builders)  
 - **[Whitepaper](https://loreum.org/whitepaper)** — long-form narrative  

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -2,11 +2,36 @@
 
 > **Audience:** developers integrating with or auditing contracts. New users should start with **[What is a Chamber?](../introduction/overview.md)** and **[Governance](../protocol/governance.md)**.
 
-Generated from interfaces in `contracts/src/` (`Registry`, `Chamber` / `IChamber`, plus **`IWallet`**, **`IBoard`**, **`IERC4626`**). Prefer NatSpec in-repo for exact wording.
+Generated from interfaces in `contracts/src/` (`Factory` / `IFactory`, leftover `Registry`, `Chamber` / `IChamber`, plus **`IWallet`**, **`IBoard`**, **`IERC4626`**). Prefer NatSpec in-repo for exact wording.
 
-## `Registry`
+## `Factory`
 
-Upgradeable registry behind a **`TransparentUpgradeableProxy`** in the production deploy script pattern (`contracts/test/utils/DeployRegistry.sol`). `Registry.initialize` pins the **Chamber implementation** and grants **`DEFAULT_ADMIN_ROLE`** and **`ADMIN_ROLE`** to `admin`.
+Thin, non-proxy deployer (`contracts/src/Factory.sol`). Constructor pins the **Chamber implementation** and **owner**. Create today uses this path. There is no **`createAgent()`**. The Factory does **not** store a world list or parent/child tables.
+
+### Write
+
+| Function | Notes |
+|---------|--------|
+| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, transfers **ProxyAdmin ownership to `chamber`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). `erc20Token` must be a **standard ERC-20** (no factory allowlist; fee-on-transfer / rebasing unsupported). |
+| **`setImplementation(address newImplementation)`** | **Owner only**; updates pointer for **future** `createChamber` only. Same-address updates are a no-op. |
+
+### Read
+
+| Function | Returns |
+|---------|---------|
+| **`implementation()`** | Chamber logic for the next proxy. |
+
+### Events / errors
+
+- **`ChamberCreated(chamber, asset, nft, seats, name, symbol, creator)`**
+- **`ChamberImplementationUpdated(previous, newImplementation)`**
+- **`ZeroAddress()`**, **`InvalidSeats()`**
+
+---
+
+## `Registry` (leftover)
+
+Historical factory + enumerable index. Not the live Create path when Factory is configured. Upgradeable registry behind a **`TransparentUpgradeableProxy`** (`contracts/test/utils/DeployRegistry.sol`). `Registry.initialize` pins the **Chamber implementation** and grants **`DEFAULT_ADMIN_ROLE`** and **`ADMIN_ROLE`** to `admin`. Parent/child getters describe leftover Registry wiring, not Factory Create.
 
 ### Write
 
@@ -109,19 +134,19 @@ Read helpers: **`getTransactionCount`**, **`getNextTransactionId`**, **`getTrans
 |---------|------|
 | **`getProxyAdmin() → address`** | Reads ERC‑1967 admin slot (OZ **ProxyAdmin** contract). |
 | **`upgradeImplementation(address newImplementation, bytes calldata data)`** | Requires **`msg.sender == address(this)`** (e.g. via **`executeTransaction`**); **`ProxyAdmin.owner() == address(this)`**; invokes **`upgradeAndCall`**. |
-| **`acceptAdmin()`** | No-op; registry transfers ProxyAdmin ownership directly. |
+| **`acceptAdmin()`** | No-op; Factory (or leftover Registry) transfers ProxyAdmin ownership directly. |
 
 ---
 
 ## Events (high-signal)
 
-From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IRegistry`** (non-exhaustive):
+From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IFactory`** / leftover **`IRegistry`** (non-exhaustive):
 
 - **Delegation / board:** `DelegationUpdated`, `Delegate`, `Undelegate`, `SetSeats`, `SeatUpdateCancelled`, `ExecuteSetSeats`  
 - **Wallet:** `SubmitTransaction`, `ProposalMetadataSet`, `ConfirmTransaction`, `RevokeConfirmation`, `ExecuteTransaction`, `CancelTransaction`, `TransactionCancelled`  
 - **Chamber-level wallet wraps:** `TransactionSubmitted`, `TransactionConfirmed`, `TransactionExecuted`, `TransactionCancelVoted`  
 - **Treasury receive:** `Received`, `ReceivedERC721`  
-- **Registry:** `ChamberCreated`, `ChamberImplementationUpdated`  
+- **Factory / leftover Registry:** `ChamberCreated`, `ChamberImplementationUpdated`  
 
 ---
 
@@ -129,7 +154,7 @@ From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IRegistry`** (non-exhaus
 
 | Area | Examples |
 |------|-----------|
-| Registry | `ZeroAddress`, `InvalidSeats` |
+| Factory / leftover Registry | `ZeroAddress`, `InvalidSeats` |
 | Chamber / IChamber | `InsufficientChamberBalance`, `ExceedsDelegatedAmount`, `AssetAmountMismatch`, `NotDirector`, `NotEnoughConfirmations`, `InvalidTransaction`, `NotAuthorized`, seat / token errors |
 | Board | `CircuitBreakerActive`, `TokenIdTooLarge`, `MaxNodesReached`, seat proposal / timelock errors |
 | Wallet / IWallet | `TransactionDoesNotExist`, `TransactionAlreadyExecuted`, `TransactionAlreadyConfirmed`, `TransactionNotConfirmed`, `TransactionAlreadyCancelled`, `DataHashMismatch`, `TransactionFailed`, `InvalidTarget` |
@@ -140,8 +165,8 @@ See interface files for full enumerations.
 
 ## Minimal integration checklist
 
-1. Discover **`Registry`** address for your chain.  
-2. Enumerate chambers via **`getChambers`** or subgraph.  
+1. Discover **`Factory`** address for your chain.  
+2. Enumerate chambers via **`ChamberCreated`** logs, indexer, or leftover Registry **`getChambers`**.  
 3. For a Chamber: read **`asset()`**, **`nft()`**, **`getSeats()`, `getQuorum()`, `getTop`/`getDirectors`**.  
 4. For wallets / indexers: subscribe to **`SubmitTransaction`** to persist **`bytes data`** alongside **`nonce`**.  
 5. For execution UI: reconstruct calldata matching stored hash before calling **`executeTransaction`**.  

--- a/app/src/docs/reference/sequence-diagrams.md
+++ b/app/src/docs/reference/sequence-diagrams.md
@@ -234,31 +234,30 @@ flowchart LR
 
 ## Chamber Deployment
 
-This diagram shows how a new Chamber is deployed through the Registry.
+This diagram shows how Create deploys a new Chamber through the **Factory**. The leftover Registry can still `createChamber` and write parent/child links; that is not the live path.
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant Registry
+    participant Factory
     participant ChamberImpl
     participant ChamberProxy
 
-    Note over User,ChamberProxy: Chamber deployment via Registry
+    Note over User,ChamberProxy: Chamber deployment via Factory
 
-    User->>Registry: createChamber(erc20Token, erc721Token, seats, name, symbol)
+    User->>Factory: createChamber(erc20Token, erc721Token, seats, name, symbol)
 
-    Registry->>Registry: Validate tokens non-zero, seats in 1..20, implementation set
+    Factory->>Factory: Validate tokens non-zero, seats in 1..20, implementation set
 
-    Registry->>ChamberProxy: new TransparentUpgradeableProxy(implementation, address(this), initData)
+    Factory->>ChamberProxy: new TransparentUpgradeableProxy(implementation, address(this), initData)
     Note over ChamberProxy: initData encodes Chamber.initialize(erc20, erc721, seats, name, symbol)
 
     ChamberProxy->>ChamberImpl: delegatecall initialize(...)
     ChamberImpl-->>ChamberProxy: ERC-4626 + Board + Wallet storage ready
 
-    Registry->>Registry: index chamber, parent/child if asset is chamber
-    Registry->>Registry: transfer Chamber ProxyAdmin ownership to address(chamber)
+    Factory->>Factory: transfer Chamber ProxyAdmin ownership to address(chamber)
 
-    Registry-->>User: ChamberCreated + return chamber proxy
+    Factory-->>User: ChamberCreated + return chamber proxy
 ```
 
 ---

--- a/app/src/docs/security/security-review.md
+++ b/app/src/docs/security/security-review.md
@@ -2,7 +2,7 @@
 
 > **Audience:** auditors and developers running structured reviews. Product users should rely on published audit reports and **[What is a Chamber?](../introduction/overview.md)** for trust assumptions.
 
-Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Chamber`, `Board`, `Wallet`, `Registry`). This page summarizes how to review it systematically.
+Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Factory`, `Chamber`, `Board`, `Wallet`, leftover `Registry`). This page summarizes how to review it systematically.
 
 ## What to protect
 
@@ -12,9 +12,9 @@ Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Chamber`
 
 ## Review phases
 
-1. **Architecture** — inheritance, storage slots, Registry → Chamber deploy path.  
+1. **Architecture** — inheritance, storage slots, Factory → Chamber deploy path.  
 2. **Per-function analysis** — access control, reentrancy, arithmetic, external calls.  
-3. **Cross-contract** — delegation vs transfers, stale confirmations, ERC‑1271 director auth.  
+3. **Cross-contract** — delegation vs transfers, stale confirmations, owner / session-key director auth.  
 4. **Tooling** — Slither, Foundry tests/fuzz, manual threat modeling.
 
 ## Common question areas

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -172,18 +172,25 @@ function Whitepaper() {
               
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">2.1 System Components</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                The Chamber Protocol consists of four primary contracts:
+                The shipped object is a Factory-deployed ERC-4626 vault, a liquid-delegated
+                ranked board of membership NFTs, and a quorum wallet. Create deploys that
+                standalone Chamber. Nested Sub-Chambers and Registry parent↔child wiring
+                are a contemplated pattern — not the live architecture. The primary
+                contracts are Factory, Chamber, Board, and Wallet.
               </p>
               
               <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
-                <h4 className="text-xl font-display mb-3 text-space-accent">Registry</h4>
+                <h4 className="text-xl font-display mb-3 text-space-accent">Factory</h4>
                 <p className="text-gray-300 leading-relaxed mb-3">
-                  A factory contract that deploys Chamber instances using the TransparentUpgradeableProxy pattern. 
-                  The Registry maintains an index of all deployed chambers and their associated assets. Upon deployment, 
-                  each Chamber receives ownership of its ProxyAdmin, enabling self-governed upgrades.
+                  A thin, non-proxy deployer that creates Chamber instances using the
+                  TransparentUpgradeableProxy pattern. Upon deployment, each Chamber
+                  receives ownership of its ProxyAdmin, enabling self-governed upgrades.
+                  The Factory does not store a world directory, asset index, or parent/child
+                  tables. Discover chambers via <code className="text-space-accent">ChamberCreated</code> logs.
+                  There is no <code className="text-space-accent">createAgent()</code> API.
                 </p>
                 <p className="text-gray-400 text-sm font-mono">
-                  Key Functions: createChamber(), createAgent(), getAllChambers()
+                  Key Functions: createChamber(), setImplementation(), implementation()
                 </p>
               </div>
 
@@ -221,6 +228,23 @@ function Whitepaper() {
                 </p>
                 <p className="text-gray-400 text-sm font-mono">
                   Key Functions: _submitTransaction(), _confirmTransaction(), _executeTransaction()
+                </p>
+              </div>
+
+              <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
+                <h4 className="text-xl font-display mb-3 text-space-accent">Registry (leftover)</h4>
+                <p className="text-gray-300 leading-relaxed mb-3">
+                  Historical factory and enumerable index. An earlier create path used
+                  Registry <code className="text-space-accent">createChamber()</code> and
+                  {" "}<code className="text-space-accent">getAllChambers()</code>, and could
+                  record parent↔child links when a Chamber&apos;s asset was another Chamber&apos;s
+                  share token. Create today uses Factory.
+                  {" "}<code className="text-space-accent">createAgent()</code> was never a
+                  shipped API. Registry remains in-repo as leftover / historical — not
+                  the live factory.
+                </p>
+                <p className="text-gray-400 text-sm font-mono">
+                  Leftover: createChamber(), getAllChambers(), getParentChamber(), getChildChambers()
                 </p>
               </div>
             </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #164.

In-app docs and the loreum.org whitepaper architecture section no longer present **Registry factory + Sub-Chambers + `createAgent()`** as the live product.

## What changed

Create deploys a **Factory** Chamber: ERC-4626 vault + liquid-delegated ranked board + quorum wallet. Nested Sub-Chambers and Registry parent↔child wiring are framed as a **contemplated / leftover** pattern.

- `app/src/docs/introduction/chamber-and-sub-chambers.md` — what Create deploys; nested chambers as design, not product
- `landing/src/Whitepaper.tsx` §2 — Factory + vault + board + quorum wallet; Registry leftover; no shipped `createAgent()`
- Related `app/src/docs/` pages (overview, architecture, governance, vision, API, sequences, deployment) so a reader cannot reconstruct the old model as live

## Out of scope (per #164)

- No Solidity
- No Sub-Chamber implementation
- No EIP-1271 reopen (director copy now matches session-key / `msg.sender` owner)
- Whitepaper body outside §2 left as-is

## How to verify

1. Open in-app docs: `/docs/introduction/chamber-and-sub-chambers` and `/docs/protocol/architecture`
2. Open loreum.org `/whitepaper` §2 Architecture Overview
3. Confirm none of those surfaces read as “Registry factory + Sub-Chambers + createAgent” being shipped

## Verification (this PR)

Rendered locally after the docs change:

- Landing `/whitepaper` §2: Factory first (`createChamber`, no `createAgent`); Chamber / Board / Wallet; **Registry (leftover)**
- In-app `/docs/introduction/chamber-and-sub-chambers`: standalone Factory Chamber; Sub-Chambers contemplated; Registry leftover
- `/docs/protocol/architecture`: mermaid Factory → Chamber proxy → vault / board / wallet
- `/docs/introduction/overview`: **Nested chambers (contemplated)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c58187a7-acb3-4900-aa0d-7a4e11b66bec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c58187a7-acb3-4900-aa0d-7a4e11b66bec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

