### PR TITLE
feat(app): show proposal expiry countdown on queue cards

### DIFF
--- a/app/src/lib/chamberGovernance.ts
+++ b/app/src/lib/chamberGovernance.ts
@@ -16,6 +16,17 @@ export const SEATING_DELAY_BLOCKS = 1n
 export const SEAT_UPDATE_TIMELOCK_SEC = 7n * 24n * 60n * 60n
 /** H-03 `SEAT_UPDATE_EXPIRY` (internal, 14 days) */
 export const SEAT_UPDATE_EXPIRY_SEC = 14n * 24n * 60n * 60n
+/** M-06 `WalletTypes.DEFAULT_TRANSACTION_MAX_AGE` (internal, 30 days) */
+export const DEFAULT_TRANSACTION_MAX_AGE_SEC = 30 * 24 * 60 * 60
+
+/** Amber when remaining time is under 1 hour or the last 10% of the default max age. */
+export function isProposalDeadlineUrgent(
+  remainingSec: number,
+  maxAgeSec = DEFAULT_TRANSACTION_MAX_AGE_SEC,
+): boolean {
+  if (remainingSec <= 0) return false
+  return remainingSec < 60 * 60 || remainingSec < maxAgeSec * 0.1
+}
 
 /** L-01 `Registry.MAX_PAGE_SIZE` */
 export const REGISTRY_PAGE_SIZE = 256n

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -62,6 +62,8 @@ import {
   UNPAUSE_SELECTOR,
   SEAT_UPDATE_TIMELOCK_SEC,
   SEAT_UPDATE_EXPIRY_SEC,
+  DEFAULT_TRANSACTION_MAX_AGE_SEC,
+  isProposalDeadlineUrgent,
   isAllowedChamberSelfCall,
   isChamberSelfCall,
   isUnpauseCall,
@@ -1197,6 +1199,12 @@ function TransactionCard({
     if (calldataTouched || !resolvedCalldata) return
     setExecuteCalldata(resolvedCalldata.calldata)
   }, [resolvedCalldata, calldataTouched])
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000))
+  useEffect(() => {
+    if (transaction.executed) return
+    const id = window.setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 15_000)
+    return () => window.clearInterval(id)
+  }, [transaction.executed])
   const { isConfirmed: userHasConfirmed } = useTransactionConfirmation(
     chamberAddress,
     leftoverTokenId ?? userTokenId,
@@ -1324,6 +1332,11 @@ function TransactionCard({
   const isExpired = transaction.status === 'expired' || transaction.expired === true
   const liveConfirmations = transaction.liveConfirmations ?? transaction.confirmations
   const requiredConfirmations = transaction.requiredConfirmations || quorum
+  const deadlineLabel = formatProposalDeadlineLabel({
+    deadline: transaction.deadline,
+    expired: isExpired,
+    nowSec,
+  })
   const executeBlockedByPause =
     !!paused &&
     !isUnpauseCall(
@@ -1434,6 +1447,21 @@ function TransactionCard({
               <FiCheck className="w-3 h-3" />
               {liveConfirmations} / {requiredConfirmations}
             </span>
+            {!transaction.executed && (
+              <span
+                className={`flex items-center gap-1 ${
+                  isExpired
+                    ? 'text-red-400'
+                    : deadlineLabel.urgent
+                      ? 'text-amber-400'
+                      : ''
+                }`}
+                title={deadlineLabel.title}
+              >
+                <FiClock className="w-3 h-3" />
+                {deadlineLabel.text}
+              </span>
+            )}
             {!isCancelled && !transaction.executed && (transaction.cancelConfirmations ?? 0) > 0 && (
               <span className="flex items-center gap-1 text-amber-400/80">
                 <FiX className="w-3 h-3" />
@@ -1628,6 +1656,31 @@ function formatDurationSeconds(total: number): string {
   if (d > 0) return `${d}d ${h}h`
   if (h > 0) return `${h}h ${m}m`
   return `${Math.max(1, m)}m`
+}
+
+function formatProposalDeadlineLabel(args: {
+  deadline?: bigint
+  expired?: boolean
+  nowSec: number
+}): { text: string; urgent: boolean; title: string } {
+  const deadlineSec = args.deadline !== undefined && args.deadline > 0n ? Number(args.deadline) : 0
+  if (deadlineSec <= 0) {
+    return {
+      text: 'No expiry',
+      urgent: false,
+      title: 'No execution deadline is stored (pre-upgrade or unset)',
+    }
+  }
+  const remaining = deadlineSec - args.nowSec
+  const absolute = new Date(deadlineSec * 1000).toLocaleString()
+  if (args.expired || remaining <= 0) {
+    return { text: 'Expired', urgent: false, title: `Deadline ${absolute}` }
+  }
+  return {
+    text: `~${formatDurationSeconds(remaining)} left`,
+    urgent: isProposalDeadlineUrgent(remaining),
+    title: `Expires ${absolute}`,
+  }
 }
 
 function BoardProposalCard({
@@ -2648,6 +2701,15 @@ function NewTransactionForm({
               </p>
               <p className="text-[11px] text-slate-500 mt-2">
                 Proposal title, description, and risk summary will be committed onchain as metadata for auditability.
+              </p>
+              {/* Deadline input is out of scope: useSubmitTransaction calls the no-deadline
+                  overloads, which apply WalletTypes.DEFAULT_TRANSACTION_MAX_AGE (30 days). */}
+              <p className="text-[11px] text-slate-500 mt-2 flex items-start gap-1.5">
+                <FiClock className="w-3 h-3 mt-0.5 shrink-0" />
+                <span>
+                  Expires {DEFAULT_TRANSACTION_MAX_AGE_SEC / 86400} days after submit (Chamber default).
+                  Confirm, revoke, and execute revert after the deadline.
+                </span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #193.

`getTransactionDeadline` was already fetched and stored on each queue item (`TransactionQueue` ~458–466 / ~632) but `TransactionCard` never rendered it. Directors only learned expiry from the failure toast.

## Changes
- Every **non-executed** card shows remaining time (or `Expired` / `No expiry` when deadline is unset). Reuses `formatDurationSeconds`. Amber when remaining time is under **1 hour** or the last **10%** of the 30-day default max age.
- New-proposal review panel surfaces the Chamber default: submit without an explicit deadline records a **30-day** execution window (`WalletTypes.DEFAULT_TRANSACTION_MAX_AGE`).
- Adds `DEFAULT_TRANSACTION_MAX_AGE_SEC` / `isProposalDeadlineUrgent` next to the other internal governance constants.

## Out of scope: custom deadline input
The contract has deadline overloads (`submitTransaction(..., deadline)` / `submitTransactionWithMetadata(..., deadline)`). The app hook does **not** call them — `useSubmitTransaction` uses the no-deadline overloads, which apply the 30-day default. This PR does not invent a new on-chain API or add a deadline field to the submit form. Wiring an optional deadline through the hook/ABI is a follow-up.

Does not rewrite #191 / #192 / #202 (expired-section nesting, treasury decimals, app CI).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32ad4ba6-a2e3-4d3b-b803-a3b4b8a39558?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32ad4ba6-a2e3-4d3b-b803-a3b4b8a39558&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

