### PR TITLE
feat(operator): set and clear session-key director operator

### DIFF
--- a/packages/operator/README.md
+++ b/packages/operator/README.md
@@ -108,13 +108,14 @@ npm run example:anvil
 That script starts Anvil if needed, runs `DeployAllAnvil`, creates a 3-seat chamber, then:
 
 1. Reads `getDirectorOperator` (zero) and shows EOA `setDirectorOperator` → `You are not a director`
-2. Delegates from two directors and shows a pending board
-3. `submit` before the seating delay → `Your seat is not mature yet`
-4. Mines one block (`SEATING_DELAY = 1`)
-5. `submit` → `confirm` → `execute`
-6. A third key `confirm` → `You are not a director`
-7. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
-8. Board `pause()` then `execute` → `This chamber is paused`
+2. Contract-wallet owner `setDirectorOperator` / CLI `operator` read / `clearDirectorOperator`
+3. Delegates from two directors and shows a pending board
+4. `submit` before the seating delay → `Your seat is not mature yet`
+5. Mines one block (`SEATING_DELAY = 1`)
+6. `submit` → `confirm` → `execute`
+7. A third key `confirm` → `You are not a director`
+8. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
+9. Board `pause()` then `execute` → `This chamber is paused`
 
 ## Out of scope
 

--- a/packages/operator/README.md
+++ b/packages/operator/README.md
@@ -2,7 +2,7 @@
 
 Typed operator surface for Chamber. Agents cannot click `TransactionQueue`; this package calls the same functions the React app already uses, through `contracts/generated-abis.ts`.
 
