### PR TITLE
test: mainnet-fork rehearsal for LORE Ownable handoff (M1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,7 @@ MIT License
 
 `make loreum-fund-wallet WALLET=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
 
+### Mainnet fork rehearsal (M1 LORE Ownable)
+
+Dry-run Factory deploy + Chamber create + Safe `transferOwnership` of LORE on an Ethereum **fork** (no live broadcast). Requires `MAINNET_RPC_URL` or `ETH_RPC_URL`. Without an RPC, `forge test` skips the fork case. Commands and success checks: [`contracts/docs/mainnet-lore-handoff-rehearsal.md`](./contracts/docs/mainnet-lore-handoff-rehearsal.md).
+

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -29,6 +29,21 @@ LOREUM_WALLET_GOV_HODLER ?= $(LOREUM_LOCAL_GOV_HODLER)
 
 ci-test :; forge test
 
+# Fork-only M1 rehearsal: Factory + Chamber on an Ethereum mainnet fork, then
+# impersonate the team Safe and transferOwnership(LORE) to the Chamber proxy.
+# Never broadcast. Requires MAINNET_RPC_URL or ETH_RPC_URL.
+# See docs/mainnet-lore-handoff-rehearsal.md
+rehearse-mainnet-lore-handoff :
+	@rpc="$(or $(MAINNET_RPC_URL),$(ETH_RPC_URL))"; \
+	test -n "$$rpc" || { echo 'Set MAINNET_RPC_URL or ETH_RPC_URL (Ethereum archive/full node)'; exit 1; }; \
+	forge test --match-path test/fork/MainnetLoreOwnableHandoff.t.sol -vvv
+
+rehearse-mainnet-lore-handoff-script :
+	@rpc="$(or $(MAINNET_RPC_URL),$(ETH_RPC_URL))"; \
+	test -n "$$rpc" || { echo 'Set MAINNET_RPC_URL or ETH_RPC_URL (Ethereum archive/full node)'; exit 1; }; \
+	forge script script/RehearseMainnetLoreHandoff.s.sol:RehearseMainnetLoreHandoff --fork-url $$rpc -vvv
+
+
 # Symbolic verification with Halmos (requires: pip install -r fv-requirements.txt)
 # Halmos 0.3.3 has --match-contract, not --no-match-contract. Chamber/Registry/Vault
 # setUp deploys TransparentUpgradeableProxy (vm.deployCode), which Halmos cannot run.

--- a/contracts/docs/mainnet-lore-handoff-rehearsal.md
+++ b/contracts/docs/mainnet-lore-handoff-rehearsal.md
@@ -1,0 +1,76 @@
+# Mainnet fork rehearsal: Factory + LORE Ownable handoff (M1)
+
+Dry run for [#188](https://github.com/loreum-org/chamber/issues/188): deploy Chamber Factory on an **Ethereum mainnet fork**, create a Chamber bound to live LORE + membership NFT, then impersonate the team Safe and `transferOwnership` of LORE to that Chamber.
+
+This proves the **mechanics**. It does **not** decide CCA vs Ownable production sequencing, move Safe residual balances, or change CCA params.
+
+**Never broadcast these transactions to live mainnet.**
+
+## What it does
+
+1. Forks Ethereum (`vm.createSelectFork` / `forge script --fork-url`).
+2. Deploys `Chamber` implementation. Foundry auto-links `BoardLib` + `WalletLib` (same as `script/DeployFactory.s.sol` / Sepolia Factory path).
+3. Deploys `Factory(implementation, team Safe)` — Factory Ownable admin matches Sepolia (`0x5d45A213B2B6259F0b3c116a8907B56AB5E22095`).
+4. Calls `Factory.createChamber`:
+   - `erc20Token`: LORE `0x7756D245527F5f8925A537be509BF54feb2FdC99`
+   - `erc721Token`: membership `0xB99DEdbDe082B8Be86f06449f2fC7b9FED044E15`
+   - `seats`: `5`
+   - `name` / `symbol`: `Chamber LORE` / `cLORE`  
+   These match `script/Chamber.s.sol` when `block.chainid == 1`.
+5. Impersonates the Safe (`vm.prank`) and calls `LORE.transferOwnership(chamber)`.
+6. Asserts / logs `LORE.owner() == chamber`.
+
+The Ownable target is the **Chamber proxy** returned by `createChamber`. Chamber wallet execution uses `address(this)` as `msg.sender` on the target, so that proxy is the account that later holds `onlyOwner` on LORE.
+
+## Env
+
+| Variable | Role |
+| --- | --- |
+| `MAINNET_RPC_URL` | Preferred archive/full Ethereum RPC (also `foundry.toml` `[rpc_endpoints].mainnet`) |
+| `ETH_RPC_URL` | Fallback if `MAINNET_RPC_URL` is unset |
+
+Do not commit RPC URLs or keys. CI (`make ci-test`) runs `forge test` **without** a fork URL; the test **skips** when both env vars are empty.
+
+## Commands
+
+From `contracts/`:
+
+```bash
+export MAINNET_RPC_URL=https://...   # or ETH_RPC_URL
+
+# Preferred: assertions + address logs
+forge test --match-path test/fork/MainnetLoreOwnableHandoff.t.sol -vvv
+
+# Same as above
+make rehearse-mainnet-lore-handoff
+
+# Interactive script (omit --broadcast)
+forge script script/RehearseMainnetLoreHandoff.s.sol:RehearseMainnetLoreHandoff \
+  --fork-url "$MAINNET_RPC_URL" -vvv
+```
+
+The script reverts if you pass `--broadcast` / `--resume`.
+
+## Success
+
+Logs look like:
+
+```
+Factory                0x...
+Chamber implementation 0x...
+Chamber (LORE owner)   0x...
+LORE.owner()           0x...   # equal to Chamber
+```
+
+The test also checks vault asset / NFT / seats, empty board, and `ProxyAdmin.owner() == chamber`.
+
+## Gaps / mainnet blockers
+
+| Topic | Finding |
+| --- | --- |
+| **Lib linking** | `new Chamber()` deploys + links `BoardLib` and `WalletLib` automatically. Production verify still needs those two lib addresses from the broadcast artifact (see `deployments/sepolia.txt` / `make verify-sepolia-factory`). |
+| **CREATE vs CREATE2** | `Factory.createChamber` uses `new TransparentUpgradeableProxy` (CREATE). Chamber address = next Factory nonce. No salt; you cannot pre-commit the address until Factory exists. |
+| **Safe path** | Fork uses `vm.prank(Safe)`. Production is a real Safe `execTransaction` / UI call to `LORE.transferOwnership(chamber)` — same `msg.sender`, different signing UX. |
+| **Board seating** | Create leaves an empty board. `seats = 5` → quorum 3. Seating needs membership NFT holders + LORE deposits + `SEATING_DELAY`. Not required to prove Ownable handoff. |
+| **Ownable vs 2-step** | Mainnet LORE ABI is single-step Ownable (`owner` / `transferOwnership` / `renounceOwnership`; no `pendingOwner`). Chamber does not need `acceptOwnership`. |
+| **CCA sequencing** | Still undecided. This fork does not claim a production order vs CCA. |

--- a/contracts/docs/mainnet-lore-handoff-rehearsal.md
+++ b/contracts/docs/mainnet-lore-handoff-rehearsal.md
@@ -9,7 +9,7 @@ This proves the **mechanics**. It does **not** decide CCA vs Ownable production 
 ## What it does
 
 1. Forks Ethereum (`vm.createSelectFork` / `forge script --fork-url`).
-2. Deploys `Chamber` implementation. Foundry auto-links `BoardLib` + `WalletLib` (same as `script/DeployFactory.s.sol` / Sepolia Factory path).
+2. Deploys a `Chamber` implementation. `forge test` uses `new Chamber()` (Foundry auto-links `BoardLib` + `WalletLib`, same as `DeployFactory.s.sol`). `forge script` dry-run cannot — it deploys the two libs and links the Chamber artifact (the pairing Etherscan verify needs).
 3. Deploys `Factory(implementation, team Safe)` — Factory Ownable admin matches Sepolia (`0x5d45A213B2B6259F0b3c116a8907B56AB5E22095`).
 4. Calls `Factory.createChamber`:
    - `erc20Token`: LORE `0x7756D245527F5f8925A537be509BF54feb2FdC99`
@@ -68,7 +68,7 @@ The test also checks vault asset / NFT / seats, empty board, and `ProxyAdmin.own
 
 | Topic | Finding |
 | --- | --- |
-| **Lib linking** | `new Chamber()` deploys + links `BoardLib` and `WalletLib` automatically. Production verify still needs those two lib addresses from the broadcast artifact (see `deployments/sepolia.txt` / `make verify-sepolia-factory`). |
+| **Lib linking** | Chamber is over EIP-170 without `BoardLib` + `WalletLib`. This rehearsal deploys both libs and links the Chamber artifact (placeholders `__$562d…$__` / `__$a345…$__`). Production `forge script --broadcast` (`DeployFactory.s.sol`) auto-deploys libs; verify still needs the two lib addresses (see `deployments/sepolia.txt` / `make verify-sepolia-factory`). |
 | **CREATE vs CREATE2** | `Factory.createChamber` uses `new TransparentUpgradeableProxy` (CREATE). Chamber address = next Factory nonce. No salt; you cannot pre-commit the address until Factory exists. |
 | **Safe path** | Fork uses `vm.prank(Safe)`. Production is a real Safe `execTransaction` / UI call to `LORE.transferOwnership(chamber)` — same `msg.sender`, different signing UX. |
 | **Board seating** | Create leaves an empty board. `seats = 5` → quorum 3. Seating needs membership NFT holders + LORE deposits + `SEATING_DELAY`. Not required to prove Ownable handoff. |

--- a/contracts/script/RehearseMainnetLoreHandoff.s.sol
+++ b/contracts/script/RehearseMainnetLoreHandoff.s.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Script, console} from "forge-std/Script.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+import {ILoreOwnable, MainnetLoreHandoff} from "test/utils/MainnetLoreHandoff.sol";
+
+/**
+ * @title RehearseMainnetLoreHandoff
+ * @notice Fork-only dry run of M1: Factory + Chamber on Ethereum mainnet, then Safe → Chamber
+ *         `LORE.transferOwnership`. Same create args as `script/Chamber.s.sol` (chainid 1).
+ *
+ * Run from `contracts/` (do **not** pass `--broadcast`):
+ *
+ *   export MAINNET_RPC_URL=...          # or ETH_RPC_URL
+ *   forge script script/RehearseMainnetLoreHandoff.s.sol:RehearseMainnetLoreHandoff \
+ *     --fork-url $MAINNET_RPC_URL -vvv
+ *
+ * Success: logs Factory / impl / Chamber, and `LORE.owner() == chamber`.
+ * See `docs/mainnet-lore-handoff-rehearsal.md`.
+ */
+contract RehearseMainnetLoreHandoff is Script {
+    function run() external {
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast) || vm.isContext(VmSafe.ForgeContext.ScriptResume)) {
+            revert("fork-only rehearsal: omit --broadcast (never send this to live mainnet)");
+        }
+
+        if (block.chainid != 1) {
+            string memory rpc = _rpcUrl();
+            if (bytes(rpc).length == 0) {
+                revert("set MAINNET_RPC_URL or ETH_RPC_URL, or pass --fork-url");
+            }
+            vm.createSelectFork(rpc);
+        }
+        if (block.chainid != 1) revert("not an Ethereum mainnet fork");
+
+        ILoreOwnable lore = ILoreOwnable(MainnetLoreHandoff.LORE);
+        console.log("LORE                   ", MainnetLoreHandoff.LORE);
+        console.log("Membership NFT         ", MainnetLoreHandoff.MEMBERSHIP_NFT);
+        console.log("Team Safe              ", MainnetLoreHandoff.TEAM_SAFE);
+        console.log("LORE.owner() before    ", lore.owner());
+        if (lore.owner() != MainnetLoreHandoff.TEAM_SAFE) revert("unexpected LORE owner");
+
+        MainnetLoreHandoff.Deployment memory d =
+            MainnetLoreHandoff.deployFactoryAndChamber(MainnetLoreHandoff.TEAM_SAFE);
+
+        vm.deal(MainnetLoreHandoff.TEAM_SAFE, 1 ether);
+        vm.prank(MainnetLoreHandoff.TEAM_SAFE);
+        lore.transferOwnership(d.chamber);
+
+        if (lore.owner() != d.chamber) revert("LORE.owner() did not flip to Chamber");
+
+        console.log("========================================");
+        console.log("RehearseMainnetLoreHandoff");
+        console.log("========================================");
+        console.log("Factory                ", address(d.factory));
+        console.log("Chamber implementation ", d.chamberImplementation);
+        console.log("Chamber (LORE owner)   ", d.chamber);
+        console.log("LORE.owner() after     ", lore.owner());
+        console.log("========================================");
+    }
+
+    function _rpcUrl() internal view returns (string memory) {
+        string memory rpc = vm.envOr("MAINNET_RPC_URL", string(""));
+        if (bytes(rpc).length != 0) return rpc;
+        return vm.envOr("ETH_RPC_URL", string(""));
+    }
+}

