### PR TITLE
fix(landing): replace footer href=# stubs with live destinations

### DIFF
--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { ArrowRight, ChevronRight, Layers, Shield, Cpu, TrendingUp, ShieldAlert, Search, Radio, Scale, Eye, Network } from 'lucide-react';
+import Footer from './Footer.tsx';
 
 const FadeIn = ({ children, delay = 0, className = "" }: { children: React.ReactNode, delay?: number, className?: string }) => (
   <motion.div
@@ -563,51 +564,7 @@ function App() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="relative z-10 bg-space-900 pt-20 pb-10 border-t border-white/10 w-full min-w-0 overflow-x-hidden">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 grid md:grid-cols-4 gap-12 mb-16 w-full min-w-0 box-border">
-          <div className="col-span-1 md:col-span-2">
-            <div className="flex items-center gap-2 mb-6">
-              <img src="/logo.svg" alt="Loreum Logo" className="w-6 h-6" />
-              <span className="text-2xl font-display tracking-wider">LOREUM</span>
-            </div>
-            <p className="text-gray-500 max-w-xs font-light">
-              The Chamber Protocol — infrastructure for credibly neutral, agent-driven
-              Decentralized Governance Systems in the CLARITY era.
-            </p>
-          </div>
-          
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">PLATFORM</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><Link to="/team" className="hover:text-white transition-colors">Team</Link></li>
-              <li><Link to="/blog" className="hover:text-white transition-colors">Blog</Link></li>
-              <li><a href="#" className="hover:text-white transition-colors">Agents</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Chambers</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Security</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Roadmap</a></li>
-            </ul>
-          </div>
-          
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">COMMUNITY</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><a href="#" className="hover:text-white transition-colors">Discord</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Twitter</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">GitHub</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Documentation</a></li>
-            </ul>
-          </div>
-        </div>
-        
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-8 border-t border-white/5 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-gray-600 w-full min-w-0 box-border text-center md:text-start">
-          <div>© 2026 LOREUM DAO LLC. ALL RIGHTS RESERVED.</div>
-          <div className="flex gap-8">
-            <a href="#" className="hover:text-gray-400">PRIVACY POLICY</a>
-            <a href="#" className="hover:text-gray-400">TERMS OF SERVICE</a>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/landing/src/Blog.tsx
+++ b/landing/src/Blog.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link, useParams } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import { formatPostDate, getPost, posts } from './posts.ts';
+import Footer from './Footer.tsx';
 
 const FadeIn = ({ children, delay = 0, className = "" }: { children: React.ReactNode, delay?: number, className?: string }) => (
   <motion.div
@@ -103,50 +104,7 @@ function BlogChrome({ title, children }: { title: string; children: React.ReactN
 
       {children}
 
-      <footer className="relative z-10 bg-space-900 pt-20 pb-10 border-t border-white/10 w-full min-w-0 overflow-x-hidden">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 grid md:grid-cols-4 gap-12 mb-16 w-full min-w-0 box-border">
-          <div className="col-span-1 md:col-span-2">
-            <div className="flex items-center gap-2 mb-6">
-              <img src="/logo.svg" alt="Loreum Logo" className="w-6 h-6" />
-              <span className="text-2xl font-display tracking-wider">LOREUM</span>
-            </div>
-            <p className="text-gray-500 max-w-xs font-light">
-              The Chamber Protocol — infrastructure for credibly neutral, agent-driven
-              Decentralized Governance Systems in the CLARITY era.
-            </p>
-          </div>
-
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">PLATFORM</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><Link to="/team" className="hover:text-white transition-colors">Team</Link></li>
-              <li><Link to="/blog" className="hover:text-white transition-colors">Blog</Link></li>
-              <li><a href="#" className="hover:text-white transition-colors">Agents</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Chambers</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Security</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Roadmap</a></li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">COMMUNITY</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><a href="#" className="hover:text-white transition-colors">Discord</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Twitter</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">GitHub</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Documentation</a></li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-8 border-t border-white/5 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-gray-600 w-full min-w-0 box-border text-center md:text-start">
-          <div>© 2026 LOREUM DAO LLC. ALL RIGHTS RESERVED.</div>
-          <div className="flex gap-8">
-            <a href="#" className="hover:text-gray-400">PRIVACY POLICY</a>
-            <a href="#" className="hover:text-gray-400">TERMS OF SERVICE</a>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/landing/src/Footer.tsx
+++ b/landing/src/Footer.tsx
@@ -1,0 +1,83 @@
+import { Link } from 'react-router-dom';
+
+/** Production default so CTAs work when env is unset in a static build. */
+const chamberAppUrl =
+  (import.meta.env.VITE_CHAMBER_APP_URL as string | undefined)?.trim() ||
+  'https://app.loreum.org';
+
+const itemClass = 'hover:text-white transition-colors';
+
+/**
+ * Landing footer. Every link is a live destination — Team, Blog, Chambers,
+ * X, GitHub, and docs.loreum.org. Dead stubs (Agents, Roadmap, Security,
+ * Discord, Privacy, Terms) are omitted until real pages exist.
+ */
+function Footer() {
+  return (
+    <footer className="relative z-10 bg-space-900 pt-20 pb-10 border-t border-white/10 w-full min-w-0 overflow-x-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 grid md:grid-cols-4 gap-12 mb-16 w-full min-w-0 box-border">
+        <div className="col-span-1 md:col-span-2">
+          <div className="flex items-center gap-2 mb-6">
+            <img src="/logo.svg" alt="Loreum Logo" className="w-6 h-6" />
+            <span className="text-2xl font-display tracking-wider">LOREUM</span>
+          </div>
+          <p className="text-gray-500 max-w-xs font-light">
+            The Chamber Protocol — infrastructure for credibly neutral, agent-driven
+            Decentralized Governance Systems in the CLARITY era.
+          </p>
+        </div>
+
+        <div>
+          <h4 className="font-bold tracking-widest text-sm mb-6">PLATFORM</h4>
+          <ul className="space-y-4 text-sm text-gray-400 font-light">
+            <li><Link to="/team" className={itemClass}>Team</Link></li>
+            <li><Link to="/blog" className={itemClass}>Blog</Link></li>
+            <li><a href={chamberAppUrl} className={itemClass}>Chambers</a></li>
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="font-bold tracking-widest text-sm mb-6">COMMUNITY</h4>
+          <ul className="space-y-4 text-sm text-gray-400 font-light">
+            <li>
+              <a
+                href="https://x.com/loreumdao"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={itemClass}
+              >
+                X
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/loreum-org/chamber"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={itemClass}
+              >
+                GitHub
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://docs.loreum.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={itemClass}
+              >
+                Documentation
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-8 border-t border-white/5 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-gray-600 w-full min-w-0 box-border text-center md:text-start">
+        <div>© 2026 LOREUM DAO LLC. ALL RIGHTS RESERVED.</div>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/landing/src/Team.tsx
+++ b/landing/src/Team.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
+import Footer from './Footer.tsx';
 
 const FadeIn = ({ children, delay = 0, className = "" }: { children: React.ReactNode, delay?: number, className?: string }) => (
   <motion.div
@@ -136,51 +137,7 @@ function Team() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="relative z-10 bg-space-900 pt-20 pb-10 border-t border-white/10 w-full min-w-0 overflow-x-hidden">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 grid md:grid-cols-4 gap-12 mb-16 w-full min-w-0 box-border">
-          <div className="col-span-1 md:col-span-2">
-            <div className="flex items-center gap-2 mb-6">
-              <img src="/logo.svg" alt="Loreum Logo" className="w-6 h-6" />
-              <span className="text-2xl font-display tracking-wider">LOREUM</span>
-            </div>
-            <p className="text-gray-500 max-w-xs font-light">
-              The Chamber Protocol — infrastructure for credibly neutral, agent-driven
-              Decentralized Governance Systems in the CLARITY era.
-            </p>
-          </div>
-
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">PLATFORM</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><Link to="/team" className="hover:text-white transition-colors">Team</Link></li>
-              <li><Link to="/blog" className="hover:text-white transition-colors">Blog</Link></li>
-              <li><a href="#" className="hover:text-white transition-colors">Agents</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Chambers</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Security</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Roadmap</a></li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-bold tracking-widest text-sm mb-6">COMMUNITY</h4>
-            <ul className="space-y-4 text-sm text-gray-400 font-light">
-              <li><a href="#" className="hover:text-white transition-colors">Discord</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Twitter</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">GitHub</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Documentation</a></li>
-            </ul>
-          </div>
-        </div>
-        
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-8 border-t border-white/5 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-gray-600 w-full min-w-0 box-border text-center md:text-start">
-          <div>© 2026 LOREUM DAO LLC. ALL RIGHTS RESERVED.</div>
-          <div className="flex gap-8">
-            <a href="#" className="hover:text-gray-400">PRIVACY POLICY</a>
-            <a href="#" className="hover:text-gray-400">TERMS OF SERVICE</a>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #168.

The loreum.org footer used `href="#"` for Platform (Agents, Chambers, Security, Roadmap), Community (Discord, Twitter, GitHub, Documentation), and Privacy / Terms. Every path 200s the SPA homepage, so visitors could not reach Team, Blog, the app, GitHub, or @loreumdao.

## What the footer now links

| Item | Destination |
| --- | --- |
| Team | `/team` |
| Blog | `/blog` |
| Chambers | `https://app.loreum.org` (`VITE_CHAMBER_APP_URL` when set) |
| X | `https://x.com/loreumdao` |
| GitHub | `https://github.com/loreum-org/chamber` |
| Documentation | `https://docs.loreum.org` (live Docusaurus) |

Removed until a real URL exists: Agents, Roadmap, Security, Discord, Privacy Policy, Terms of Service.

The same stub footer lived on Team and Blog, so those pages now share `landing/src/Footer.tsx`. Visual language is unchanged. Whitepaper keeps its existing simple footer (already had real Team / Blog links). Digital Fleet / fake APY is untouched (#163 / PR #165).

## Out of scope

- Digital Fleet / fake APY (#163 / PR #165)
- Building Agents / Roadmap / Security / legal pages
- Discord (no inventing an invite)
- Solidity / CCA / GTM

## Verified

Local `npm run build` + `vite preview` on :4173. Production bundle has zero `href="#"`, Privacy Policy, or Terms of Service strings. Walked home → Team → Blog and hovered Chambers / X / GitHub / Documentation. Same footer on desktop and a 390px viewport.

[Homepage footer desktop](https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_footer_desktop.webp)
[Team page footer](https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam_footer_desktop.webp)
[Blog page footer](https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_footer_desktop.webp)
[Homepage footer mobile](https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_footer_mobile.webp)
[landing_footer_links_walkthrough.mp4](https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_footer_links_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53b753a3-89b2-41cb-99b7-decc7db00654?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b753a3-89b2-41cb-99b7-decc7db00654&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