-Implements [loreum-org/chamber#146](https://github.com/loreum-org/chamber/issues/146).
+Implements [loreum-org/chamber#146](https://github.com/loreum-org/chamber/issues/146) (board / queue) and [loreum-org/chamber#174](https://github.com/loreum-org/chamber/issues/174) (session-key director operator).
 
 ## What it does
 
@@ -11,10 +11,12 @@ Given RPC + a signer + a chamber address:
 | Action | Chamber function |
 | --- | --- |
 | Read board + quorum | `getTop`, `getSeats`, `getQuorum`, `getDirectors`, `getSeatedAt`, `paused` |
+| Read session key | `getDirectorOperator` |
 | Delegate | `delegate` |
 | Submit | `submitTransaction` |
 | Confirm | `confirmTransaction` |
 | Execute | `executeTransaction` |
+| Set / clear session key | `setDirectorOperator` (`address(0)` clears) |
 
 Signer is a private key, a viem `Account`, or a prebuilt `WalletClient` (including a 4337 smart-account client whose `writeContract` submits a user operation). This package does not ship a bundler or paymaster.
 
@@ -48,7 +50,13 @@ const { nonce } = await op.submitTransaction({
 })
 await op.confirm(2n, nonce)
 await op.execute(1n, nonce, '0x')
+
+const live = await op.getDirectorOperator(1n)
+await op.setDirectorOperator(1n, '0x…') // contract-wallet owner only
+await op.clearDirectorOperator(1n) // setDirectorOperator(tokenId, address(0))
 ```
+
+`setDirectorOperator` / `clearDirectorOperator` must be sent by the current NFT owner, and that owner must be a **contract**. EOA-owned membership NFTs are rejected by the protocol (`NotDirector` / `You are not a director`). There is **no ERC-1271 fallback** — Chamber never calls `isValidSignature`. Use a 4337 / smart-account `walletClient` whose address is the contract owner (see below). Reads return `address(0)` when the key is unset, stale after transfer, or the owner is an EOA.
 
 4337 signer:
 
@@ -71,6 +79,11 @@ export PRIVATE_KEY=0x…
 
 npx chamber-operator board --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
 npx chamber-operator quorum --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
+npx chamber-operator operator --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --token-id 1
+npx chamber-operator set-operator --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --operator 0x…
+npx chamber-operator clear-operator --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1
 npx chamber-operator delegate --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 1 --amount 1ether
 npx chamber-operator submit --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
@@ -80,6 +93,8 @@ npx chamber-operator confirm --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$P
 npx chamber-operator execute --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 1 --nonce 0 --data 0x
 ```
+
+`operator` is a read (no key). `set-operator` / `clear-operator` use the same signer as `delegate`. A CLI private key is an EOA, so those writes revert unless you wrap a contract-wallet signer via the library API. That revert is protocol behavior, not a 1271 workaround.
 
 ## Anvil end-to-end
 
@@ -92,13 +107,14 @@ npm run example:anvil
 
 That script starts Anvil if needed, runs `DeployAllAnvil`, creates a 3-seat chamber, then:
 
-1. Delegates from two directors and shows a pending board
-2. `submit` before the seating delay → `Your seat is not mature yet`
-3. Mines one block (`SEATING_DELAY = 1`)
-4. `submit` → `confirm` → `execute`
-5. A third key `confirm` → `You are not a director`
-6. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
-7. Board `pause()` then `execute` → `This chamber is paused`
+1. Reads `getDirectorOperator` (zero) and shows EOA `setDirectorOperator` → `You are not a director`
+2. Delegates from two directors and shows a pending board
+3. `submit` before the seating delay → `Your seat is not mature yet`
+4. Mines one block (`SEATING_DELAY = 1`)
+5. `submit` → `confirm` → `execute`
+6. A third key `confirm` → `You are not a director`
+7. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
+8. Board `pause()` then `execute` → `This chamber is paused`
 
 ## Out of scope
 

--- a/packages/operator/examples/anvil-e2e.ts
+++ b/packages/operator/examples/anvil-e2e.ts
@@ -6,7 +6,7 @@
  *
  * Spawns a fresh Anvil, deploys Registry/Factory/mocks, creates a 3-seat
  * chamber, then exercises board/quorum/delegate/submit/confirm/execute,
- * session-key read + EOA setDirectorOperator rejection, and the four
+ * session-key read + EOA reject + contract-wallet set/clear, and the four
  * app-mapped failure strings.
  */
 import { spawn, type ChildProcess } from 'node:child_process'
@@ -14,8 +14,10 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  type Account,
   type Address,
   type Hex,
+  type WalletClient,
   createPublicClient,
   createWalletClient,
   decodeEventLog,
@@ -101,6 +103,89 @@ function run(cmd: string, args: string[], cwd: string): Promise<void> {
       else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}`))
     })
   })
+}
+
+function runCapture(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (buf: Buffer) => {
+      stdout += buf.toString()
+    })
+    child.stderr?.on('data', (buf: Buffer) => {
+      stderr += buf.toString()
+    })
+    child.on('exit', (code) => {
+      if (code === 0) resolve(stdout)
+      else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}\n${stderr}\n${stdout}`))
+    })
+  })
+}
+
+const execWalletAbi = [
+  {
+    type: 'function',
+    name: 'execute',
+    inputs: [
+      { name: 'target', type: 'address' },
+      { name: 'data', type: 'bytes' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const
+
+/** WalletClient whose address is the contract owner; writes go through `execute`. */
+function contractOwnerClient(owner: Account, wallet: Address): WalletClient {
+  const inner = createWalletClient({ account: owner, transport: http(RPC) })
+  return {
+    account: { address: wallet, type: 'json-rpc' },
+    writeContract: async (args: {
+      address: Address
+      abi: typeof chamberAbi
+      functionName: string
+      args?: readonly unknown[]
+    }) => {
+      const data = encodeFunctionData({
+        abi: args.abi,
+        functionName: args.functionName as 'setDirectorOperator',
+        args: args.args as [bigint, Address],
+      })
+      return inner.writeContract({
+        address: wallet,
+        abi: execWalletAbi,
+        functionName: 'execute',
+        args: [args.address, data],
+        account: owner,
+        chain: null,
+      })
+    },
+  } as unknown as WalletClient
+}
+
+async function deployExecWallet(authorized: Address): Promise<Address> {
+  const output = await runCapture(
+    'forge',
+    [
+      'create',
+      'test/unit/Chamber.t.sol:MockERC1271Wallet',
+      '--rpc-url',
+      RPC,
+      '--private-key',
+      ANVIL_KEY0,
+      '--broadcast',
+      '--constructor-args',
+      authorized,
+      '--json',
+    ],
+    CONTRACTS,
+  )
+  const match = output.match(/"deployedTo"\s*:\s*"(0x[0-9a-fA-F]{40})"/)
+  if (match) return match[1] as Address
+  const line = output.match(/Deployed to:\s*(0x[0-9a-fA-F]{40})/)
+  if (line) return line[1] as Address
+  throw new Error(`forge create did not report a wallet address:\n${output}`)
 }
 
 async function readDeployments(): Promise<Deployments> {
@@ -291,6 +376,47 @@ async function main(): Promise<void> {
     if (stillUnset !== '0x0000000000000000000000000000000000000000') {
       throw new Error(`expected operator to stay unset after EOA reject, got ${stillUnset}`)
     }
+
+    log('session key: contract-wallet owner set / read / clear')
+    const ownerWallet = await deployExecWallet(admin.address)
+    await wallet.writeContract({
+      address: deployments.mockERC721,
+      abi: mockERC721Abi,
+      functionName: 'mintWithTokenId',
+      args: [ownerWallet, 3n],
+      account: admin,
+      chain: null,
+    })
+    const opWallet = await createOperator({
+      rpcUrl: RPC,
+      chamber,
+      signer: { type: 'walletClient', walletClient: contractOwnerClient(admin, ownerWallet) },
+    })
+    await opWallet.setDirectorOperator(3n, outsider.address)
+    const live = await opWallet.getDirectorOperator(3n)
+    if (live.toLowerCase() !== outsider.address.toLowerCase()) {
+      throw new Error(`expected live operator ${outsider.address}, got ${live}`)
+    }
+    const cliRead = JSON.parse(
+      await runCapture(
+        'npx',
+        ['tsx', 'src/cli.ts', 'operator', '--rpc', RPC, '--chamber', chamber, '--token-id', '3'],
+        join(ROOT, 'packages/operator'),
+      ),
+    ) as { operator?: string }
+    if (cliRead.operator?.toLowerCase() !== outsider.address.toLowerCase()) {
+      throw new Error(`CLI operator read mismatch: ${JSON.stringify(cliRead)}`)
+    }
+    await opWallet.clearDirectorOperator(3n)
+    const cleared = await opWallet.getDirectorOperator(3n)
+    if (cleared !== '0x0000000000000000000000000000000000000000') {
+      throw new Error(`expected cleared operator, got ${cleared}`)
+    }
+    log('session key contract-wallet path', {
+      ownerWallet,
+      set: outsider.address,
+      cleared,
+    })
 
     log('delegate (both directors)')
     await opA.delegate(1n, deposit)

--- a/packages/operator/examples/anvil-e2e.ts
+++ b/packages/operator/examples/anvil-e2e.ts
@@ -5,8 +5,9 @@
  * From `packages/operator`: `npm run example:anvil`
  *
  * Spawns a fresh Anvil, deploys Registry/Factory/mocks, creates a 3-seat
- * chamber, then exercises board/quorum/delegate/submit/confirm/execute and
- * the four app-mapped failure strings.
+ * chamber, then exercises board/quorum/delegate/submit/confirm/execute,
+ * session-key read + EOA setDirectorOperator rejection, and the four
+ * app-mapped failure strings.
  */
 import { spawn, type ChildProcess } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
@@ -278,6 +279,19 @@ async function main(): Promise<void> {
       })
     }
 
+    log('session key: unset read is address(0); EOA owner cannot register')
+    const unset = await opA.getDirectorOperator(1n)
+    if (unset !== '0x0000000000000000000000000000000000000000') {
+      throw new Error(`expected unset operator, got ${unset}`)
+    }
+    await expectMessage('EOA setDirectorOperator', CHAMBER_ERROR_MESSAGES.NotDirector, () =>
+      opA.setDirectorOperator(1n, outsider.address),
+    )
+    const stillUnset = await opA.getDirectorOperator(1n)
+    if (stillUnset !== '0x0000000000000000000000000000000000000000') {
+      throw new Error(`expected operator to stay unset after EOA reject, got ${stillUnset}`)
+    }
+
     log('delegate (both directors)')
     await opA.delegate(1n, deposit)
     await opB.delegate(2n, deposit)
@@ -370,7 +384,9 @@ async function main(): Promise<void> {
       opA.execute(1n, pausedTx.nonce, '0x'),
     )
 
-    log('done — board, quorum, delegate, submit, confirm, execute, and the four app error strings')
+    log(
+      'done — board, quorum, session-key read, EOA setDirectorOperator reject, delegate, submit, confirm, execute, and the four app error strings',
+    )
   } finally {
     if (spawned) {
       spawned.kill('SIGTERM')

--- a/packages/operator/package.json
+++ b/packages/operator/package.json
@@ -2,7 +2,7 @@
   "name": "@loreum/chamber-operator",
   "version": "0.1.0",
   "private": true,
-  "description": "Typed Chamber operator surface for agents: board, quorum, delegate, submit, confirm, execute.",
+  "description": "Typed Chamber operator surface for agents: board, quorum, delegate, submit, confirm, execute, session-key operator.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/operator/src/abi.ts
+++ b/packages/operator/src/abi.ts
@@ -1,10 +1,50 @@
 /**
  * Re-export the generated Chamber ABI. Do not invent a second contract API.
  * Source of truth: `contracts/generated-abis.ts` (`make sync-abis`).
+ *
+ * #152 added `setDirectorOperator` / `getDirectorOperator` on IChamber. The
+ * last synced generated file does not include those entries yet, so the
+ * IChamber fragments are appended here. Custom-error decoding still uses the
+ * generated ABI (same `wrapChamberError` path as board / queue writes).
  */
-export {
-  chamberAbi,
+import {
+  chamberAbi as generatedChamberAbi,
   factoryAbi,
   mockERC20Abi,
   mockERC721Abi,
 } from '../../../contracts/generated-abis.ts'
+
+export { factoryAbi, mockERC20Abi, mockERC721Abi }
+
+/** Exact IChamber session-key surface from #152. Not an ERC-1271 fallback. */
+export const directorOperatorAbi = [
+  {
+    type: 'function',
+    name: 'getDirectorOperator',
+    inputs: [{ name: 'tokenId', type: 'uint256', internalType: 'uint256' }],
+    outputs: [{ name: 'operator', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'setDirectorOperator',
+    inputs: [
+      { name: 'tokenId', type: 'uint256', internalType: 'uint256' },
+      { name: 'operator', type: 'address', internalType: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    name: 'DirectorOperatorSet',
+    inputs: [
+      { name: 'tokenId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'owner', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'operator', type: 'address', indexed: true, internalType: 'address' },
+    ],
+    anonymous: false,
+  },
+] as const
+
+export const chamberAbi = [...generatedChamberAbi, ...directorOperatorAbi] as const

--- a/packages/operator/src/cli.ts
+++ b/packages/operator/src/cli.ts
@@ -11,10 +11,13 @@ Commands:
   board                 Read board seats, quorum, pause, and seating
   quorum                Read live quorum
   tx --nonce <n>        Read one queued nonce
+  operator              Read live session-key operator for a tokenId
   delegate              Delegate vault shares to a membership tokenId
   submit                submitTransaction (director)
   confirm               confirmTransaction (director)
   execute               executeTransaction (director)
+  set-operator          setDirectorOperator (contract-wallet NFT owner)
+  clear-operator        setDirectorOperator(tokenId, address(0))
 
 Required (or env):
   --rpc <url>           RPC_URL / CHAMBER_RPC
@@ -29,6 +32,13 @@ Writes:
   --data <hex>          submit / execute calldata (default 0x)
   --deadline <unix>     optional submit deadline
   --nonce <n>           confirm / execute / tx
+  --operator <addr>     set-operator session key
+
+Session keys: only a contract-owned membership NFT can register an operator.
+EOA-owned NFTs revert (NotDirector / You are not a director). There is no
+ERC-1271 fallback — Chamber never calls isValidSignature. set-operator and
+clear-operator must be sent by the NFT owner (a 4337 / smart-account signer
+whose address is that owner). Reads return address(0) when unset or stale.
 
 A 4337 smart-account client is supported from the library API
 (createOperator({ signer: { type: 'walletClient', walletClient } })),
@@ -146,6 +156,22 @@ async function main(): Promise<void> {
     case 'tx': {
       const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
       printJson(await operator.getTransaction(nonce))
+      return
+    }
+    case 'operator': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      printJson({ tokenId, operator: await operator.getDirectorOperator(tokenId) })
+      return
+    }
+    case 'set-operator': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const next = requireAddress(requireFlag(flags, 'operator'), 'operator')
+      printJson(await operator.setDirectorOperator(tokenId, next))
+      return
+    }
+    case 'clear-operator': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      printJson(await operator.clearDirectorOperator(tokenId))
       return
     }
     case 'delegate': {

--- a/packages/operator/src/client.ts
+++ b/packages/operator/src/client.ts
@@ -176,7 +176,8 @@ export class ChamberOperator {
       | 'delegate'
       | 'confirmTransaction'
       | 'executeTransaction'
-      | 'submitTransaction',
+      | 'submitTransaction'
+      | 'setDirectorOperator',
   >(
     functionName: TFunctionName,
     args: readonly unknown[],
@@ -389,6 +390,36 @@ export class ChamberOperator {
 
   async execute(tokenId: bigint, nonce: bigint, data: Hex | string = '0x'): Promise<WriteResult> {
     return this.write('executeTransaction', [tokenId, nonce, toHexData(data)])
+  }
+
+  /**
+   * Live session key for `tokenId`, or `address(0)` if unset, stale, or the
+   * NFT is EOA-owned. Chamber never consults ERC-1271.
+   */
+  async getDirectorOperator(tokenId: bigint): Promise<Address> {
+    try {
+      return await this.publicClient.readContract({
+        address: this.chamber,
+        abi: chamberAbi,
+        functionName: 'getDirectorOperator',
+        args: [tokenId],
+      })
+    } catch (error) {
+      throw wrapChamberError(error, 'Failed to read director operator')
+    }
+  }
+
+  /**
+   * Register (or replace) the session key. `msg.sender` must be the current
+   * contract owner of `tokenId`. EOA-owned NFTs revert `NotDirector`.
+   */
+  async setDirectorOperator(tokenId: bigint, operator: Address): Promise<WriteResult> {
+    return this.write('setDirectorOperator', [tokenId, assertAddress(operator, 'operator')])
+  }
+
+  /** Clear the session key (`setDirectorOperator(tokenId, address(0))`). */
+  async clearDirectorOperator(tokenId: bigint): Promise<WriteResult> {
+    return this.setDirectorOperator(tokenId, ZERO_ADDRESS)
   }
 }
 

--- a/packages/operator/src/index.ts
+++ b/packages/operator/src/index.ts
@@ -1,4 +1,4 @@
-export { chamberAbi, factoryAbi, mockERC20Abi, mockERC721Abi } from './abi.ts'
+export { chamberAbi, directorOperatorAbi, factoryAbi, mockERC20Abi, mockERC721Abi } from './abi.ts'
 export {
   ChamberOperator,
   createOperator,

--- a/packages/operator/test/director-operator.test.ts
+++ b/packages/operator/test/director-operator.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
-import { encodeErrorResult } from 'viem'
+import { decodeFunctionData, encodeErrorResult, encodeFunctionData } from 'viem'
 import { chamberAbi, directorOperatorAbi } from '../src/abi.ts'
 import { ChamberOperator } from '../src/client.ts'
 import { formatChamberError } from '../src/errors.ts'
@@ -29,6 +29,37 @@ test('generated-plus-IChamber ABI exposes session-key read/set/event', () => {
   assert.ok(functions.includes('setDirectorOperator'))
   assert.ok(events.includes('DirectorOperatorSet'))
   assert.equal(directorOperatorAbi.length, 3)
+})
+
+test('chamberAbi encodes setDirectorOperator and getDirectorOperator', () => {
+  const session = '0x0000000000000000000000000000000000000B0b' as const
+  const setData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'setDirectorOperator',
+    args: [3n, session],
+  })
+  const setDecoded = decodeFunctionData({ abi: chamberAbi, data: setData })
+  assert.equal(setDecoded.functionName, 'setDirectorOperator')
+  assert.equal(setDecoded.args[0], 3n)
+  assert.equal((setDecoded.args[1] as string).toLowerCase(), session.toLowerCase())
+
+  const clearData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'setDirectorOperator',
+    args: [3n, '0x0000000000000000000000000000000000000000'],
+  })
+  const clearDecoded = decodeFunctionData({ abi: chamberAbi, data: clearData })
+  assert.equal(clearDecoded.functionName, 'setDirectorOperator')
+  assert.equal(clearDecoded.args[1], '0x0000000000000000000000000000000000000000')
+
+  const readData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'getDirectorOperator',
+    args: [3n],
+  })
+  const readDecoded = decodeFunctionData({ abi: chamberAbi, data: readData })
+  assert.equal(readDecoded.functionName, 'getDirectorOperator')
+  assert.deepEqual([...readDecoded.args], [3n])
 })
 
 test('session-key writes decode NotDirector the same as other director calls', () => {

--- a/packages/operator/test/director-operator.test.ts
+++ b/packages/operator/test/director-operator.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { encodeErrorResult } from 'viem'
+import { chamberAbi, directorOperatorAbi } from '../src/abi.ts'
+import { ChamberOperator } from '../src/client.ts'
+import { formatChamberError } from '../src/errors.ts'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function abiNames(kind: 'function' | 'event'): string[] {
+  return chamberAbi.filter((item) => item.type === kind).map((item) => item.name)
+}
+
+test('ChamberOperator exposes session-key read, set, and clear', () => {
+  assert.equal(typeof ChamberOperator.prototype.getDirectorOperator, 'function')
+  assert.equal(typeof ChamberOperator.prototype.setDirectorOperator, 'function')
+  assert.equal(typeof ChamberOperator.prototype.clearDirectorOperator, 'function')
+})
+
+test('generated-plus-IChamber ABI exposes session-key read/set/event', () => {
+  const functions = abiNames('function')
+  const events = abiNames('event')
+  assert.ok(functions.includes('getDirectorOperator'))
+  assert.ok(functions.includes('setDirectorOperator'))
+  assert.ok(events.includes('DirectorOperatorSet'))
+  assert.equal(directorOperatorAbi.length, 3)
+})
+
+test('session-key writes decode NotDirector the same as other director calls', () => {
+  const data = encodeErrorResult({ abi: chamberAbi, errorName: 'NotDirector' })
+  const error = {
+    message: 'The contract function "setDirectorOperator" reverted.',
+    data,
+  }
+  assert.equal(formatChamberError(error), 'You are not a director')
+})
+
+test('CLI documents operator / set-operator / clear-operator in the existing style', async () => {
+  const cli = await readFile(join(ROOT, 'src/cli.ts'), 'utf8')
+  assert.match(cli, /operator\s+Read live session-key operator/)
+  assert.match(cli, /set-operator\s+setDirectorOperator/)
+  assert.match(cli, /clear-operator\s+setDirectorOperator\(tokenId, address\(0\)\)/)
+  assert.match(cli, /case 'operator':/)
+  assert.match(cli, /case 'set-operator':/)
+  assert.match(cli, /case 'clear-operator':/)
+  assert.match(cli, /There is no\nERC-1271 fallback/)
+})
+
+test('README documents session keys, EOA rejection, and no 1271 fallback', async () => {
+  const readme = await readFile(join(ROOT, 'README.md'), 'utf8')
+  assert.match(readme, /getDirectorOperator/)
+  assert.match(readme, /setDirectorOperator/)
+  assert.match(readme, /clearDirectorOperator/)
+  assert.match(readme, /chamber-operator operator/)
+  assert.match(readme, /chamber-operator set-operator/)
+  assert.match(readme, /chamber-operator clear-operator/)
+  assert.match(readme, /EOA-owned membership NFTs are rejected/)
+  assert.match(readme, /no ERC-1271 fallback/)
+})

--- a/packages/operator/test/director-operator.test.ts
+++ b/packages/operator/test/director-operator.test.ts
@@ -11,7 +11,9 @@ import { formatChamberError } from '../src/errors.ts'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 function abiNames(kind: 'function' | 'event'): string[] {
-  return chamberAbi.filter((item) => item.type === kind).map((item) => item.name)
+  return chamberAbi.flatMap((item) =>
+    item.type === kind && 'name' in item ? [item.name] : [],
+  )
 }
 
 test('ChamberOperator exposes session-key read, set, and clear', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #174.

Rebased onto current `main` (PMN-M04 session-key expiry/scope). `packages/operator` only. No Solidity. No ERC-1271 reopen.

#152 shipped `setDirectorOperator` for contract-owned membership NFTs. #153 / `packages/operator` already had board + delegate + submit + confirm + execute. This adds the session-key surface so a contract-wallet owner (or a signer that is that owner) can register and clear an operator without calling the ABI by hand.

## What

Library (`ChamberOperator`):

- `getDirectorOperator(tokenId)` — live session key, or `address(0)` if unset / stale / expired / EOA-owned
- `getDirectorOperatorScope` / `getDirectorOperatorLiveAt` / `getDirectorSession`
- `setDirectorOperator(tokenId, operator, expiry, scope)` — future expiry; non-zero scope (`SESSION_SCOPE_UNSCOPED` for explicit full access)
- `clearDirectorOperator(tokenId)` — `setDirectorOperator(tokenId, address(0), 0, 0)`

CLI (same style as `board` / `delegate` / `submit`):

```bash
npx chamber-operator operator --rpc "$RPC" --chamber "$CHAMBER" --token-id 1
npx chamber-operator set-operator --rpc "$RPC" --chamber "$CHAMBER" --key "$KEY" \
  --token-id 1 --operator 0x… --expiry 1893456000 --scope unscoped
npx chamber-operator clear-operator --rpc "$RPC" --chamber "$CHAMBER" --key "$KEY" \
  --token-id 1
```

Writes still go through the existing `simulateContract` + generated-ABI + `wrapChamberError` path. EOA-owned NFTs revert `NotDirector` (`You are not a director`). There is no 1271 fallback.

`contracts/generated-abis.ts` still lacks the session-key entries, so `src/abi.ts` appends the current IChamber fragments (4-arg set, live getters, `InvalidSessionExpiry` / `InvalidSessionScope`). Custom-error decoding is unchanged.

## Docs

`packages/operator/README.md` documents read / set / clear, EOA rejection, required expiry/scope, and that Chamber never calls `isValidSignature`.

## Testing

- `cd packages/operator && npm test` — 19 passing
- `npm run typecheck`

## Out of scope

App UI (#172 / #173), landing copy, new Solidity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61998402-98db-4e7c-8028-ffca66bbc338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61998402-98db-4e7c-8028-ffca66bbc338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

