### PR TITLE
blog: docs deep-links changelog (2026-09-09)

### DIFF
--- a/landing/content/blog/2026-09-09-docs-deeplinks.md
+++ b/landing/content/blog/2026-09-09-docs-deeplinks.md
@@ -1,0 +1,12 @@
+---
+title: Docs deep-links from empty states and banners
+date: 2026-09-09
+summary: Empty boards, execute calldata, and pause/upgrade banners now link into the in-app docs.
+---
+
+9 September 2026. Docs deep-links from empty states and banners.
+
+- Empty seat-the-board, no-directors, and empty-queue states link to Getting started.
+- Execute hex field and calldata note link to the proposal-queue (multisig) doc.
+- Paused banners link to governance; upgrade banners link to architecture.
+- Links stay in-app (same React docs routes), not an external site.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the 9 September 2026 Chamber changelog post for docs deep-links from empty states and banners.

**Live URL after merge:** https://www.loreum.org/blog/2026-09-09-docs-deeplinks

**Source:** loreum-org/chamber #218 (merged 2026-09-09).

The landing blog eager-loads `landing/content/blog/*.md` via `import.meta.glob` in `landing/src/posts.ts`. This PR only adds the markdown file. No generated index update is required.

- Empty seat-the-board, no-directors, and empty-queue states link to Getting started
- Execute hex field and calldata note link to the proposal-queue (multisig) doc
- Paused banners link to governance; upgrade banners link to architecture
- Links stay in-app (same React docs routes), not an external site

Verified locally: `npm run build` in `landing/` succeeded. The Vite bundle includes all three dated files (`2026-09-09-docs-deeplinks.md`, `2026-09-01-session-key-director.md`, `2026-08-26-factory-my-chambers.md`). Preview at `/blog` listed the new post first in the same card layout as the siblings; `/blog/2026-09-09-docs-deeplinks` rendered the post (not 404).

![Blog index with the new docs deep-links post first](https://cursor.com/artifacts/c/art-57fafc7d-ea87-4a20-8978-f2cd160fc2bf)

![Docs deep-links changelog post page](https://cursor.com/artifacts/c/art-b7d19437-fdfa-46c2-81b5-0cacdb912e18)

<a href="https://cursor.com/agents/bc-ce6e5ddc-df13-464c-abfb-9c0e4cacfd75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_docs_deeplinks_changelog.mp4"><img src="https://cursor.com/artifacts/c/art-5777a6af-df68-43ef-b66b-9e7ca645bbe8" alt="blog_docs_deeplinks_changelog.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce6e5ddc-df13-464c-abfb-9c0e4cacfd75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce6e5ddc-df13-464c-abfb-9c0e4cacfd75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