--- a/contracts/script/RehearseMainnetLoreHandoff.s.sol
+++ b/contracts/script/RehearseMainnetLoreHandoff.s.sol
@@ -16,7 +16,8 @@ import {ILoreOwnable, MainnetLoreHandoff} from "test/utils/MainnetLoreHandoff.so
  *   forge script script/RehearseMainnetLoreHandoff.s.sol:RehearseMainnetLoreHandoff \
  *     --fork-url $MAINNET_RPC_URL -vvv
  *
- * Success: logs Factory / impl / Chamber, and `LORE.owner() == chamber`.
+ * Success: logs BoardLib / WalletLib / Factory / impl / Chamber, and `LORE.owner() == chamber`.
+ * Dry-run uses `deployFactoryAndChamberLinked` because `new Chamber()` is unlinked here.
  * See `docs/mainnet-lore-handoff-rehearsal.md`.
  */
 contract RehearseMainnetLoreHandoff is Script {
@@ -42,7 +43,7 @@ contract RehearseMainnetLoreHandoff is Script {
         if (lore.owner() != MainnetLoreHandoff.TEAM_SAFE) revert("unexpected LORE owner");
 
         MainnetLoreHandoff.Deployment memory d =
-            MainnetLoreHandoff.deployFactoryAndChamber(MainnetLoreHandoff.TEAM_SAFE);
+            MainnetLoreHandoff.deployFactoryAndChamberLinked(MainnetLoreHandoff.TEAM_SAFE);
 
         vm.deal(MainnetLoreHandoff.TEAM_SAFE, 1 ether);
         vm.prank(MainnetLoreHandoff.TEAM_SAFE);
@@ -53,6 +54,8 @@ contract RehearseMainnetLoreHandoff is Script {
         console.log("========================================");
         console.log("RehearseMainnetLoreHandoff");
         console.log("========================================");
+        console.log("BoardLib               ", d.boardLib);
+        console.log("WalletLib              ", d.walletLib);
         console.log("Factory                ", address(d.factory));
         console.log("Chamber implementation ", d.chamberImplementation);
         console.log("Chamber (LORE owner)   ", d.chamber);

--- a/contracts/test/fork/MainnetLoreOwnableHandoff.t.sol
+++ b/contracts/test/fork/MainnetLoreOwnableHandoff.t.sol
@@ -88,6 +88,7 @@ contract MainnetLoreOwnableHandoffTest is Test {
         console.log("Chamber implementation ", d.chamberImplementation);
         console.log("Chamber (LORE owner)   ", d.chamber);
         console.log("LORE.owner()           ", lore.owner());
+        console.log("BoardLib/WalletLib     auto-linked by forge test (see script for explicit addrs)");
         console.log("========================================");
     }
 

--- a/contracts/test/fork/MainnetLoreOwnableHandoff.t.sol
+++ b/contracts/test/fork/MainnetLoreOwnableHandoff.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Factory} from "src/Factory.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {ProxyAdmin} from "lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {ILoreOwnable, MainnetLoreHandoff} from "test/utils/MainnetLoreHandoff.sol";
+
+/**
+ * @title MainnetLoreOwnableHandoffTest
+ * @notice Fork-only M1 rehearsal: deploy Factory + Chamber on an Ethereum mainnet fork, then
+ *         impersonate the team Safe and `transferOwnership` of LORE to the Chamber proxy.
+ *
+ * @dev Run (from `contracts/`):
+ *
+ *      export MAINNET_RPC_URL=...   # or ETH_RPC_URL
+ *      forge test --match-path test/fork/MainnetLoreOwnableHandoff.t.sol -vvv
+ *
+ *      Or: `make rehearse-mainnet-lore-handoff`
+ *
+ *      Without an RPC the test is skipped so `make ci-test` / `forge test` stay green.
+ *      This is a dry run — it never broadcasts to live mainnet.
+ *
+ *      Success: logs Factory / Chamber impl / Chamber proxy, and `LORE.owner() == chamber`.
+ *
+ *      Board seating is not exercised here. Factory create leaves an empty board
+ *      (`FactoryBootstrap.t.sol`); seats=5 → quorum `1 + (5 * 51) / 100` = 3, so a queue
+ *      smoke needs three seated membership NFTs plus LORE deposits. Ownable handoff does
+ *      not require a seated board.
+ *
+ *      Fork proves the *mechanics* of Factory create + single-step Ownable handoff.
+ *      It does **not** decide CCA vs Ownable production sequencing (#188).
+ */
+contract MainnetLoreOwnableHandoffTest is Test {
+    bool internal forked;
+
+    function setUp() public {
+        string memory rpc = _rpcUrl();
+        if (bytes(rpc).length == 0) {
+            // No mainnet RPC in CI / default `forge test` — skip rather than fail.
+            return;
+        }
+        vm.createSelectFork(rpc);
+        forked = true;
+    }
+
+    function test_FactoryCreateAndLoreOwnableHandoff() public {
+        if (!forked) {
+            vm.skip(true);
+            return;
+        }
+
+        assertEq(block.chainid, 1, "fork must be Ethereum mainnet");
+
+        ILoreOwnable lore = ILoreOwnable(MainnetLoreHandoff.LORE);
+        assertEq(lore.owner(), MainnetLoreHandoff.TEAM_SAFE, "precondition: team Safe is LORE owner");
+        _assertSingleStepOwnable(MainnetLoreHandoff.LORE);
+
+        MainnetLoreHandoff.Deployment memory d =
+            MainnetLoreHandoff.deployFactoryAndChamber(MainnetLoreHandoff.TEAM_SAFE);
+
+        Chamber chamber = Chamber(d.chamber);
+        assertEq(d.factory.owner(), MainnetLoreHandoff.TEAM_SAFE);
+        assertEq(d.factory.implementation(), d.chamberImplementation);
+        assertEq(chamber.asset(), MainnetLoreHandoff.LORE);
+        assertEq(address(chamber.nft()), MainnetLoreHandoff.MEMBERSHIP_NFT);
+        assertEq(chamber.getSeats(), MainnetLoreHandoff.SEATS);
+        assertEq(chamber.name(), MainnetLoreHandoff.NAME);
+        assertEq(chamber.symbol(), MainnetLoreHandoff.SYMBOL);
+        assertEq(chamber.getDirectors().length, 0, "factory create leaves an empty board");
+        assertEq(chamber.getQuorum(), 1 + (MainnetLoreHandoff.SEATS * 51) / 100);
+
+        address proxyAdmin = IChamber(d.chamber).getProxyAdmin();
+        assertEq(ProxyAdmin(proxyAdmin).owner(), d.chamber, "ProxyAdmin owned by Chamber proxy");
+
+        vm.deal(MainnetLoreHandoff.TEAM_SAFE, 1 ether);
+        vm.prank(MainnetLoreHandoff.TEAM_SAFE);
+        lore.transferOwnership(d.chamber);
+
+        assertEq(lore.owner(), d.chamber, "LORE.owner() flipped to Chamber proxy");
+
+        console.log("========================================");
+        console.log("Mainnet fork rehearsal (Ownable handoff)");
+        console.log("========================================");
+        console.log("Factory                ", address(d.factory));
+        console.log("Chamber implementation ", d.chamberImplementation);
+        console.log("Chamber (LORE owner)   ", d.chamber);
+        console.log("LORE.owner()           ", lore.owner());
+        console.log("========================================");
+    }
+
+    function _rpcUrl() internal view returns (string memory) {
+        string memory rpc = vm.envOr("MAINNET_RPC_URL", string(""));
+        if (bytes(rpc).length != 0) return rpc;
+        return vm.envOr("ETH_RPC_URL", string(""));
+    }
+
+    /// @dev Deployed LORE ABI has `transferOwnership` / `owner` and no `pendingOwner`.
+    function _assertSingleStepOwnable(address token) internal view {
+        (bool ok, bytes memory ret) = token.staticcall(abi.encodeWithSignature("pendingOwner()"));
+        if (ok && ret.length >= 32) {
+            revert("LORE looks Ownable2Step; rehearsal expects single-step transferOwnership");
+        }
+    }
+}

--- a/contracts/test/utils/MainnetLoreHandoff.sol
+++ b/contracts/test/utils/MainnetLoreHandoff.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Factory} from "src/Factory.sol";
+import {Chamber} from "src/Chamber.sol";
+
+/// @notice Minimal Ownable surface of mainnet LORE (single-step; no `pendingOwner`).
+interface ILoreOwnable {
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+}
+
+/**
+ * @title MainnetLoreHandoff
+ * @notice Shared mainnet constants + Factory/Chamber create path for the M1 fork rehearsal.
+ * @dev Extends the Sepolia / Anvil deploy path (`script/DeployFactory.s.sol`):
+ *      `new Chamber()` (Foundry auto-links `BoardLib` + `WalletLib`) then `new Factory(impl, admin)`
+ *      then `Factory.createChamber(erc20, erc721, seats, name, symbol)`.
+ *
+ *      The Ownable account that should receive LORE is the **Chamber proxy** (`createChamber` return
+ *      value). Wallet execution (`WalletLib.executeTransaction`) uses `address(this)` as `msg.sender`
+ *      on the target, so `LORE.owner() == chamber` is the address that can later call `onlyOwner`.
+ *
+ *      `createChamber` uses CREATE (not CREATE2). The chamber address is
+ *      `computeCreateAddress(factory, factoryNonce)` for that one proxy CREATE — no salt.
+ */
+library MainnetLoreHandoff {
+    /// @dev Checksums match `script/Chamber.s.sol` (chainid == 1) and the repo README.
+    address internal constant LORE = 0x7756D245527F5f8925A537be509BF54feb2FdC99;
+    address internal constant MEMBERSHIP_NFT = 0xB99DEdbDe082B8Be86f06449f2fC7b9FED044E15;
+    address internal constant TEAM_SAFE = 0x5d45A213B2B6259F0b3c116a8907B56AB5E22095;
+
+    /// @dev Same seats / share token labels as `script/Chamber.s.sol` mainnet branch.
+    uint256 internal constant SEATS = 5;
+    string internal constant NAME = "Chamber LORE";
+    string internal constant SYMBOL = "cLORE";
+
+    struct Deployment {
+        Factory factory;
+        address chamberImplementation;
+        address payable chamber;
+    }
+
+    /**
+     * @notice Deploy Chamber implementation + Factory, then create a Chamber on the current chain.
+     * @param factoryAdmin Factory Ownable admin (`setImplementation`). Sepolia used the team Safe.
+     */
+    function deployFactoryAndChamber(address factoryAdmin) internal returns (Deployment memory d) {
+        Chamber implementation = new Chamber();
+        d.chamberImplementation = address(implementation);
+        d.factory = new Factory(address(implementation), factoryAdmin);
+        d.chamber = payable(d.factory.createChamber(LORE, MEMBERSHIP_NFT, SEATS, NAME, SYMBOL));
+    }
+}

--- a/contracts/test/utils/MainnetLoreHandoff.sol
+++ b/contracts/test/utils/MainnetLoreHandoff.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Vm} from "forge-std/Vm.sol";
+import {stdJson} from "forge-std/StdJson.sol";
 import {Factory} from "src/Factory.sol";
 import {Chamber} from "src/Chamber.sol";
