### PR TITLE
blog: seat-the-board changelog after Factory create (2026-09-07)

### DIFF
--- a/landing/content/blog/2026-09-07-seat-the-board.md
+++ b/landing/content/blog/2026-09-07-seat-the-board.md
@@ -1,0 +1,11 @@
+---
+title: Seat the board after Factory create
+date: 2026-09-07
+summary: Factory create leaves an empty board until you hold a membership NFT and delegate. Deploy success points at SeatTheBoard. Sepolia demo mint when wired.
+---
+
+7 September 2026. Seat the board after Factory create.
+
+- After Factory create the board is empty until you hold a membership NFT and delegate.
+- Director actions wait for the seating delay (1 block).
+- Deploy success points at SeatTheBoard. Sepolia demo mint when wired.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #185.

Adds the 7 September 2026 Chamber changelog post for seating the board after Factory create.

**Live URL after merge:** https://www.loreum.org/blog/2026-09-07-seat-the-board

**Source:** loreum-org/chamber #150 (merged 2026-08-28).

The landing blog already eager-loads `landing/content/blog/*.md` via `import.meta.glob` in `landing/src/posts.ts`. This PR only adds the markdown file.

- After Factory create the board is empty until you hold a membership NFT and delegate
- Director actions wait for the seating delay (1 block)
- Deploy success points at SeatTheBoard; Sepolia demo mint when wired

No marketing rewrite. No seating implementation. No CCA.

Verified locally: `npm run build` in `landing/` succeeded, and the Vite preview served `/blog` and `/blog/2026-09-07-seat-the-board` with the new post first and the older Factory / session-key posts still present.

[Blog index with the new seat-the-board post first](https://cursor.com/agents/bc-f543ccf3-65bd-4232-80a2-a61575b56520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_index_seat_the_board_first.webp)

[Seat the board changelog post page](https://cursor.com/agents/bc-f543ccf3-65bd-4232-80a2-a61575b56520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblog_post_seat_the_board.webp)

[blog_seat_the_board_changelog.mp4](https://cursor.com/agents/bc-f543ccf3-65bd-4232-80a2-a61575b56520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_seat_the_board_changelog.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f543ccf3-65bd-4232-80a2-a61575b56520?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f543ccf3-65bd-4232-80a2-a61575b56520&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

