### PR TITLE
app: lead execute with decoded action; hide calldata hex in Advanced

### DIFF
--- a/app/src/lib/proposalCalldata.ts
+++ b/app/src/lib/proposalCalldata.ts
@@ -10,6 +10,7 @@ import {
   erc20Abi,
   formatUnits,
   keccak256,
+  parseAbi,
   parseAbiItem,
   type Hex,
   type PublicClient,
@@ -104,6 +105,24 @@ export async function fetchProposalCalldataFromEvents(
   return null
 }
 
+const KNOWN_ACTION_ABI = parseAbi([
+  'function transfer(address to, uint256 amount)',
+  'function approve(address spender, uint256 amount)',
+  'function transferFrom(address from, address to, uint256 amount)',
+  'function mint(address to, uint256 amount)',
+  'function mint(uint256 amount)',
+  'function burn(uint256 amount)',
+  'function pause()',
+  'function unpause()',
+  'function upgradeImplementation(address newImplementation, bytes data)',
+  'function deposit()',
+  'function deposit(uint256 assets, address receiver)',
+  'function withdraw(uint256 amount)',
+  'function withdraw(uint256 assets, address receiver, address owner)',
+  'function claim()',
+  'function claim(uint256 id)',
+])
+
 export function normalizeCalldataHex(raw: string): `0x${string}` | null {
   const trimmed = raw.trim()
   if (!trimmed || trimmed === '0x') return null
@@ -116,6 +135,7 @@ function shortHexAddress(value: string): string {
 }
 
 function formatUintAmount(value: bigint): string {
+  if (value === 0n) return '0'
   const formatted = formatUnits(value, 18)
   const [whole, frac = ''] = formatted.split('.')
   if (whole !== '0') {
@@ -124,7 +144,8 @@ function formatUintAmount(value: bigint): string {
   }
   const leadingZeros = frac.match(/^0*/)?.[0].length ?? 0
   if (leadingZeros >= 6) return value.toString()
-  return `0.${frac.replace(/0+$/, '')}`
+  const trimmedFrac = frac.replace(/0+$/, '')
+  return trimmedFrac ? `0.${trimmedFrac}` : '0'
 }
 
 function formatDecodedArg(value: unknown): string {
@@ -183,7 +204,7 @@ export function decodeProposalAction(
   const hex = calldata ? normalizeCalldataHex(calldata) : null
   if (!hex) return null
 
-  for (const abi of [chamberAbi, erc20Abi] as const) {
+  for (const abi of [KNOWN_ACTION_ABI, erc20Abi, chamberAbi] as const) {
     try {
       const decoded = decodeFunctionData({ abi, data: hex })
       const args = (decoded.args as readonly unknown[] | undefined) ?? []

--- a/app/src/lib/proposalCalldata.ts
+++ b/app/src/lib/proposalCalldata.ts
@@ -5,7 +5,15 @@
  * metadata URI, SubmitTransaction logs.
  */
 
-import { keccak256, parseAbiItem, type Hex, type PublicClient } from 'viem'
+import {
+  decodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  keccak256,
+  parseAbiItem,
+  type Hex,
+  type PublicClient,
+} from 'viem'
 import { chamberAbi } from '@/contracts/abis'
 
 const STORAGE_PREFIX = 'chamber-proposal-calldata'
@@ -96,10 +104,109 @@ export async function fetchProposalCalldataFromEvents(
   return null
 }
 
-function normalizeCalldataHex(raw: string): `0x${string}` | null {
+export function normalizeCalldataHex(raw: string): `0x${string}` | null {
   const trimmed = raw.trim()
   if (!trimmed || trimmed === '0x') return null
   return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as `0x${string}`
+}
+
+function shortHexAddress(value: string): string {
+  if (value.length < 12) return value
+  return `${value.slice(0, 6)}…${value.slice(-4)}`
+}
+
+function formatUintAmount(value: bigint): string {
+  const formatted = formatUnits(value, 18)
+  const [whole, frac = ''] = formatted.split('.')
+  if (whole !== '0') {
+    const trimmedFrac = frac.replace(/0+$/, '')
+    return trimmedFrac ? `${whole}.${trimmedFrac}` : whole
+  }
+  const leadingZeros = frac.match(/^0*/)?.[0].length ?? 0
+  if (leadingZeros >= 6) return value.toString()
+  return `0.${frac.replace(/0+$/, '')}`
+}
+
+function formatDecodedArg(value: unknown): string {
+  if (typeof value === 'bigint') return formatUintAmount(value)
+  if (typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)) return shortHexAddress(value)
+  if (typeof value === 'string') return value.length > 22 ? `${value.slice(0, 10)}…` : value
+  if (Array.isArray(value)) return `[${value.map(formatDecodedArg).join(', ')}]`
+  return String(value)
+}
+
+function summarizeDecodedCall(name: string, args: readonly unknown[] | undefined): string {
+  const a = args ?? []
+  switch (name) {
+    case 'transfer':
+      return `Transfer ${formatDecodedArg(a[1])} to ${formatDecodedArg(a[0])}`
+    case 'approve':
+      return `Approve ${formatDecodedArg(a[0])} for ${formatDecodedArg(a[1])}`
+    case 'transferFrom':
+      return `Transfer ${formatDecodedArg(a[2])} from ${formatDecodedArg(a[0])} to ${formatDecodedArg(a[1])}`
+    case 'mint':
+      return a.length >= 2
+        ? `Mint ${formatDecodedArg(a[1])} to ${formatDecodedArg(a[0])}`
+        : `Mint ${formatDecodedArg(a[0])}`
+    case 'burn':
+      return `Burn ${formatDecodedArg(a[0])}`
+    case 'pause':
+      return 'Pause'
+    case 'unpause':
+      return 'Unpause'
+    case 'upgradeImplementation':
+      return `Upgrade implementation to ${formatDecodedArg(a[0])}`
+    case 'deposit':
+      return a.length >= 1 ? `Deposit ${formatDecodedArg(a[0])}` : 'Deposit'
+    case 'withdraw':
+      return a.length >= 1 ? `Withdraw ${formatDecodedArg(a[0])}` : 'Withdraw'
+    case 'claim':
+      return a.length >= 1 ? `Claim ${formatDecodedArg(a[0])}` : 'Claim'
+    default:
+      return a.length > 0 ? `${name}(${a.map(formatDecodedArg).join(', ')})` : `${name}()`
+  }
+}
+
+export type DecodedProposalAction = {
+  functionName: string
+  summary: string
+}
+
+/**
+ * Decode archived execution bytes into a director-facing action line.
+ * Tries Chamber + ERC-20 ABIs; falls back to metadata functionName or the selector.
+ */
+export function decodeProposalAction(
+  calldata: string | undefined,
+  hints?: { functionName?: string },
+): DecodedProposalAction | null {
+  const hex = calldata ? normalizeCalldataHex(calldata) : null
+  if (!hex) return null
+
+  for (const abi of [chamberAbi, erc20Abi] as const) {
+    try {
+      const decoded = decodeFunctionData({ abi, data: hex })
+      const args = (decoded.args as readonly unknown[] | undefined) ?? []
+      return {
+        functionName: decoded.functionName,
+        summary: summarizeDecodedCall(decoded.functionName, args),
+      }
+    } catch {
+      // Selector is not in this ABI.
+    }
+  }
+
+  const selector = hex.slice(0, 10).toLowerCase()
+  if (hints?.functionName) {
+    return {
+      functionName: hints.functionName,
+      summary: `${hints.functionName} (${selector})`,
+    }
+  }
+  return {
+    functionName: selector,
+    summary: `Contract call ${selector}`,
+  }
 }
 
 export function resolveCalldataFromMetadataField(

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -19,6 +19,7 @@ import {
   FiHash,
   FiUsers,
   FiX,
+  FiChevronDown,
 } from 'react-icons/fi'
 import toast from 'react-hot-toast'
 import {
@@ -77,6 +78,8 @@ import {
   setProposalMetadata,
 } from '@/lib/proposalMetadata'
 import {
+  decodeProposalAction,
+  normalizeCalldataHex,
   proposalCalldataMatchesHash,
   setStoredProposalCalldata,
 } from '@/lib/proposalCalldata'
@@ -1188,6 +1191,7 @@ function TransactionCard({
           : undefined
   const [executeCalldata, setExecuteCalldata] = useState('0x')
   const [calldataTouched, setCalldataTouched] = useState(false)
+  const [advancedCalldataOpen, setAdvancedCalldataOpen] = useState(false)
   const onchainMeta = parseProposalMetadataURI(transaction.metadataURI)
   const proposalMeta = onchainMeta || getProposalMetadata(chamberAddress, transaction.id)
   const metadataCalldata =
@@ -1216,12 +1220,40 @@ function TransactionCard({
   useEffect(() => {
     setExecuteCalldata('0x')
     setCalldataTouched(false)
+    setAdvancedCalldataOpen(false)
   }, [transaction.id])
 
   useEffect(() => {
     if (calldataTouched || !resolvedCalldata) return
     setExecuteCalldata(resolvedCalldata.calldata)
   }, [resolvedCalldata, calldataTouched])
+
+  const calldataNotArchived =
+    !isResolvingCalldata && !resolvedCalldata && !hasOnchainPreimage
+
+  useEffect(() => {
+    if (calldataNotArchived) setAdvancedCalldataOpen(true)
+  }, [calldataNotArchived])
+
+  const previewCalldata = useMemo(() => {
+    const fromInput = normalizeCalldataHex(executeCalldata)
+    if (fromInput) return fromInput
+    if (resolvedCalldata?.calldata) return resolvedCalldata.calldata
+    if (typeof onchainStoredCalldata === 'string') {
+      return normalizeCalldataHex(onchainStoredCalldata)
+    }
+    return null
+  }, [executeCalldata, resolvedCalldata, onchainStoredCalldata])
+
+  const calldataMatchesCommitment = !!(
+    previewCalldata &&
+    proposalCalldataMatchesHash(previewCalldata, transaction.dataHash)
+  )
+
+  const decodedAction = useMemo(
+    () => decodeProposalAction(previewCalldata ?? undefined, { functionName: proposalMeta?.functionName }),
+    [previewCalldata, proposalMeta?.functionName],
+  )
   const { isConfirmed: userHasConfirmed } = useTransactionConfirmation(
     chamberAddress,
     leftoverTokenId ?? userTokenId,
@@ -1468,49 +1500,82 @@ function TransactionCard({
           </div>
 
           {!transaction.executed && !isCancelled && transaction.status === 'ready' && hasData && (
-            <div className="mt-3 space-y-1.5">
-              <label className="block text-slate-500 text-xs font-medium">
-                Execution calldata (hex)
-              </label>
-              {isResolvingCalldata && !calldataTouched && (
+            <div className="mt-3 space-y-2">
+              {isResolvingCalldata && !calldataTouched && !resolvedCalldata && (
                 <p className="text-slate-500 text-xs flex items-center gap-1.5">
                   <FiLoader className="w-3 h-3 animate-spin" />
                   Loading calldata from submission event…
                 </p>
               )}
-              {resolvedCalldata && !calldataTouched && (
-                <p className="text-emerald-400/90 text-xs">
-                  Calldata loaded from{' '}
-                  {resolvedCalldata.source === 'onchain'
-                    ? 'on-chain calldata store'
-                    : resolvedCalldata.source === 'event'
-                      ? 'onchain submit event'
-                      : resolvedCalldata.source === 'metadata'
-                        ? 'proposal metadata'
-                        : 'this browser'}
-                  — review before executing.
-                </p>
+              {decodedAction && calldataMatchesCommitment && (
+                <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-3">
+                  <p className="text-sm text-slate-100 font-medium">{decodedAction.summary}</p>
+                  <p className="text-emerald-400/90 text-xs mt-1">
+                    Calldata matches the on-chain commitment
+                    {resolvedCalldata && !calldataTouched && (
+                      <>
+                        {' '}
+                        · loaded from{' '}
+                        {resolvedCalldata.source === 'onchain'
+                          ? 'on-chain calldata store'
+                          : resolvedCalldata.source === 'event'
+                            ? 'onchain submit event'
+                            : resolvedCalldata.source === 'metadata'
+                              ? 'proposal metadata'
+                              : 'this browser'}
+                      </>
+                    )}
+                    {!resolvedCalldata && hasOnchainPreimage && (executeCalldata.trim() === '0x' || executeCalldata.trim() === '') && (
+                      <> · stored on-chain; execute may pass empty data</>
+                    )}
+                  </p>
+                </div>
               )}
-              {!isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && hasOnchainPreimage && (
+              {decodedAction && !calldataMatchesCommitment && (
+                <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+                  <p className="text-sm text-slate-100 font-medium">{decodedAction.summary}</p>
+                  <p className="text-red-400/90 text-xs mt-1">
+                    Decoded from pasted hex — does not match the on-chain commitment.
+                  </p>
+                </div>
+              )}
+              {!decodedAction && !isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && hasOnchainPreimage && (
                 <p className="text-emerald-400/90 text-xs">
                   Calldata is stored on-chain. Execute may pass empty data.
                 </p>
               )}
-              {!isResolvingCalldata && !resolvedCalldata && executeCalldata === '0x' && !hasOnchainPreimage && (
+              {calldataNotArchived && executeCalldata === '0x' && (
                 <p className="text-amber-400/90 text-xs">
                   Calldata not archived here. Ask the proposer for the hex, or paste from your records.
                 </p>
               )}
-              <textarea
-                className="input font-mono text-xs min-h-[4rem] resize-y w-full"
-                placeholder="0x… (must match onchain hash)"
-                value={executeCalldata}
-                onChange={(e) => {
-                  setCalldataTouched(true)
-                  setExecuteCalldata(e.target.value)
-                }}
-                spellCheck={false}
-              />
+              <details
+                className="rounded-lg border border-slate-700/50 bg-slate-900/40"
+                open={advancedCalldataOpen}
+                onToggle={(e) => setAdvancedCalldataOpen(e.currentTarget.open)}
+              >
+                <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium text-slate-500 list-none flex items-center gap-1.5">
+                  <FiChevronDown
+                    className={`w-3.5 h-3.5 shrink-0 transition-transform ${advancedCalldataOpen ? '' : '-rotate-90'}`}
+                  />
+                  Advanced — raw calldata
+                </summary>
+                <div className="px-3 pb-3 space-y-1.5">
+                  <label className="block text-slate-500 text-xs font-medium">
+                    Execution calldata (hex)
+                  </label>
+                  <textarea
+                    className="input font-mono text-xs min-h-[4rem] resize-y w-full"
+                    placeholder="0x… (must match onchain hash)"
+                    value={executeCalldata}
+                    onChange={(e) => {
+                      setCalldataTouched(true)
+                      setExecuteCalldata(e.target.value)
+                    }}
+                    spellCheck={false}
+                  />
+                </div>
+              </details>
               <p className="pt-1">
                 <Link
                   to="/docs/protocol/multisig"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ready proposals with calldata no longer ask the director to paste raw hex as the primary execute UI.

**What changed**
- Decode archived execution bytes (known transfer/approve/upgrade/pause ABIs, plus Chamber + ERC-20 fallbacks, then metadata `functionName` / selector) and lead with a human-readable action (e.g. `Transfer 1.5 to 0xabc…def`).
- Green state when those bytes match the on-chain `dataHash` commitment.
- Raw hex is collapsed under **Advanced — raw calldata**. The panel auto-expands only on the “Calldata not archived here” path.
- `handleExecute` still hash-checks pasted/resolved bytes (or allows empty data when the L-04 on-chain preimage is present).

**Out of scope**
#195–#199 are not in this PR.

Closes #194.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a312545-42cd-4a56-8541-3ba345ef3972?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a312545-42cd-4a56-8541-3ba345ef3972&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