+import {BoardLib} from "src/libraries/BoardLib.sol";
+import {WalletLib} from "src/libraries/WalletLib.sol";
 
 /// @notice Minimal Ownable surface of mainnet LORE (single-step; no `pendingOwner`).
 interface ILoreOwnable {
@@ -13,18 +17,20 @@ interface ILoreOwnable {
 /**
  * @title MainnetLoreHandoff
  * @notice Shared mainnet constants + Factory/Chamber create path for the M1 fork rehearsal.
- * @dev Extends the Sepolia / Anvil deploy path (`script/DeployFactory.s.sol`):
- *      `new Chamber()` (Foundry auto-links `BoardLib` + `WalletLib`) then `new Factory(impl, admin)`
- *      then `Factory.createChamber(erc20, erc721, seats, name, symbol)`.
+ * @dev Extends `script/DeployFactory.s.sol`: `new Chamber()` then `new Factory(impl, admin)` then
+ *      `Factory.createChamber`. Tests auto-link `BoardLib` + `WalletLib`. `forge script` dry-run
+ *      cannot `new Chamber()` (unlinked) — use {deployFactoryAndChamberLinked}.
  *
- *      The Ownable account that should receive LORE is the **Chamber proxy** (`createChamber` return
- *      value). Wallet execution (`WalletLib.executeTransaction`) uses `address(this)` as `msg.sender`
- *      on the target, so `LORE.owner() == chamber` is the address that can later call `onlyOwner`.
+ *      The Ownable account that should receive LORE is the **Chamber proxy** (`createChamber`
+ *      return value). Wallet execution uses `address(this)` as `msg.sender` on the target.
  *
- *      `createChamber` uses CREATE (not CREATE2). The chamber address is
- *      `computeCreateAddress(factory, factoryNonce)` for that one proxy CREATE — no salt.
+ *      `createChamber` uses CREATE (not CREATE2). No salt.
  */
 library MainnetLoreHandoff {
+    using stdJson for string;
+
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     /// @dev Checksums match `script/Chamber.s.sol` (chainid == 1) and the repo README.
     address internal constant LORE = 0x7756D245527F5f8925A537be509BF54feb2FdC99;
     address internal constant MEMBERSHIP_NFT = 0xB99DEdbDe082B8Be86f06449f2fC7b9FED044E15;
@@ -35,20 +41,95 @@ library MainnetLoreHandoff {
     string internal constant NAME = "Chamber LORE";
     string internal constant SYMBOL = "cLORE";
 
+    /// @dev solc placeholders for `src/libraries/{Board,Wallet}Lib.sol:{Board,Wallet}Lib`.
+    string internal constant BOARD_LIB_PLACEHOLDER = "__$562d0ceeeab35c7b4159c1d109bae4c407$__";
+    string internal constant WALLET_LIB_PLACEHOLDER = "__$a34514150719d1f4c4dbc9690f221c78b7$__";
+
     struct Deployment {
         Factory factory;
         address chamberImplementation;
+        address boardLib;
+        address walletLib;
         address payable chamber;
     }
 
-    /**
-     * @notice Deploy Chamber implementation + Factory, then create a Chamber on the current chain.
-     * @param factoryAdmin Factory Ownable admin (`setImplementation`). Sepolia used the team Safe.
-     */
+    /// @notice Test / broadcast path: Foundry auto-deploys and links BoardLib + WalletLib.
     function deployFactoryAndChamber(address factoryAdmin) internal returns (Deployment memory d) {
         Chamber implementation = new Chamber();
         d.chamberImplementation = address(implementation);
         d.factory = new Factory(address(implementation), factoryAdmin);
         d.chamber = payable(d.factory.createChamber(LORE, MEMBERSHIP_NFT, SEATS, NAME, SYMBOL));
+    }
+
+    /**
+     * @notice Script dry-run path: deploy libs, link Chamber artifact, then Factory + create.
+     * @dev `vm.deployCode("Chamber")` reverts when unlinked. Production `forge script --broadcast`
+     *      (`DeployFactory.s.sol`) auto-deploys libs; this mirrors that pairing for a fork dry-run.
+     */
+    function deployFactoryAndChamberLinked(address factoryAdmin) internal returns (Deployment memory d) {
+        d.boardLib = address(new BoardLib());
+        d.walletLib = address(new WalletLib());
+        d.chamberImplementation = _deployLinkedChamber(d.boardLib, d.walletLib);
+        d.factory = new Factory(d.chamberImplementation, factoryAdmin);
+        d.chamber = payable(d.factory.createChamber(LORE, MEMBERSHIP_NFT, SEATS, NAME, SYMBOL));
+    }
+
+    function _deployLinkedChamber(address boardLib, address walletLib) internal returns (address impl) {
+        string memory artifact = vm.readFile("out/Chamber.sol/Chamber.json");
+        string memory hexObj = artifact.readString(".bytecode.object");
+        hexObj = _replaceAll(hexObj, BOARD_LIB_PLACEHOLDER, _addrHex(boardLib));
+        hexObj = _replaceAll(hexObj, WALLET_LIB_PLACEHOLDER, _addrHex(walletLib));
+        bytes memory bytecode = vm.parseBytes(hexObj);
+        assembly {
+            impl := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+        if (impl == address(0) || impl.code.length == 0) {
+            revert("linked Chamber deploy failed");
+        }
+    }
+
+    function _addrHex(address account) internal pure returns (string memory) {
+        bytes16 hexits = "0123456789abcdef";
+        bytes20 data = bytes20(account);
+        bytes memory out = new bytes(40);
+        for (uint256 i; i < 20; ++i) {
+            out[2 * i] = hexits[uint8(data[i] >> 4)];
+            out[2 * i + 1] = hexits[uint8(data[i] & 0x0f)];
+        }
+        return string(out);
+    }
+
+    /// @dev In-place replace; needle and replacement must be the same length (40-char placeholders).
+    function _replaceAll(string memory subject, string memory needle, string memory replacement)
+        internal
+        pure
+        returns (string memory)
+    {
+        bytes memory s = bytes(subject);
+        bytes memory n = bytes(needle);
+        bytes memory r = bytes(replacement);
+        if (n.length != r.length) revert("placeholder length mismatch");
+        if (n.length == 0) revert("empty placeholder");
+
+        uint256 replaced;
+        for (uint256 i; i + n.length <= s.length; ++i) {
+            bool match_ = true;
+            for (uint256 j; j < n.length; ++j) {
+                if (s[i + j] != n[j]) {
+                    match_ = false;
+                    break;
+                }
+            }
+            if (!match_) continue;
+            for (uint256 j; j < r.length; ++j) {
+                s[i + j] = r[j];
+            }
+            unchecked {
+                i += n.length - 1;
+                ++replaced;
+            }
+        }
+        if (replaced == 0) revert("Chamber bytecode missing library placeholder");
+        return string(s);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks a Foundry **mainnet-fork rehearsal** in front of the real Ethereum deploy in #188.

## What this is
Dry run only: deploy Factory + Chamber implementation on an Ethereum mainnet fork, `createChamber` with live LORE + membership NFT, impersonate the team Safe, `transferOwnership` of LORE to the **Chamber proxy**, assert `LORE.owner() == chamber`.

This proves the **mechanics**. It does **not** decide CCA vs Ownable production sequencing, move Safe residual balances, or change CCA params.

## How to run
From `contracts/`:

```bash
export MAINNET_RPC_URL=https://...   # or ETH_RPC_URL
forge test --match-path test/fork/MainnetLoreOwnableHandoff.t.sol -vvv
# or
make rehearse-mainnet-lore-handoff
```

Interactive script (never `--broadcast`):

```bash
forge script script/RehearseMainnetLoreHandoff.s.sol:RehearseMainnetLoreHandoff \
  --fork-url "$MAINNET_RPC_URL" -vvv
```

Docs: `contracts/docs/mainnet-lore-handoff-rehearsal.md`.

**Success:** logs Factory / Chamber impl / Chamber proxy, and `LORE.owner()` equals the Chamber proxy.

**CI:** `make ci-test` skips the fork case when `MAINNET_RPC_URL` / `ETH_RPC_URL` are unset.

## Verified in code (not assumed)
- `Factory.createChamber(erc20, erc721, seats, name, symbol)` — same args as `script/Chamber.s.sol` mainnet: LORE, membership NFT, 5 seats, `Chamber LORE` / `cLORE`.
- Ownable target is the Chamber **proxy** (`createChamber` return). Wallet execute uses `address(this)` as `msg.sender`.
- Mainnet LORE ABI is single-step Ownable (no `pendingOwner`). Live `owner()` is the team Safe `0x5d45A213B2B6259F0b3c116a8907B56AB5E22095`.
- Foundry `new Chamber()` auto-links `BoardLib` + `WalletLib` in tests (Sepolia / `DeployFactory` path). Script dry-run cannot — it deploys the two libs and links the artifact.

## Fork run (this PR, publicnode RPC)
`forge test` (auto-link, test-contract CREATE — **not** addresses to record on mainnet):

- Factory `0x2e234DAe75C793f67A35089C9d99245E1C58470b`
- Chamber impl `0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f`
- Chamber / `LORE.owner()` after `0xffD4505B3452Dc22f8473616d50503bA9E1710Ac`

`forge script` (explicit libs):

- BoardLib `0x5aAdFB43eF8dAF45DD80F4676345b7676f1D70e3`
- WalletLib `0xf13D09eD3cbdD1C930d4de74808de1f33B6b3D4f`
- Chamber / `LORE.owner()` after `0x7033E581DCFAA189d0cB21932Fb318644387D194`

Assertion: `LORE.owner()` flipped from the Safe to the Chamber proxy.

## Mainnet blockers / gaps
- CREATE, not CREATE2 — chamber address is Factory nonce; no salt. Record it after `createChamber`, then Safe-sign `transferOwnership`.
- Fork uses `vm.prank(Safe)`; production is a real Safe `execTransaction` / UI call.
- Board seating not exercised: empty board after create; seats=5 → quorum 3; needs NFT holders + LORE deposits + `SEATING_DELAY`.
- Production Etherscan verify still needs BoardLib + WalletLib addresses from the broadcast artifact.
- `forge script` dry-run cannot `new Chamber()` while unlinked (this PR links the artifact). `--broadcast` on `DeployFactory.s.sol` auto-deploys libs.

Ready for Reviewer Bot. Do not merge until reviewed.

Closes / advances #188 (rehearsal only — live deploy + app wiring remain).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6884099b-8a8e-4205-bba1-ad15d632c263?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6884099b-8a8e-4205-bba1-ad15d632c263&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

