### PR TITLE
blog: session-key director changelog (2026-09-01)

### DIFF
--- a/landing/content/blog/2026-09-01-session-key-director.md
+++ b/landing/content/blog/2026-09-01-session-key-director.md
@@ -1,0 +1,11 @@
+---
+title: Session key for contract-owned membership NFTs
+date: 2026-09-01
+summary: Contract-owned membership NFTs can register a session-key operator. Queue and ChamberDetail show owner vs operator.
+---
+
+1 September 2026. Session key for contract-owned membership NFTs.
+
+- If a membership NFT is owned by a contract wallet, the owner can set a session key. That key can submit, confirm, execute, and change the board the same way the owner can.
+- Transfer clears the session. EOA-owned NFTs do not get this path. Chamber does not call ERC-1271.
+- Queue and ChamberDetail show NFT owner vs operator.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the 1 September 2026 Chamber changelog post for session keys on contract-owned membership NFTs.

**Live URL after merge:** https://www.loreum.org/blog/2026-09-01-session-key-director

**Source:** loreum-org/chamber #152 (merged 2026-08-31 11:24pm PHT).

The landing blog already eager-loads `landing/content/blog/*.md` via `import.meta.glob` in `landing/src/posts.ts`. This PR only adds the markdown file.

- Contract-owned membership NFTs can register a session-key operator
- Transfer clears the session; EOA-owned NFTs do not get this path
- Queue and ChamberDetail show NFT owner vs operator

Verified locally: `npm run build` in `landing/` succeeded, and the Vite preview served `/blog` and `/blog/2026-09-01-session-key-director` with both posts listed (new one first) and the older Factory post still present.

[Blog index with the new session-key post first](https://cursor.com/agents/bc-6c7722e5-bfbb-4573-9689-664ce256d5f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_index_session_key_post.webp)

[Session key changelog post page](https://cursor.com/agents/bc-6c7722e5-bfbb-4573-9689-664ce256d5f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_post_session_key_director.webp)

[blog_session_key_director_changelog.mp4](https://cursor.com/agents/bc-6c7722e5-bfbb-4573-9689-664ce256d5f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_session_key_director_changelog.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c7722e5-bfbb-4573-9689-664ce256d5f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c7722e5-bfbb-4573-9689-664ce256d5f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

