### PR TITLE
fix(app): hoist Expired queue section out of Pending

### DIFF
--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -894,7 +894,10 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     {...writeReporters}
                   />
                 ))}
+              </div>
+            )}
 
+            {/* Expired */}
             {expiredTransactions.length > 0 && (
               <div className="space-y-3">
                 <h3 className="font-heading font-semibold text-red-400/80 flex items-center gap-2">
@@ -914,8 +917,6 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     {...writeReporters}
                   />
                 ))}
-              </div>
-            )}
               </div>
             )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #191.

Expired proposals only rendered when at least one pending proposal also existed. The Expired block in `app/src/pages/TransactionQueue.tsx` sat inside the `pendingTransactions.length > 0` conditional, so an expire-only queue showed a blank tab while the Queue badge and Expired header stat still counted those items.

## Change

Hoist Expired to a sibling of Pending (same pattern as Ready / Cancelled). Empty-state already requires `expiredTransactions.length === 0`, so expire-only queues now show the Expired list. Badge (`queueCount`) and header counts are unchanged and still include expired items.

## Out of scope

- No count formula changes
- No card or expiry-UX work from the first-run review

## Testing

- Structural read of the queue tab: Pending closes before Expired opens
- Empty-state condition still includes `expiredTransactions.length === 0`
- `queueCount` and the Expired stat still use `expiredTransactions.length`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4387bc6b-54b2-4837-ae9b-da1bf03e884e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4387bc6b-54b2-4837-ae9b-da1bf03e884e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

