### PR TITLE
blog: Chamber operator changelog (2026-09-04)

### DIFF
--- a/landing/content/blog/2026-09-04-chamber-operator.md
+++ b/landing/content/blog/2026-09-04-chamber-operator.md
@@ -1,0 +1,11 @@
+---
+title: Chamber operator for agents
+date: 2026-09-04
+summary: @loreum/chamber-operator is a typed surface for board, delegate, submit, confirm, and execute. Same ABI as the app. No bundler or paymaster. Not a UI replacement.
+---
+
+4 September 2026. Chamber operator for agents.
+
+- `@loreum/chamber-operator` is a typed surface for board, delegate, submit, confirm, and execute.
+- Same ABI as the app. Agents that cannot click TransactionQueue can call the same functions.
+- No bundler or paymaster ships with the package. It is not a click-UI replacement.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the 4 September 2026 Chamber changelog post for `@loreum/chamber-operator`.

Fixes #175.

**Live URL after merge:** https://www.loreum.org/blog/2026-09-04-chamber-operator

**Source:** loreum-org/chamber #153 (merged 2026-08-30).

The landing blog already eager-loads `landing/content/blog/*.md` via `import.meta.glob` in `landing/src/posts.ts`. This PR only adds the markdown file.

- Typed surface for board, delegate, submit, confirm, and execute
- Same ABI as the app — for agents that cannot click TransactionQueue
- No bundler or paymaster shipped; not a click-UI replacement

Session-key on the operator is out of scope (separate issue #174).

Verified locally: `npm run build` in `landing/` succeeded. Vite preview served `/blog` and `/blog/2026-09-04-chamber-operator` with the new post first; the session-key and Factory posts still render; unknown slugs still show “Post not found”.

[Blog index with three posts, operator changelog first](https://cursor.com/agents/bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_index_three_posts.webp)

[Chamber operator changelog post page](https://cursor.com/agents/bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_post_chamber_operator.webp)

[Blog index on a 390px mobile viewport](https://cursor.com/agents/bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_index_mobile.webp)

[blog_chamber_operator_changelog.mp4](https://cursor.com/agents/bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_chamber_operator_changelog.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9df5b0dc-6c7f-4736-bd96-c82c30bd85f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

