### PR TITLE
fix(landing): state shipped session-key director path (#169)

### DIFF
--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -197,7 +197,7 @@ function App() {
                 icon: <Network className="w-7 h-7 text-emerald-300" />,
                 tag: "§ 104(c)(2)(F–G)",
                 title: "Distributed & Impartial",
-                desc: "Authority must be distributed and the system impartial. Chamber seats directors from liquid delegation to membership NFTs. Director actions require the caller to be that NFT's owner; a quorum of directors then executes.",
+                desc: "Authority must be distributed and the system impartial. Chamber seats directors from liquid delegation to membership NFTs. Director actions require the NFT owner as msg.sender, or a session key the contract owner registered; a quorum of directors then executes.",
                 glow: "bg-emerald-500/10"
               }
             ].map((item, i) => (
@@ -288,7 +288,7 @@ function App() {
               {
                 icon: <Cpu className="w-8 h-8 text-emerald-400" />,
                 title: "Ranked Board & Quorum Wallet",
-                desc: "Membership NFTs form a liquid-delegated ranked board. Directors submit and confirm; a quorum of seats executes. The caller must be the NFT owner — an EIP-1271 agent-director path is not shipped.",
+                desc: "Membership NFTs form a liquid-delegated ranked board. Directors submit and confirm; a quorum of seats executes. The caller must be the NFT owner as msg.sender, or a session key the contract owner registered. An EIP-1271 agent-director path is not shipped.",
                 glow: "bg-emerald-500/20"
               }
             ].map((feature, i) => (
@@ -373,7 +373,8 @@ function App() {
                    <h3 className="text-2xl font-display mb-3 text-white group-hover:text-space-accent transition-colors">Quorum Wallet</h3>
                    <p className="text-gray-400 leading-relaxed font-light break-words">
                       Directors submit and confirm transactions; execution requires quorum.
-                      The caller must own the membership NFT for that seat.
+                      The caller must be the NFT owner as msg.sender, or a session key the
+                      contract owner registered. EIP-1271 is not shipped.
                    </p>
                 </div>
              </FadeIn>

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -86,8 +86,9 @@ function Whitepaper() {
               </p>
               <p className="text-gray-300 leading-relaxed">
                 Technical contributions include: (1) NFT-based directorship (live auth is the
-                membership NFT owner as <code className="text-space-accent">msg.sender</code>;
-                EIP-1271 contract-agent directors remain a design path, not shipped),
+                membership NFT owner as <code className="text-space-accent">msg.sender</code>,
+                or a session key the contract owner registered; EIP-1271 contract-agent
+                directors remain a design path, not shipped),
                 (2) liquid delegation without governance lockups, subject to solvency checks on delegated balances, 
                 (3) circuit-safe linked list repositioning for the governance leaderboard, and (4) self-sovereign
                 upgrade paths executed only through quorum-approved transactions. We provide specifications, security
@@ -139,7 +140,8 @@ function Whitepaper() {
                 single-actor capture when parameters and seat counts are tuned to policy; <strong className="text-space-accent font-normal">
                 agent parity</strong> — a designed EIP-1271 path would let smart-contract directors participate under the
                 same validation rules as EOAs. That path is not shipped; live director auth requires
-                {" "}<code className="text-space-accent">msg.sender</code> to be the membership NFT owner.
+                {" "}<code className="text-space-accent">msg.sender</code> to be the membership NFT owner, or a
+                session key the contract owner registered.
               </p>
 
               <h3 className="text-2xl font-display mb-4 mt-10 text-white">1.2 Chamber as protocol response</h3>
@@ -315,8 +317,8 @@ function Whitepaper() {
                 This section is a design specification for contract-agent directors, not the live
                 authorization path. Shipped Chamber requires{" "}
                 <code className="text-space-accent">msg.sender</code> to be the membership NFT
-                owner. EIP-1271 agent directors are research; they are not a Chamber capability
-                until that path ships.
+                owner, or a session key the contract owner registered. EIP-1271 agent directors
+                are research; they are not a Chamber capability until that path ships.
               </p>
               
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.1 EIP-1271 Signature Validation</h3>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #169.

The homepage still described director auth as owner-only plus “EIP-1271 is not shipped.” That remains true for 1271, but #152 already shipped `setDirectorOperator` for contract-owned membership NFTs.

## What a visitor can now read
- **Ranked Board & Quorum Wallet** (Autonomous Architecture): caller is the NFT owner as `msg.sender`, **or** a session key the contract owner registered. EIP-1271 is still not shipped.
- **Quorum Wallet** (Ecosystem Governance) and the CLARITY “Distributed & Impartial” card use the same live rule.
- Whitepaper live-auth sentences (abstract, §1.1, §4 framing) add that same session-key clause. §4 is **not** rewritten into a 1271 tutorial.

## Out of scope
- Solidity / new 1271 work (does not reopen M-01 / #116)
- Digital Fleet / fake APY (#163 / PR #165)
- Registry / Sub-Chambers docs rewrite (#164 / PR #166)
- CCA

Changelog already live: https://www.loreum.org/blog/2026-09-01-session-key-director

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-009e6872-fe02-4abe-a084-f6d3a86bd69b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-009e6872-fe02-4abe-a084-f6d3a86bd69b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

