### PR TITLE
feat(operator): undelegate, revokeConfirmation, and cancelTransaction

### DIFF
--- a/packages/operator/README.md
+++ b/packages/operator/README.md
@@ -2,7 +2,7 @@
 
 Typed operator surface for Chamber. Agents cannot click `TransactionQueue`; this package calls the same functions the React app already uses, through `contracts/generated-abis.ts`.
 
-Implements [loreum-org/chamber#146](https://github.com/loreum-org/chamber/issues/146).
+Implements [loreum-org/chamber#146](https://github.com/loreum-org/chamber/issues/146) and [loreum-org/chamber#180](https://github.com/loreum-org/chamber/issues/180).
 
 ## What it does
 
@@ -12,8 +12,11 @@ Given RPC + a signer + a chamber address:
 | --- | --- |
 | Read board + quorum | `getTop`, `getSeats`, `getQuorum`, `getDirectors`, `getSeatedAt`, `paused` |
 | Delegate | `delegate` |
+| Undelegate | `undelegate` |
 | Submit | `submitTransaction` |
 | Confirm | `confirmTransaction` |
+| Revoke confirmation | `revokeConfirmation` |
+| Cancel queued tx | `cancelTransaction` |
 | Execute | `executeTransaction` |
 
 Signer is a private key, a viem `Account`, or a prebuilt `WalletClient` (including a 4337 smart-account client whose `writeContract` submits a user operation). This package does not ship a bundler or paymaster.
@@ -47,7 +50,18 @@ const { nonce } = await op.submitTransaction({
   data: '0x',
 })
 await op.confirm(2n, nonce)
-await op.execute(1n, nonce, '0x')
+await op.revokeConfirmation(2n, nonce)
+await op.cancelTransaction(1n, nonce)
+await op.undelegate(1n, 10n ** 18n)
+
+const next = await op.submitTransaction({
+  tokenId: 1n,
+  target: '0x…',
+  value: 0n,
+  data: '0x',
+})
+await op.confirm(2n, next.nonce)
+await op.execute(1n, next.nonce, '0x')
 ```
 
 4337 signer:
@@ -73,10 +87,16 @@ npx chamber-operator board --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
 npx chamber-operator quorum --rpc "$CHAMBER_RPC" --chamber "$CHAMBER"
 npx chamber-operator delegate --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 1 --amount 1ether
+npx chamber-operator undelegate --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --amount 1ether
 npx chamber-operator submit --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 1 --target 0x… --value 0 --data 0x
 npx chamber-operator confirm --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 2 --nonce 0
+npx chamber-operator revoke --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 2 --nonce 0
+npx chamber-operator cancel --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
+  --token-id 1 --nonce 0
 npx chamber-operator execute --rpc "$CHAMBER_RPC" --chamber "$CHAMBER" --key "$PRIVATE_KEY" \
   --token-id 1 --nonce 0 --data 0x
 ```
@@ -95,10 +115,12 @@ That script starts Anvil if needed, runs `DeployAllAnvil`, creates a 3-seat cham
 1. Delegates from two directors and shows a pending board
 2. `submit` before the seating delay → `Your seat is not mature yet`
 3. Mines one block (`SEATING_DELAY = 1`)
-4. `submit` → `confirm` → `execute`
-5. A third key `confirm` → `You are not a director`
-6. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
-7. Board `pause()` then `execute` → `This chamber is paused`
+4. `submit` → `confirm` → `revokeConfirmation` → `cancelTransaction` (quorum of cancel votes)
+5. `submit` → `confirm` → `execute`
+6. A third key `confirm` → `You are not a director`
+7. A short-deadline nonce after `evm_increaseTime` → `This transaction has expired`
+8. `undelegate` a partial amount from a membership tokenId
+9. Board `pause()` then `execute` → `This chamber is paused`
 
 ## Out of scope
 

--- a/packages/operator/examples/anvil-e2e.ts
+++ b/packages/operator/examples/anvil-e2e.ts
@@ -5,8 +5,8 @@
  * From `packages/operator`: `npm run example:anvil`
  *
  * Spawns a fresh Anvil, deploys Registry/Factory/mocks, creates a 3-seat
- * chamber, then exercises board/quorum/delegate/submit/confirm/execute and
- * the four app-mapped failure strings.
+ * chamber, then exercises board/quorum/delegate/undelegate/submit/confirm/
+ * revoke/cancel/execute and the four app-mapped failure strings.
  */
 import { spawn, type ChildProcess } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
@@ -313,6 +313,40 @@ async function main(): Promise<void> {
     }
     log('board after seating', readyBoard)
 
+    const queued = await opA.submitTransaction({
+      tokenId: 1n,
+      target: outsider.address,
+      value: 0n,
+      data: '0x',
+    })
+    log('submitTransaction (revoke/cancel path)', { nonce: queued.nonce.toString(), hash: queued.hash })
+
+    const firstConfirm = await opB.confirm(2n, queued.nonce)
+    log('confirm', { hash: firstConfirm.hash })
+    const afterConfirm = await opA.getTransaction(queued.nonce)
+    if (afterConfirm.confirmations < 1) {
+      throw new Error('expected at least one confirmation before revoke')
+    }
+
+    const revoked = await opB.revokeConfirmation(2n, queued.nonce)
+    log('revokeConfirmation', { hash: revoked.hash })
+    const afterRevoke = await opA.getTransaction(queued.nonce)
+    if (afterRevoke.confirmations !== afterConfirm.confirmations - 1) {
+      throw new Error(
+        `expected confirmations to drop after revoke (${afterConfirm.confirmations} → ${afterRevoke.confirmations})`,
+      )
+    }
+
+    const cancelA = await opA.cancelTransaction(1n, queued.nonce)
+    log('cancelTransaction (vote 1)', { hash: cancelA.hash })
+    const cancelB = await opB.cancelTransaction(2n, queued.nonce)
+    log('cancelTransaction (vote 2 / quorum)', { hash: cancelB.hash })
+    const afterCancel = await opA.getTransaction(queued.nonce)
+    if (!afterCancel.cancelled) {
+      throw new Error('expected getCancelled / tx.cancelled after quorum cancel votes')
+    }
+    log('tx after cancel', afterCancel)
+
     const submitted = await opA.submitTransaction({
       tokenId: 1n,
       target: outsider.address,
@@ -345,6 +379,10 @@ async function main(): Promise<void> {
       opB.confirm(2n, expiring.nonce),
     )
 
+    const undelegateAmount = parseEther('1')
+    const undelegated = await opA.undelegate(1n, undelegateAmount)
+    log('undelegate', { hash: undelegated.hash, amount: undelegateAmount.toString() })
+
     const pauseData = encodeFunctionData({ abi: chamberAbi, functionName: 'pause' })
     const pauseSubmit = await opA.submitTransaction({
       tokenId: 1n,
@@ -370,7 +408,7 @@ async function main(): Promise<void> {
       opA.execute(1n, pausedTx.nonce, '0x'),
     )
 
-    log('done — board, quorum, delegate, submit, confirm, execute, and the four app error strings')
+    log('done — board, quorum, delegate, undelegate, submit, confirm, revoke, cancel, execute, and the four app error strings')
   } finally {
     if (spawned) {
       spawned.kill('SIGTERM')

--- a/packages/operator/package.json
+++ b/packages/operator/package.json
@@ -2,7 +2,7 @@
   "name": "@loreum/chamber-operator",
   "version": "0.1.0",
   "private": true,
-  "description": "Typed Chamber operator surface for agents: board, quorum, delegate, submit, confirm, execute.",
+  "description": "Typed Chamber operator surface for agents: board, quorum, delegate, undelegate, submit, confirm, revoke, cancel, execute.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/operator/src/cli.ts
+++ b/packages/operator/src/cli.ts
@@ -12,8 +12,11 @@ Commands:
   quorum                Read live quorum
   tx --nonce <n>        Read one queued nonce
   delegate              Delegate vault shares to a membership tokenId
+  undelegate            Undelegate vault shares from a membership tokenId
   submit                submitTransaction (director)
   confirm               confirmTransaction (director)
+  revoke                revokeConfirmation (director)
+  cancel                cancelTransaction (director)
   execute               executeTransaction (director)
 
 Required (or env):
@@ -23,12 +26,12 @@ Required (or env):
 
 Writes:
   --token-id <n>
-  --amount <wei|ether>  delegate amount (1ether or raw wei)
+  --amount <wei|ether>  delegate / undelegate amount (1ether or raw wei)
   --target <addr>       submit target
   --value <wei|ether>   submit ETH value (default 0)
   --data <hex>          submit / execute calldata (default 0x)
   --deadline <unix>     optional submit deadline
-  --nonce <n>           confirm / execute / tx
+  --nonce <n>           confirm / revoke / cancel / execute / tx
 
 A 4337 smart-account client is supported from the library API
 (createOperator({ signer: { type: 'walletClient', walletClient } })),
@@ -154,6 +157,12 @@ async function main(): Promise<void> {
       printJson(await operator.delegate(tokenId, amount))
       return
     }
+    case 'undelegate': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const amount = parseAmount(requireFlag(flags, 'amount'))
+      printJson(await operator.undelegate(tokenId, amount))
+      return
+    }
     case 'submit': {
       const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
       const target = requireAddress(requireFlag(flags, 'target'), 'target')
@@ -176,6 +185,18 @@ async function main(): Promise<void> {
       const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
       const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
       printJson(await operator.confirm(tokenId, nonce))
+      return
+    }
+    case 'revoke': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
+      printJson(await operator.revokeConfirmation(tokenId, nonce))
+      return
+    }
+    case 'cancel': {
+      const tokenId = parseUint(requireFlag(flags, 'token-id'), 'token-id')
+      const nonce = parseUint(requireFlag(flags, 'nonce'), 'nonce')
+      printJson(await operator.cancelTransaction(tokenId, nonce))
       return
     }
     case 'execute': {

--- a/packages/operator/src/client.ts
+++ b/packages/operator/src/client.ts
@@ -58,6 +58,7 @@ export type BoardSnapshot = {
 export type TransactionSnapshot = {
   nonce: bigint
   executed: boolean
+  cancelled: boolean
   confirmations: number
   target: Address
   value: bigint
@@ -174,7 +175,10 @@ export class ChamberOperator {
   private async write<
     TFunctionName extends
       | 'delegate'
+      | 'undelegate'
       | 'confirmTransaction'
+      | 'revokeConfirmation'
+      | 'cancelTransaction'
       | 'executeTransaction'
       | 'submitTransaction',
   >(
@@ -325,7 +329,7 @@ export class ChamberOperator {
           functionName: 'getTransaction',
           args: [nonce],
         })
-      const [expired, deadline, requiredQuorum] = await Promise.all([
+      const [expired, deadline, requiredQuorum, cancelled] = await Promise.all([
         this.publicClient.readContract({
           address: this.chamber,
           abi: chamberAbi,
@@ -344,10 +348,17 @@ export class ChamberOperator {
           functionName: 'getTransactionRequiredQuorum',
           args: [nonce],
         }),
+        this.publicClient.readContract({
+          address: this.chamber,
+          abi: chamberAbi,
+          functionName: 'getCancelled',
+          args: [nonce],
+        }),
       ])
       return {
         nonce,
         executed,
+        cancelled,
         confirmations,
         target,
         value,
@@ -363,6 +374,10 @@ export class ChamberOperator {
 
   async delegate(tokenId: bigint, amount: bigint): Promise<WriteResult> {
     return this.write('delegate', [tokenId, amount])
+  }
+
+  async undelegate(tokenId: bigint, amount: bigint): Promise<WriteResult> {
+    return this.write('undelegate', [tokenId, amount])
   }
 
   async submitTransaction(args: {
@@ -385,6 +400,14 @@ export class ChamberOperator {
 
   async confirm(tokenId: bigint, nonce: bigint): Promise<WriteResult> {
     return this.write('confirmTransaction', [tokenId, nonce])
+  }
+
+  async revokeConfirmation(tokenId: bigint, nonce: bigint): Promise<WriteResult> {
+    return this.write('revokeConfirmation', [tokenId, nonce])
+  }
+
+  async cancelTransaction(tokenId: bigint, nonce: bigint): Promise<WriteResult> {
+    return this.write('cancelTransaction', [tokenId, nonce])
   }
 
   async execute(tokenId: bigint, nonce: bigint, data: Hex | string = '0x'): Promise<WriteResult> {

--- a/packages/operator/test/queue-writes.test.ts
+++ b/packages/operator/test/queue-writes.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { decodeFunctionData, encodeErrorResult, encodeFunctionData } from 'viem'
+import { chamberAbi } from '../src/abi.ts'
+import { ChamberOperator } from '../src/client.ts'
+import { formatChamberError } from '../src/errors.ts'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function abiNames(kind: 'function' | 'event'): string[] {
+  return chamberAbi.flatMap((item) =>
+    item.type === kind && 'name' in item ? [item.name] : [],
+  )
+}
+
+test('ChamberOperator exposes undelegate, revokeConfirmation, and cancelTransaction', () => {
+  assert.equal(typeof ChamberOperator.prototype.undelegate, 'function')
+  assert.equal(typeof ChamberOperator.prototype.revokeConfirmation, 'function')
+  assert.equal(typeof ChamberOperator.prototype.cancelTransaction, 'function')
+})
+
+test('generated Chamber ABI exposes undelegate / revoke / cancel', () => {
+  const functions = abiNames('function')
+  const events = abiNames('event')
+  assert.ok(functions.includes('undelegate'))
+  assert.ok(functions.includes('revokeConfirmation'))
+  assert.ok(functions.includes('cancelTransaction'))
+  assert.ok(functions.includes('getCancelled'))
+  assert.ok(events.includes('RevokeConfirmation') || events.includes('ConfirmationRevoked'))
+  assert.ok(events.includes('TransactionCancelled') || events.includes('CancelTransaction'))
+})
+
+test('chamberAbi encodes undelegate, revokeConfirmation, and cancelTransaction', () => {
+  const undelegateData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'undelegate',
+    args: [1n, 10n ** 18n],
+  })
+  const undelegateDecoded = decodeFunctionData({ abi: chamberAbi, data: undelegateData })
+  assert.equal(undelegateDecoded.functionName, 'undelegate')
+  assert.deepEqual([...undelegateDecoded.args], [1n, 10n ** 18n])
+
+  const revokeData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'revokeConfirmation',
+    args: [2n, 7n],
+  })
+  const revokeDecoded = decodeFunctionData({ abi: chamberAbi, data: revokeData })
+  assert.equal(revokeDecoded.functionName, 'revokeConfirmation')
+  assert.deepEqual([...revokeDecoded.args], [2n, 7n])
+
+  const cancelData = encodeFunctionData({
+    abi: chamberAbi,
+    functionName: 'cancelTransaction',
+    args: [1n, 7n],
+  })
+  const cancelDecoded = decodeFunctionData({ abi: chamberAbi, data: cancelData })
+  assert.equal(cancelDecoded.functionName, 'cancelTransaction')
+  assert.deepEqual([...cancelDecoded.args], [1n, 7n])
+})
+
+test('undelegate / revoke / cancel writes decode the same app-mapped errors', () => {
+  const insufficient = encodeErrorResult({ abi: chamberAbi, errorName: 'InsufficientDelegatedAmount' })
+  assert.equal(
+    formatChamberError({
+      message: 'The contract function "undelegate" reverted.',
+      data: insufficient,
+    }),
+    "You haven't delegated this much to this member",
+  )
+
+  const notDirector = encodeErrorResult({ abi: chamberAbi, errorName: 'NotDirector' })
+  assert.equal(
+    formatChamberError({
+      message: 'The contract function "cancelTransaction" reverted.',
+      data: notDirector,
+    }),
+    'You are not a director',
+  )
+
+  const expired = encodeErrorResult({ abi: chamberAbi, errorName: 'TransactionExpired' })
+  assert.equal(
+    formatChamberError({
+      message: 'The contract function "revokeConfirmation" reverted.',
+      data: expired,
+    }),
+    'This transaction has expired',
+  )
+})
+
+test('CLI documents undelegate / revoke / cancel in the existing style', async () => {
+  const cli = await readFile(join(ROOT, 'src/cli.ts'), 'utf8')
+  assert.match(cli, /undelegate\s+Undelegate vault shares from a membership tokenId/)
+  assert.match(cli, /revoke\s+revokeConfirmation \(director\)/)
+  assert.match(cli, /cancel\s+cancelTransaction \(director\)/)
+  assert.match(cli, /case 'undelegate':/)
+  assert.match(cli, /case 'revoke':/)
+  assert.match(cli, /case 'cancel':/)
+  assert.match(cli, /operator\.undelegate/)
+  assert.match(cli, /operator\.revokeConfirmation/)
+  assert.match(cli, /operator\.cancelTransaction/)
+})
+
+test('README documents undelegate, revokeConfirmation, and cancelTransaction', async () => {
+  const readme = await readFile(join(ROOT, 'README.md'), 'utf8')
+  assert.match(readme, /`undelegate`/)
+  assert.match(readme, /`revokeConfirmation`/)
+  assert.match(readme, /`cancelTransaction`/)
+  assert.match(readme, /chamber-operator undelegate/)
+  assert.match(readme, /chamber-operator revoke/)
+  assert.match(readme, /chamber-operator cancel/)
+  assert.match(readme, /op\.undelegate/)
+  assert.match(readme, /op\.revokeConfirmation/)
+  assert.match(readme, /op\.cancelTransaction/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #180.

App hooks already expose `undelegate`, `revokeConfirmation`, and `cancelTransaction`. `packages/operator` only had board / quorum / tx / delegate / submit / confirm / execute. Agents that cannot click `TransactionQueue` can now do the remaining queue and delegation writes through the same generated ABI and `wrapChamberError` path.

## What

`packages/operator` only. No Solidity. No ERC-1271 reopen. Session-key (#174 / #177) is still an open PR and is not on `main`, so this branch starts from current `main`.

Library (`ChamberOperator`):

- `undelegate(tokenId, amount)`
- `revokeConfirmation(tokenId, nonce)`
- `cancelTransaction(tokenId, nonce)`
- `getTransaction` also reports `cancelled` via `getCancelled`

CLI (same style as `delegate` / `confirm` / `execute`):

```bash
npx chamber-operator undelegate --rpc "$RPC" --chamber "$CHAMBER" --key "$KEY" \
  --token-id 1 --amount 1ether
npx chamber-operator revoke --rpc "$RPC" --chamber "$CHAMBER" --key "$KEY" \
  --token-id 2 --nonce 0
npx chamber-operator cancel --rpc "$RPC" --chamber "$CHAMBER" --key "$KEY" \
  --token-id 1 --nonce 0
```

Writes still go through `simulateContract` + `contracts/generated-abis.ts` + `wrapChamberError`.

## Docs

`packages/operator/README.md` documents the three writes, CLI examples, and the Anvil walkthrough steps.

## Testing

- `cd packages/operator && npm test` — 19 passing (error map, seating, ABI encode/decode, CLI/README surface)
- `npm run typecheck`
- CLI `--help` lists `undelegate` / `revoke` / `cancel`
- `examples/anvil-e2e.ts` adds confirm → revoke → quorum cancel, then undelegate, before the existing execute / pause path
- Live `DeployAllAnvil` still fails on this tree (`vm.deployCode` / upgradeable Chamber) — pre-existing, same as #177, not introduced here

## Out of scope

App UI, landing copy, new Solidity, EIP-1271, session-key operator (#174 / #177).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28171756-383a-426f-8a58-e6e4d36901c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28171756-383a-426f-8a58-e6e4d36901c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

