### PR TITLE
fix(app): TreasuryOverview uses vault asset decimals (#192)

### DIFF
--- a/app/src/components/TreasuryOverview.tsx
+++ b/app/src/components/TreasuryOverview.tsx
@@ -24,7 +24,7 @@ import {
   useSimulateDeposit,
   useSimulateWithdraw,
 } from '@/hooks'
-import { erc20Abi } from '@/contracts'
+import { chamberAbi, erc20Abi } from '@/contracts'
 
 interface TreasuryOverviewProps {
   chamberAddress: `0x${string}`
@@ -40,21 +40,39 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [pollAllowanceAfterApprove, setPollAllowanceAfterApprove] = useState(false)
 
+  // Fetch decimals for the vault asset — avoids hardcoding 18
+  const { data: assetDecimalsData } = useReadContract({
+    address: chamberInfo.assetToken,
+    abi: erc20Abi,
+    functionName: 'decimals',
+    query: { enabled: !!chamberInfo.assetToken },
+  })
+  const assetDecimals = typeof assetDecimalsData === 'number' ? assetDecimalsData : 18
+
+  // Share token decimals (ERC-4626: underlying + offset), for share/price display
+  const { data: shareDecimalsData } = useReadContract({
+    address: chamberAddress,
+    abi: erc20Abi,
+    functionName: 'decimals',
+    query: { enabled: !!chamberAddress },
+  })
+  const shareDecimals = typeof shareDecimalsData === 'number' ? shareDecimalsData : 18
+
   const depositAmountBigInt = useMemo(() => {
     try {
-      return depositAmount ? parseUnits(depositAmount, 18) : 0n
+      return depositAmount ? parseUnits(depositAmount, assetDecimals) : 0n
     } catch {
       return 0n
     }
-  }, [depositAmount])
+  }, [depositAmount, assetDecimals])
 
   const withdrawAmountBigInt = useMemo(() => {
     try {
-      return withdrawAmount ? parseUnits(withdrawAmount, 18) : 0n
+      return withdrawAmount ? parseUnits(withdrawAmount, assetDecimals) : 0n
     } catch {
       return 0n
     }
-  }, [withdrawAmount])
+  }, [withdrawAmount, assetDecimals])
 
   // Get asset token symbol
   const { data: assetSymbol } = useReadContract({
@@ -82,6 +100,22 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
   const { approve, isPending: isApproving, isConfirming: isApproveConfirming, isSuccess: isApproveSuccess } = useTokenApprove(chamberInfo.assetToken)
   const { deposit, isPending: isDepositing, isConfirming: isDepositConfirming } = useDeposit(chamberAddress)
   const { withdraw, isPending: isWithdrawing, isConfirming: isWithdrawConfirming } = useWithdraw(chamberAddress)
+
+  const withdrawableShares =
+    userBalance !== undefined
+      ? userBalance > totalDelegated
+        ? userBalance - totalDelegated
+        : 0n
+      : undefined
+
+  // withdraw() takes assets; convert free shares so MAX matches the typed amount
+  const { data: withdrawableAssets } = useReadContract({
+    address: chamberAddress,
+    abi: chamberAbi,
+    functionName: 'convertToAssets',
+    args: withdrawableShares !== undefined ? [withdrawableShares] : undefined,
+    query: { enabled: withdrawableShares !== undefined },
+  })
 
   // Watch for vault events and refresh data when transactions are mined
   useChamberEvents(chamberAddress, {
@@ -203,7 +237,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
   const handleDeposit = async () => {
     if (!depositAmount || !userAddress) return
     try {
-      const amount = parseUnits(depositAmount, 18)
+      const amount = parseUnits(depositAmount, assetDecimals)
       await deposit(amount, userAddress)
       toast.success('Deposit submitted!')
       setDepositAmount('')
@@ -217,7 +251,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
   const handleWithdraw = async () => {
     if (!withdrawAmount || !userAddress) return
     try {
-      const amount = parseUnits(withdrawAmount, 18)
+      const amount = parseUnits(withdrawAmount, assetDecimals)
       await withdraw(amount, userAddress, userAddress)
       toast.success('Withdrawal submitted!')
       setWithdrawAmount('')
@@ -251,7 +285,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
               <p className="text-slate-400 text-sm">Total Assets</p>
               <p className="font-heading text-2xl font-bold gradient-text">
                 {chamberInfo.totalAssets !== undefined
-                  ? parseFloat(formatUnits(chamberInfo.totalAssets, 18)).toLocaleString(undefined, {
+                  ? parseFloat(formatUnits(chamberInfo.totalAssets, assetDecimals)).toLocaleString(undefined, {
                       maximumFractionDigits: 2,
                     })
                   : '...'
@@ -286,7 +320,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
               <p className="text-slate-400 text-sm">Total Shares</p>
               <p className="font-heading text-2xl font-bold text-slate-100">
                 {chamberInfo.totalSupply !== undefined
-                  ? parseFloat(formatUnits(chamberInfo.totalSupply, 18)).toLocaleString(undefined, {
+                  ? parseFloat(formatUnits(chamberInfo.totalSupply, shareDecimals)).toLocaleString(undefined, {
                       maximumFractionDigits: 2,
                     })
                   : '...'
@@ -299,7 +333,10 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
           </div>
           <div className="text-slate-500 text-sm">
             1 {chamberInfo.symbol || 'share'} = {chamberInfo.totalSupply && chamberInfo.totalAssets && chamberInfo.totalSupply > 0n
-              ? (Number(chamberInfo.totalAssets) / Number(chamberInfo.totalSupply)).toFixed(4)
+              ? (
+                  Number(formatUnits(chamberInfo.totalAssets, assetDecimals)) /
+                  Number(formatUnits(chamberInfo.totalSupply, shareDecimals))
+                ).toFixed(4)
               : '1.0000'
             } {assetSymbol as string || 'assets'}
           </div>
@@ -319,7 +356,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
               <p className="text-slate-400 text-sm">Your Shares</p>
               <p className="font-heading text-2xl font-bold gradient-text">
                 {userBalance !== undefined
-                  ? parseFloat(formatUnits(userBalance, 18)).toLocaleString(undefined, {
+                  ? parseFloat(formatUnits(userBalance, shareDecimals)).toLocaleString(undefined, {
                       maximumFractionDigits: 4,
                     })
                   : 'Connect Wallet'
@@ -363,7 +400,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
                 <span className="text-slate-500 shrink-0">Wallet balance</span>
                 <span className="text-slate-200 font-mono text-right tabular-nums">
                   {tokenBalance !== undefined
-                    ? `${parseFloat(formatUnits(tokenBalance, 18)).toLocaleString(undefined, { maximumFractionDigits: 4 })} ${assetSymbol as string || ''}`
+                    ? `${parseFloat(formatUnits(tokenBalance, assetDecimals)).toLocaleString(undefined, { maximumFractionDigits: 4 })} ${assetSymbol as string || ''}`
                     : '—'}
                 </span>
               </div>
@@ -384,7 +421,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
                   />
                   <button
                     type="button"
-                    onClick={() => tokenBalance && setDepositAmount(formatUnits(tokenBalance, 18))}
+                    onClick={() => tokenBalance && setDepositAmount(formatUnits(tokenBalance, assetDecimals))}
                     className="absolute right-4 top-1/2 -translate-y-1/2 text-accent-400 hover:text-accent-300 text-sm font-medium"
                   >
                     MAX
@@ -508,15 +545,15 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
               <div className="flex items-center justify-between gap-3 text-sm">
                 <span className="text-slate-500 shrink-0">Withdrawable</span>
                 <span className="text-slate-200 font-mono text-right tabular-nums">
-                  {userBalance !== undefined
-                    ? `${parseFloat(formatUnits(userBalance > totalDelegated ? userBalance - totalDelegated : 0n, 18)).toFixed(4)} ${chamberInfo.symbol || ''}`
+                  {withdrawableAssets !== undefined
+                    ? `${parseFloat(formatUnits(withdrawableAssets, assetDecimals)).toFixed(4)} ${assetSymbol as string || ''}`
                     : '—'}
                 </span>
               </div>
               {totalDelegated > 0n && userBalance !== undefined && (
                 <p className="mt-2.5 text-xs leading-relaxed text-amber-200/90 border-l-2 border-amber-500/45 pl-2.5">
                   <span className="font-medium text-amber-300">
-                    {parseFloat(formatUnits(totalDelegated, 18)).toFixed(4)} {chamberInfo.symbol || 'shares'} delegated
+                    {parseFloat(formatUnits(totalDelegated, shareDecimals)).toFixed(4)} {chamberInfo.symbol || 'shares'} delegated
                   </span>
                   <span className="text-amber-200/75"> — locked until you undelegate.</span>
                 </p>
@@ -539,9 +576,8 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
                   <button
                     type="button"
                     onClick={() => {
-                      if (userBalance === undefined) return
-                      const withdrawable = userBalance > totalDelegated ? userBalance - totalDelegated : 0n
-                      setWithdrawAmount(formatUnits(withdrawable, 18))
+                      if (withdrawableAssets === undefined) return
+                      setWithdrawAmount(formatUnits(withdrawableAssets, assetDecimals))
                     }}
                     className="absolute right-4 top-1/2 -translate-y-1/2 text-accent-400 hover:text-accent-300 text-sm font-medium"
                   >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TreasuryOverview` hardcoded `parseUnits`/`formatUnits(..., 18)` on deposit (and related treasury amounts). A USDC (6-decimal) chamber mis-scaled deposits by ~1e12.

This matches the queue’s token-transfer path: read `decimals()` from the vault asset (`chamberInfo.assetToken`) and use it for deposit, withdraw, wallet balance, MAX, and total assets.

Share balances and share-price use the chamber share token’s `decimals()` (ERC-4626 underlying + offset). Withdraw MAX converts free shares via `convertToAssets` because `withdraw()` takes assets.

Closes #192.

## Test plan

- [ ] Typecheck `app` (`tsc --noEmit`)
- [ ] On an 18-decimal vault, deposit the amount typed; MAX fills wallet balance
- [ ] On a 6-decimal vault (USDC), deposit `1` → `parseUnits(1, 6)` (not `1e18`)
- [ ] Withdraw MAX fills withdrawable **assets**, not raw shares
- [ ] Total assets / share-price render with the correct decimal scaling

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b22e1494-55c8-4f94-9249-dea33af001bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b22e1494-55c8-4f94-9249-dea33af001bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

