### PR TITLE
app: deep-link docs from empty states and confusing moments

### DIFF
--- a/app/src/components/DelegationManager.tsx
+++ b/app/src/components/DelegationManager.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAccount } from 'wagmi'
 import { formatUnits, parseUnits, zeroAddress } from 'viem'
@@ -267,6 +267,12 @@ export default function DelegationManager({
           <p className="text-slate-400 text-xs mt-1 leading-relaxed">
             The board is empty. Delegate shares to a membership NFT you hold. Director rights unlock one block later.
           </p>
+          <Link
+            to="/docs/introduction/getting-started"
+            className="text-accent-400 text-xs hover:underline mt-2 inline-block"
+          >
+            Getting started →
+          </Link>
         </div>
       )}
       {/* Balance Overview */}

--- a/app/src/components/SeatTheBoard.tsx
+++ b/app/src/components/SeatTheBoard.tsx
@@ -137,6 +137,12 @@ export default function SeatTheBoard({
             This chamber has no directors. Submit, confirm, and execute stay locked until a membership NFT
             receives delegation and seating matures.
           </p>
+          <Link
+            to="/docs/introduction/getting-started"
+            className="text-accent-400 text-sm hover:underline mt-2 inline-block"
+          >
+            Getting started →
+          </Link>
         </div>
       </div>
 

--- a/app/src/components/TreasuryOverview.tsx
+++ b/app/src/components/TreasuryOverview.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAccount, useReadContract } from 'wagmi'
 import { formatUnits, parseUnits, maxUint256 } from 'viem'
@@ -233,7 +234,10 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
     <div className="space-y-6">
       {vaultPaused && (
         <div className="rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-200">
-          This chamber is paused. Deposits and withdrawals are halted until the board unpauses.
+          This chamber is paused. Deposits and withdrawals are halted until the board unpauses.{' '}
+          <Link to="/docs/protocol/governance" className="text-accent-400 hover:underline">
+            How governance works →
+          </Link>
         </div>
       )}
       {/* Treasury Stats */}

--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -253,6 +253,12 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
               <p className="text-red-100/80 leading-relaxed">
                 Deposits, withdrawals, and wallet execute are halted. Directors can still submit and confirm an unpause proposal.
               </p>
+              <Link
+                to="/docs/protocol/governance"
+                className="text-accent-400 hover:text-accent-300 font-medium mt-1.5 inline-block"
+              >
+                How governance works →
+              </Link>
             </div>
           </div>
         </motion.div>
@@ -280,6 +286,14 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
                 </span>
                 . Directors can
                 upgrade this proxy via the Chamber’s upgrade flow so it aligns with the Registry.
+              </p>
+              <p className="mt-1.5">
+                <Link
+                  to="/docs/protocol/architecture"
+                  className="inline-flex items-center gap-1 text-accent-400 hover:text-accent-300 font-medium"
+                >
+                  How Chamber upgrades work →
+                </Link>
               </p>
               {implSync.registryAddress && chainId !== 31337 && (
                 <a
@@ -828,6 +842,12 @@ function OverviewTab({ chamberAddress, chamberInfo, members, totalDelegated, use
               <p className="text-slate-500 text-xs max-w-sm mx-auto leading-relaxed">
                 Hold a membership NFT, deposit shares, and delegate to that token. Director actions unlock after one block.
               </p>
+              <Link
+                to="/docs/introduction/getting-started"
+                className="text-accent-400 text-xs hover:underline inline-block"
+              >
+                Getting started →
+              </Link>
               <button
                 type="button"
                 onClick={() => setActiveTab('delegation')}

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -714,7 +714,10 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
 
         {chamberInfo.paused && (
           <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-200">
-            This chamber is paused. Deposits, withdrawals, and execute are halted. Directors can still submit and confirm an unpause proposal.
+            This chamber is paused. Deposits, withdrawals, and execute are halted. Directors can still submit and confirm an unpause proposal.{' '}
+            <Link to="/docs/protocol/governance" className="text-accent-400 hover:underline">
+              How governance works →
+            </Link>
           </div>
         )}
         <DirectorCallerStatus
@@ -743,6 +746,12 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
               className="text-accent-400 text-sm hover:underline mt-2 inline-block"
             >
               Seat the board →
+            </Link>
+            <Link
+              to="/docs/introduction/getting-started"
+              className="text-accent-400 text-sm hover:underline mt-2 ml-4 inline-block"
+            >
+              Getting started →
             </Link>
           </div>
         )}
@@ -959,6 +968,14 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                     >
                       Seat the board
                     </Link>
+                    <p className="mt-4">
+                      <Link
+                        to="/docs/introduction/getting-started"
+                        className="text-accent-400 text-sm hover:underline"
+                      >
+                        Getting started →
+                      </Link>
+                    </p>
                   </>
                 ) : (
                   <>
@@ -1071,6 +1088,14 @@ function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${stri
                       . Ask a director to open this link (with{' '}
                       <span className="font-mono">?proposal=upgrade</span>
                       ), review the prefilled multisig proposal, then submit.
+                    </p>
+                    <p className="mb-3">
+                      <Link
+                        to="/docs/protocol/architecture"
+                        className="text-accent-400 hover:text-accent-300 font-medium"
+                      >
+                        How Chamber upgrades work →
+                      </Link>
                     </p>
                     <div className="flex flex-wrap gap-2">
                       {chainId !== 31337 && (
@@ -1486,6 +1511,14 @@ function TransactionCard({
                 }}
                 spellCheck={false}
               />
+              <p className="pt-1">
+                <Link
+                  to="/docs/protocol/multisig"
+                  className="text-accent-400 text-xs hover:underline"
+                >
+                  How calldata and execute work →
+                </Link>
+              </p>
             </div>
           )}
 
@@ -1600,6 +1633,14 @@ function TransactionCard({
             {hasOnchainPreimage
               ? 'Self-call calldata is stored on-chain. Execute may pass empty data, or re-supply the original bytes.'
               : 'Only the hash is stored onchain. To execute, directors must supply the exact calldata bytes (or use 0x for plain ETH with no call data).'}
+          </p>
+          <p className="mt-2">
+            <Link
+              to="/docs/protocol/multisig"
+              className="text-accent-400 text-xs hover:underline"
+            >
+              How calldata and execute work →
+            </Link>
           </p>
         </div>
       ) : null}
@@ -2408,6 +2449,14 @@ function NewTransactionForm({
                     ? ` (VERSION ${registryUpgradeDraft.registryVersionLabel})`
                     : ''}
                   . Other directors still need to confirm until quorum before execution.
+                </p>
+                <p className="mt-2">
+                  <Link
+                    to="/docs/protocol/architecture"
+                    className="text-accent-400 hover:text-accent-300"
+                  >
+                    How Chamber upgrades work →
+                  </Link>
                 </p>
               </div>
             )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #199.

`/docs` was only reachable from header/footer. Empty boards, execute calldata, and pause/upgrade banners now deep-link into existing in-app doc routes (`<Link to="/docs/…">`, same React Router as `/docs/*`).

## Link sites

1. **Seat-the-board empty states** → `/docs/introduction/getting-started`
   - `SeatTheBoard`, Delegation empty-board callout, Overview “No directors seated”, queue empty-board banner and empty queue.

2. **Calldata / execute Advanced** → `/docs/protocol/multisig`
   - There is no separate queue page. This is the existing in-app doc **Treasury actions (the proposal queue)** (`app/src/docs/protocol/multisig.md`). Linked from the execute hex field and the calldata-commitment note.

3. **Paused / upgrade banners** → existing protocol docs
   - **Paused** (chamber header, queue header, vault): `/docs/protocol/governance`. There is no pause-specific page; this is the closest protocol doc (who directors are and that they act through the queue, including an unpause proposal).
   - **Upgrade** (chamber banner, queue Registry-upgrade callouts): `/docs/protocol/architecture` (upgradeable proxy + Registry implementation pointer). `protocol/multisig` also has an Upgrades section; architecture is the closer match for “new implementation on the Registry.”

## Out of scope

- Docs were not rewritten.
- Contract behavior unchanged.
- No restyle beyond adding the links (same accent-link pattern already used on the queue).
- Branched from `main`. Does not stack on #215 / #216 / #217. Overlap is additive links only.

## Verification

`tsc --noEmit` passed. Browser-checked the four destination routes in the same app chrome (header + docs sidebar, not an external site). Click-through from the three UI sites:

[Seat the board empty state with Getting started link, plus paused and upgrade banners](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseat_board_getting_started_link.png)
[Getting started doc in-app after clicking the empty-state link](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_getting_started_in_app.png)
[Governance doc in-app after clicking the paused banner](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_governance_in_app.png)
[Architecture doc in-app after clicking the upgrade banner](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_architecture_in_app.png)
[Multisig / proposal-queue doc in-app after the calldata link](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_multisig_in_app.png)

[docs_deeplinks_in_app.mp4](https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_deeplinks_in_app.mp4)

The live Sepolia chamber used for the click-through (`0x0ad3…9888`) already has directors and is not paused, so the empty-board / pause / upgrade surfaces were force-shown only for that recording. Those force flags are not in this PR. The calldata destination was verified in-app; this chamber had no queued proposals, so the execute-card hex field was not on screen.

Do not merge from this agent. No review requested.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fee92197-641e-4c3c-81e2-3939d3897acd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fee92197-641e-4c3c-81e2-3939d3897acd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

