### PR TITLE
chore: regenerate generated-abis.ts for session-key operators

### DIFF
--- a/contracts/generated-abis.ts
+++ b/contracts/generated-abis.ts
@@ -1430,6 +1430,25 @@ export const chamberAbi = [
   },
   {
     "type": "function",
+    "name": "getDirectorOperator",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getDirectors",
     "inputs": [],
     "outputs": [
@@ -1817,6 +1836,30 @@ export const chamberAbi = [
   },
   {
     "type": "function",
+    "name": "isTokenAuthorized",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "isTransactionExpired",
     "inputs": [
       {
@@ -2132,6 +2175,24 @@ export const chamberAbi = [
         "name": "transactionId",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDirectorOperator",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "outputs": [],
@@ -2619,6 +2680,31 @@ export const chamberAbi = [
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DirectorOperatorSet",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       }
     ],
     "anonymous": false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #184.

`Chamber.sol` and `app/contracts/abis.ts` already expose `setDirectorOperator` / `getDirectorOperator` / `DirectorOperatorSet` from #152. `contracts/generated-abis.ts` on main was last synced before that landing, so `packages/operator` (which imports the generated file via `make sync-abis`) could not see the session-key surface without a hand-written ABI append (#177).

## What

Regenerated `contracts/generated-abis.ts` with the repo path:

```
cd contracts && forge build && make sync-abis
```

`chamberAbi` now includes:

- `getDirectorOperator(uint256 tokenId)`
- `setDirectorOperator(uint256 tokenId, address operator)`
- `DirectorOperatorSet(uint256 tokenId, address owner, address operator)`
- `isTokenAuthorized(uint256 tokenId, address account)` (also landed with #152 and was missing from the generated file)

`packages/operator/src/abi.ts` on main already re-exports `contracts/generated-abis.ts` with no session-key append, so no operator patch was removed. Operator can encode/decode the session-key functions through that import.

## Out of scope

- No Solidity behavior change
- `app/contracts/abis.ts` left alone (`app/scripts/sync-contracts.mjs` intentionally skips it)
- No EIP-1271 reopen
- Does not implement the operator CLI from #177

## Testing

- `make sync-abis` after `forge build` — 86-line additive diff only
- Generated file contains the three session-key names
- SHA-256 of `Chamber.sol` and `app/contracts/abis.ts` unchanged
- `cd packages/operator && npm test` — 13 passing
- `npm run typecheck` — clean
- viem `encodeFunctionData` / `decodeFunctionData` via `packages/operator/src/abi.ts` for `setDirectorOperator` and `getDirectorOperator`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb006a51-d5b8-4abe-bea1-b11297843947?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb006a51-d5b8-4abe-bea1-b11297843947&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

