### PR TITLE
fix(contracts): PMN-H01 Solution A — seating delay binds NFT control transfer

### DIFF
--- a/contracts/src/Board.sol
+++ b/contracts/src/Board.sol
@@ -6,6 +6,8 @@ import {
 } from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardTransientUpgradeable.sol";
 import {BoardTypes} from "src/types/BoardTypes.sol";
 import {BoardLib} from "src/libraries/BoardLib.sol";
+import {IERC721} from "lib/openzeppelin-contracts/contracts/interfaces/IERC721.sol";
+import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
 
 /**
  * @title Board
@@ -42,12 +44,12 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
         return Node({tokenId: node.tokenId, amount: node.amount, next: node.next, prev: node.prev});
     }
 
-    function _delegate(uint256 tokenId, uint256 amount) internal {
-        BoardLib.delegate(_getBoardStorage(), tokenId, amount, msg.sender);
+    function _delegate(uint256 tokenId, uint256 amount, IERC721 nft) internal {
+        BoardLib.delegate(_getBoardStorage(), tokenId, amount, msg.sender, nft);
     }
 
-    function _undelegate(uint256 tokenId, uint256 amount) internal {
-        BoardLib.undelegate(_getBoardStorage(), tokenId, amount, msg.sender);
+    function _undelegate(uint256 tokenId, uint256 amount, IERC721 nft) internal {
+        BoardLib.undelegate(_getBoardStorage(), tokenId, amount, msg.sender, nft);
     }
 
     function _reposition(uint256 tokenId) internal {
@@ -78,8 +80,8 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
         BoardLib.setSeats(_getBoardStorage(), tokenId, numOfSeats);
     }
 
-    function _executeSeatsUpdate(uint256 tokenId) internal {
-        BoardLib.executeSeatsUpdate(_getBoardStorage(), tokenId);
+    function _executeSeatsUpdate(uint256 tokenId, IERC721 nft) internal {
+        BoardLib.executeSeatsUpdate(_getBoardStorage(), tokenId, nft);
     }
 
     function _cancelSeatUpdate(uint256 tokenId) internal {
@@ -96,5 +98,45 @@ abstract contract Board is ReentrancyGuardTransientUpgradeable {
 
     function _isSeatingMature(uint256 tokenId) internal view returns (bool) {
         return BoardLib.isSeatingMature(_getBoardStorage(), tokenId);
+    }
+
+    function _effectiveSeatedAt(IERC721 nft, uint256 tokenId) internal view returns (uint256) {
+        return BoardLib.effectiveSeatedAt(_getBoardStorage(), nft, tokenId);
+    }
+
+    function _isSeatingMature(IERC721 nft, uint256 tokenId) internal view returns (bool) {
+        return BoardLib.isSeatingMature(_getBoardStorage(), nft, tokenId);
+    }
+
+    function _syncSeatingControl(IERC721 nft, uint256 tokenId) internal {
+        BoardLib.syncSeatingControl(_getBoardStorage(), nft, tokenId);
+    }
+
+    function _countCurrentDirectorFlags(
+        IERC721 nft,
+        mapping(uint256 nonce => mapping(uint256 tokenId => bool)) storage flags,
+        mapping(uint256 nonce => mapping(uint256 tokenId => address)) storage flagOwners,
+        uint256 nonce
+    ) internal view returns (uint256) {
+        return BoardLib.countCurrentDirectorFlags(_getBoardStorage(), nft, flags, flagOwners, nonce);
+    }
+
+    function _collectDelegations(
+        mapping(address => mapping(uint256 => uint256)) storage holderDelegation,
+        mapping(address => uint256) storage totalHolderDelegations,
+        mapping(address => EnumerableSet.UintSet) storage holderDelegatedTokenIds,
+        address holder
+    ) internal view returns (uint256[] memory, uint256[] memory) {
+        return BoardLib.collectDelegations(
+            _getBoardStorage(), holderDelegation, totalHolderDelegations, holderDelegatedTokenIds, holder
+        );
+    }
+
+    function _syncTrackedDelegations(
+        mapping(address => mapping(uint256 => uint256)) storage holderDelegation,
+        mapping(address => EnumerableSet.UintSet) storage holderDelegatedTokenIds,
+        address holder
+    ) internal {
+        BoardLib.syncTrackedDelegations(_getBoardStorage(), holderDelegation, holderDelegatedTokenIds, holder);
     }
 }

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -41,8 +41,8 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
      * @notice ERC-7201 namespaced storage layout for Chamber
      * @dev Packing: `nft` (address, 20 bytes) sits alone in its slot; remaining fields are
      *      dynamic types or mappings which each occupy a full slot.
-     *      `holderDelegatedTokenIds` and `directorSession` are appended so existing ERC-7201
-     *      slots stay stable.
+     *      `holderDelegatedTokenIds`, `directorSession`, `confirmOwner`, and `cancelOwner`
+     *      are appended so existing ERC-7201 slots stay stable.
      * @custom:storage-location erc7201:loreum.Chamber
      */
     struct ChamberStorage {
@@ -53,6 +53,10 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         mapping(address => EnumerableSet.UintSet) holderDelegatedTokenIds;
         /// @dev Session key for a contract-owned membership NFT. Stale if `owner` != current `ownerOf`.
         mapping(uint256 tokenId => DirectorSession) directorSession;
+        /// @dev `ownerOf` when the confirm bit was last written. Mismatch is ignored for quorum (PMN-H01 A).
+        mapping(uint256 nonce => mapping(uint256 tokenId => address)) confirmOwner;
+        /// @dev `ownerOf` when the cancel bit was last written. Mismatch is ignored for quorum (PMN-H01 A).
+        mapping(uint256 nonce => mapping(uint256 tokenId => address)) cancelOwner;
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Chamber")) - 1)) & ~bytes32(uint256(0xff))
@@ -75,7 +79,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
      *      (length word + data word) and incurs an SLOAD on every read. A bytes32 constant is
      *      inlined at compile time: zero runtime gas, zero storage slots.
      */
-    bytes32 public constant VERSION = "1.1.6";
+    bytes32 public constant VERSION = "1.1.7";
 
     /// @notice Function selector for upgradeImplementation(address,bytes)
     bytes4 private constant UPGRADE_SELECTOR = 0xc89311b6;
@@ -160,8 +164,8 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
             revert IChamber.InsufficientChamberBalance();
         }
 
-        _delegate(tokenId, amount);
-        _syncTrackedDelegations(msg.sender);
+        _delegate(tokenId, amount, $.nft);
+        _syncTrackedDelegations($.holderDelegation, $.holderDelegatedTokenIds, msg.sender);
 
         emit IChamber.DelegationUpdated(msg.sender, tokenId, $.holderDelegation[msg.sender][tokenId]);
     }
@@ -189,10 +193,10 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         // Only update board if node still exists (handles evicted nodes — Fix Finding 11)
         BoardTypes.BoardStorage storage $b = _getBoardStorage();
         if ($b.nodes[tokenId].tokenId == tokenId) {
-            _undelegate(tokenId, amount);
+            _undelegate(tokenId, amount, $.nft);
         }
 
-        _syncTrackedDelegations(msg.sender);
+        _syncTrackedDelegations($.holderDelegation, $.holderDelegatedTokenIds, msg.sender);
 
         emit IChamber.DelegationUpdated(msg.sender, tokenId, newDelegation);
     }
@@ -286,131 +290,8 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         returns (uint256[] memory tokenIds, uint256[] memory amounts)
     {
         if (holder == address(0)) revert IChamber.ZeroAddress();
-        return _collectDelegations(holder);
-    }
-
-    /**
-     * @dev Union of the holder set with leftover board/evicted amounts. When the set already
-     *      accounts for `totalHolderDelegations`, extras are skipped so insertion order is kept.
-     */
-    function _collectDelegations(address holder)
-        private
-        view
-        returns (uint256[] memory tokenIds, uint256[] memory amounts)
-    {
         ChamberStorage storage $c = _getChamberStorage();
-        EnumerableSet.UintSet storage tracked = $c.holderDelegatedTokenIds[holder];
-        uint256[] memory setIds = tracked.values();
-        uint256 setLen = setIds.length;
-
-        uint256 trackedTotal;
-        for (uint256 i = 0; i < setLen;) {
-            trackedTotal += $c.holderDelegation[holder][setIds[i]];
-            unchecked {
-                ++i;
-            }
-        }
-
-        if (trackedTotal == $c.totalHolderDelegations[holder]) {
-            tokenIds = setIds;
-            amounts = new uint256[](setLen);
-            for (uint256 i = 0; i < setLen;) {
-                amounts[i] = $c.holderDelegation[holder][setIds[i]];
-                unchecked {
-                    ++i;
-                }
-            }
-            return (tokenIds, amounts);
-        }
-
-        BoardTypes.BoardStorage storage $b = _getBoardStorage();
-        uint256 maxLen = setLen + uint256($b.size) + $b.evictedTokenIds.length();
-        uint256[] memory tmpIds = new uint256[](maxLen);
-        uint256[] memory tmpAmts = new uint256[](maxLen);
-        uint256 n;
-
-        for (uint256 i = 0; i < setLen;) {
-            uint256 id = setIds[i];
-            uint256 amount = $c.holderDelegation[holder][id];
-            if (amount > 0) {
-                tmpIds[n] = id;
-                tmpAmts[n] = amount;
-                unchecked {
-                    ++n;
-                }
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        uint256 tokenId = $b.head;
-        while (tokenId != 0) {
-            uint256 amount = $c.holderDelegation[holder][tokenId];
-            if (amount > 0 && !tracked.contains(tokenId)) {
-                tmpIds[n] = tokenId;
-                tmpAmts[n] = amount;
-                unchecked {
-                    ++n;
-                }
-            }
-            tokenId = uint256($b.nodes[tokenId].next);
-        }
-
-        uint256 evictedLen = $b.evictedTokenIds.length();
-        for (uint256 i = 0; i < evictedLen;) {
-            uint256 evictedId = $b.evictedTokenIds.at(i);
-            uint256 amount = $c.holderDelegation[holder][evictedId];
-            if (amount > 0 && !tracked.contains(evictedId) && $b.nodes[evictedId].tokenId != evictedId) {
-                tmpIds[n] = evictedId;
-                tmpAmts[n] = amount;
-                unchecked {
-                    ++n;
-                }
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        tokenIds = new uint256[](n);
-        amounts = new uint256[](n);
-        for (uint256 i = 0; i < n;) {
-            tokenIds[i] = tmpIds[i];
-            amounts[i] = tmpAmts[i];
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    /**
-     * @dev Lazy-backfill the holder set from leftover board/evicted amounts after an upgrade.
-     *      Does not require an off-chain holder list; only the caller is synced.
-     */
-    function _syncTrackedDelegations(address holder) private {
-        ChamberStorage storage $c = _getChamberStorage();
-        BoardTypes.BoardStorage storage $b = _getBoardStorage();
-        EnumerableSet.UintSet storage tracked = $c.holderDelegatedTokenIds[holder];
-
-        uint256 tokenId = $b.head;
-        while (tokenId != 0) {
-            if ($c.holderDelegation[holder][tokenId] > 0) {
-                tracked.add(tokenId);
-            }
-            tokenId = uint256($b.nodes[tokenId].next);
-        }
-
-        uint256 evictedLen = $b.evictedTokenIds.length();
-        for (uint256 i = 0; i < evictedLen;) {
-            uint256 evictedId = $b.evictedTokenIds.at(i);
-            if ($c.holderDelegation[holder][evictedId] > 0) {
-                tracked.add(evictedId);
-            }
-            unchecked {
-                ++i;
-            }
-        }
+        return _collectDelegations($c.holderDelegation, $c.totalHolderDelegations, $c.holderDelegatedTokenIds, holder);
     }
 
     /**
@@ -494,7 +375,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
      * @param tokenId The tokenId executing the update
      */
     function executeSeatsUpdate(uint256 tokenId) public override nonReentrant isDirector(tokenId) {
-        _executeSeatsUpdate(tokenId);
+        _executeSeatsUpdate(tokenId, _getChamberStorage().nft);
     }
 
     /**
@@ -630,7 +511,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
         if ($w.cancelled[transactionId]) revert IWallet.TransactionAlreadyCancelled();
         _notExpired(transactionId);
-        if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
+        if (_countLiveConfirmFlags(transactionId) < _requiredConfirmations(transactionId)) {
             revert IChamber.NotEnoughConfirmations();
         }
         _requireWalletExecuteAllowed(transaction.target, transactionId, data);
@@ -670,7 +551,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         _recordCancelVote(tokenId, transactionId);
         emit IChamber.TransactionCancelVoted(transactionId, msg.sender);
 
-        if (_countCurrentDirectorFlags($w.isCancelConfirmed, transactionId) >= getQuorum()) {
+        if (_countLiveCancelFlags(transactionId) >= getQuorum()) {
             _cancelTransaction(transactionId);
         }
     }
@@ -830,7 +711,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
 
             if (transaction.executed) revert IWallet.TransactionAlreadyExecuted();
             _notExpired(transactionId);
-            if (_countCurrentDirectorFlags($w.isConfirmed, transactionId) < _requiredConfirmations(transactionId)) {
+            if (_countLiveConfirmFlags(transactionId) < _requiredConfirmations(transactionId)) {
                 revert IChamber.NotEnoughConfirmations();
             }
             _requireWalletExecuteAllowed(transaction.target, transactionId, data[i]);
@@ -876,6 +757,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
     ///      that holds `quorum` distinct top-seat membership NFTs can submit, self-confirm, and
     ///      execute — a single-actor treasury. This is intended; confirmations are not capped per owner.
     modifier isDirector(uint256 tokenId) {
+        _syncSeatingControl(_getChamberStorage().nft, tokenId);
         _isDirector(tokenId);
         _;
     }
@@ -886,7 +768,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
     function _isDirector(uint256 tokenId) internal view {
         _requireTokenAuthorized(tokenId);
         if (!_isInTopSeats(tokenId)) revert IChamber.NotDirector();
-        if (!_isSeatingMature(tokenId)) revert IChamber.DirectorNotSeated();
+        if (!_isSeatingMature(_getChamberStorage().nft, tokenId)) revert IChamber.DirectorNotSeated();
     }
 
     /// @dev NFT owner of `tokenId`, or the live session key on a contract-owned NFT.
@@ -946,26 +828,42 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         return false;
     }
 
-    /**
-     * @notice Counts flags set by tokenIds that are still in the top-seat set.
-     * @dev Mirrors {_executeSeatsUpdate}: one O(seats) walk; evicted tokenIds are ignored.
-     */
-    function _countCurrentDirectorFlags(
-        mapping(uint256 nonce => mapping(uint256 tokenId => bool)) storage flags,
-        uint256 nonce
-    ) internal view returns (uint256 count) {
-        BoardTypes.BoardStorage storage $b = _getBoardStorage();
-        uint256 current = $b.head;
-        uint256 remaining = _getSeats();
-        unchecked {
-            while (current != 0 && remaining > 0) {
-                if (flags[nonce][current]) {
-                    ++count;
-                }
-                current = uint256($b.nodes[current].next);
-                --remaining;
-            }
-        }
+    function _countLiveConfirmFlags(uint256 nonce) internal view returns (uint256) {
+        ChamberStorage storage $ = _getChamberStorage();
+        return _countCurrentDirectorFlags($.nft, _getWalletStorage().isConfirmed, $.confirmOwner, nonce);
+    }
+
+    function _countLiveCancelFlags(uint256 nonce) internal view returns (uint256) {
+        ChamberStorage storage $ = _getChamberStorage();
+        return _countCurrentDirectorFlags($.nft, _getWalletStorage().isCancelConfirmed, $.cancelOwner, nonce);
+    }
+
+    function _submitTransactionWithMetadata(
+        uint256 tokenId,
+        address target,
+        uint256 value,
+        bytes memory data,
+        string memory metadataURI,
+        uint256 deadline
+    ) internal override {
+        super._submitTransactionWithMetadata(tokenId, target, value, data, metadataURI, deadline);
+        _getChamberStorage().confirmOwner[getNextTransactionId() - 1][tokenId] = _ownerOfOrZero(tokenId);
+    }
+
+    function _confirmTransaction(uint256 tokenId, uint256 nonce) internal override {
+        super._confirmTransaction(tokenId, nonce);
+        _getChamberStorage().confirmOwner[nonce][tokenId] = _ownerOfOrZero(tokenId);
+    }
+
+    function _recordCancelVote(uint256 tokenId, uint256 nonce) internal override {
+        super._recordCancelVote(tokenId, nonce);
+        _getChamberStorage().cancelOwner[nonce][tokenId] = _ownerOfOrZero(tokenId);
+    }
+
+    function _ownerOfOrZero(uint256 tokenId) internal view returns (address owner) {
+        try _getChamberStorage().nft.ownerOf(tokenId) returns (address o) {
+            owner = o;
+        } catch {}
     }
 
     /**
@@ -974,7 +872,13 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
      * @return seatedAtBlock Activation block, or zero if no checkpoint is stored
      */
     function getSeatedAt(uint256 tokenId) public view override returns (uint256 seatedAtBlock) {
-        return _getSeatedAt(tokenId);
+        return _effectiveSeatedAt(_getChamberStorage().nft, tokenId);
+    }
+
+    /// @inheritdoc IChamber
+    function syncSeating(uint256 tokenId) external override {
+        if (tokenId == 0) revert IChamber.ZeroTokenId();
+        _syncSeatingControl(_getChamberStorage().nft, tokenId);
     }
 
     /// PROXY UPGRADE FUNCTIONS ///

--- a/contracts/src/Wallet.sol
+++ b/contracts/src/Wallet.sol
@@ -106,7 +106,7 @@ abstract contract Wallet {
         bytes memory data,
         string memory metadataURI,
         uint256 deadline
-    ) internal {
+    ) internal virtual {
         WalletLib.submitTransactionWithMetadata(
             _getWalletStorage(),
             tokenId,
@@ -124,7 +124,7 @@ abstract contract Wallet {
         return 0;
     }
 
-    function _confirmTransaction(uint256 tokenId, uint256 nonce) internal {
+    function _confirmTransaction(uint256 tokenId, uint256 nonce) internal virtual {
         WalletLib.confirmTransaction(_getWalletStorage(), tokenId, nonce);
     }
 
@@ -132,7 +132,7 @@ abstract contract Wallet {
         WalletLib.revokeConfirmation(_getWalletStorage(), tokenId, nonce);
     }
 
-    function _recordCancelVote(uint256 tokenId, uint256 nonce) internal {
+    function _recordCancelVote(uint256 tokenId, uint256 nonce) internal virtual {
         WalletLib.recordCancelVote(_getWalletStorage(), tokenId, nonce);
     }
 

--- a/contracts/src/interfaces/IBoard.sol
+++ b/contracts/src/interfaces/IBoard.sol
@@ -60,7 +60,9 @@ interface IBoard {
      * @notice First block at which `tokenId` may exercise director rights.
      * @dev Zero means no checkpoint: a pre-upgrade incumbent already in the top set
      *      (treated as mature), or a token that is not seated. Newly entering tokenIds
-     *      are set to `block.number + SEATING_DELAY`.
+     *      are set to `block.number + SEATING_DELAY`. After `ownerOf` changes for an
+     *      already-seated token, the effective value moves to `block.number + SEATING_DELAY`
+     *      until the new controller's delay elapses (PMN-H01 Solution A).
      * @param tokenId The membership token ID
      * @return seatedAtBlock Activation block, or zero if no checkpoint is stored
      */

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -91,6 +91,14 @@ interface IChamber is IERC4626, IBoard, IWallet {
     function isTokenAuthorized(uint256 tokenId, address account) external view returns (bool);
 
     /**
+     * @notice Binds `seatedAt` to the current `ownerOf(tokenId)` (PMN-H01 Solution A).
+     * @dev Permissionless. Call after a seated NFT changes hands so the new controller's
+     *      `SEATING_DELAY` is stored. Director actions that revert do not persist this write.
+     * @param tokenId Membership token to rebind
+     */
+    function syncSeating(uint256 tokenId) external;
+
+    /**
      * @notice Updates the number of seats
      * @param tokenId The tokenId proposing the update
      * @param numOfSeats The new number of seats
@@ -236,6 +244,7 @@ interface IChamber is IERC4626, IBoard, IWallet {
     error NotDirector();
 
     /// @notice Thrown when a tokenId is in the live top seats but the seating delay has not elapsed
+    ///         (new top-seat entry, or `ownerOf` change since the last seating bind).
     error DirectorNotSeated();
 
     /// @notice Thrown when address is zero

--- a/contracts/src/libraries/BoardLib.sol
+++ b/contracts/src/libraries/BoardLib.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IBoard} from "src/interfaces/IBoard.sol";
 import {BoardTypes} from "src/types/BoardTypes.sol";
 import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
+import {IERC721} from "lib/openzeppelin-contracts/contracts/interfaces/IERC721.sol";
 
 /**
  * @title BoardLib
@@ -18,7 +19,13 @@ library BoardLib {
         return $.nodes[tokenId];
     }
 
-    function delegate(BoardTypes.BoardStorage storage $, uint256 tokenId, uint256 amount, address sender) external {
+    function delegate(
+        BoardTypes.BoardStorage storage $,
+        uint256 tokenId,
+        uint256 amount,
+        address sender,
+        IERC721 nft
+    ) external {
         uint256[] memory prevTop = topTokenIds($);
         BoardTypes.Node storage node = $.nodes[tokenId];
         if (node.tokenId == tokenId) {
@@ -28,10 +35,18 @@ library BoardLib {
             insert($, tokenId, amount);
         }
         refreshSeating($, prevTop);
+        syncTopSeatControl($, nft);
+        syncSeatingControl($, nft, tokenId);
         emit IBoard.Delegate(sender, tokenId, amount);
     }
 
-    function undelegate(BoardTypes.BoardStorage storage $, uint256 tokenId, uint256 amount, address sender) external {
+    function undelegate(
+        BoardTypes.BoardStorage storage $,
+        uint256 tokenId,
+        uint256 amount,
+        address sender,
+        IERC721 nft
+    ) external {
         uint256[] memory prevTop = topTokenIds($);
         BoardTypes.Node storage node = $.nodes[tokenId];
         if (node.tokenId != tokenId) revert IBoard.NodeDoesNotExist();
@@ -45,6 +60,8 @@ library BoardLib {
             reposition($, tokenId);
         }
         refreshSeating($, prevTop);
+        syncTopSeatControl($, nft);
+        syncSeatingControl($, nft, tokenId);
         emit IBoard.Undelegate(sender, tokenId, amount);
     }
 
@@ -187,7 +204,7 @@ library BoardLib {
         emit IBoard.SetSeats(tokenId, numOfSeats);
     }
 
-    function executeSeatsUpdate(BoardTypes.BoardStorage storage $, uint256 tokenId) external {
+    function executeSeatsUpdate(BoardTypes.BoardStorage storage $, uint256 tokenId, IERC721 nft) external {
         uint256[] memory prevTop = topTokenIds($);
         BoardTypes.SeatUpdate storage proposal = $.seatUpdate;
 
@@ -228,6 +245,7 @@ library BoardLib {
         $.seats = uint32(newSeats);
         delete $.seatUpdate;
         refreshSeating($, prevTop);
+        syncTopSeatControl($, nft);
         emit IBoard.ExecuteSetSeats(tokenId, newSeats);
     }
 
@@ -278,6 +296,119 @@ library BoardLib {
         uint256 seatedAt = $.seatedAt[tokenId];
         if (seatedAt == 0) return true;
         return block.number >= seatedAt;
+    }
+
+    /// @dev Stored checkpoint, or `block.number + SEATING_DELAY` when `ownerOf` != seated snap (PMN-H01 A).
+    function effectiveSeatedAt(BoardTypes.BoardStorage storage $, IERC721 nft, uint256 tokenId)
+        public
+        view
+        returns (uint256)
+    {
+        uint256 stored = $.seatedAt[tokenId];
+        address snap = $.seatedOwner[tokenId];
+        if (snap == address(0)) return stored;
+        address owner = tryOwnerOf(nft, tokenId);
+        if (owner != address(0) && owner != snap) {
+            return block.number + BoardTypes.SEATING_DELAY;
+        }
+        return stored;
+    }
+
+    function isSeatingMature(BoardTypes.BoardStorage storage $, IERC721 nft, uint256 tokenId)
+        external
+        view
+        returns (bool)
+    {
+        uint256 seatedAt = effectiveSeatedAt($, nft, tokenId);
+        if (seatedAt == 0) return true;
+        return block.number >= seatedAt;
+    }
+
+    /// @dev Bind or reset the seating clock when `ownerOf` changes. Call after board mutations and before director checks.
+    function syncSeatingControl(BoardTypes.BoardStorage storage $, IERC721 nft, uint256 tokenId) public {
+        address owner = tryOwnerOf(nft, tokenId);
+        if (owner == address(0)) {
+            delete $.seatedOwner[tokenId];
+            return;
+        }
+
+        address snap = $.seatedOwner[tokenId];
+        if (snap == address(0)) {
+            $.seatedOwner[tokenId] = owner;
+            return;
+        }
+        if (snap == owner) return;
+
+        $.seatedOwner[tokenId] = owner;
+        if (inTopSeats($, tokenId)) {
+            $.seatedAt[tokenId] = block.number + BoardTypes.SEATING_DELAY;
+        }
+    }
+
+    function syncTopSeatControl(BoardTypes.BoardStorage storage $, IERC721 nft) public {
+        uint256 current = $.head;
+        uint256 remaining = $.seats;
+        while (current != 0 && remaining != 0) {
+            syncSeatingControl($, nft, current);
+            current = uint256($.nodes[current].next);
+            unchecked {
+                --remaining;
+            }
+        }
+    }
+
+    function tryOwnerOf(IERC721 nft, uint256 tokenId) internal view returns (address owner) {
+        try nft.ownerOf(tokenId) returns (address o) {
+            return o;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function inTopSeats(BoardTypes.BoardStorage storage $, uint256 tokenId) internal view returns (bool) {
+        uint256 current = $.head;
+        uint256 remaining = $.seats;
+        while (current != 0 && remaining != 0) {
+            if (current == tokenId) return true;
+            current = uint256($.nodes[current].next);
+            unchecked {
+                --remaining;
+            }
+        }
+        return false;
+    }
+
+    /// @dev Live top-seat flags whose recorded controller still matches `ownerOf` (PMN-H01 A).
+    function countCurrentDirectorFlags(
+        BoardTypes.BoardStorage storage $,
+        IERC721 nft,
+        mapping(uint256 nonce => mapping(uint256 tokenId => bool)) storage flags,
+        mapping(uint256 nonce => mapping(uint256 tokenId => address)) storage flagOwners,
+        uint256 nonce
+    ) external view returns (uint256 count) {
+        uint256 current = $.head;
+        uint256 remaining = $.seats;
+        unchecked {
+            while (current != 0 && remaining > 0) {
+                if (flags[nonce][current] && flagBelongsToCurrentController(nft, flagOwners, nonce, current)) {
+                    ++count;
+                }
+                current = uint256($.nodes[current].next);
+                --remaining;
+            }
+        }
+    }
+
+    function flagBelongsToCurrentController(
+        IERC721 nft,
+        mapping(uint256 nonce => mapping(uint256 tokenId => address)) storage flagOwners,
+        uint256 nonce,
+        uint256 tokenId
+    ) internal view returns (bool) {
+        address recorded = flagOwners[nonce][tokenId];
+        if (recorded == address(0)) return true;
+        address owner = tryOwnerOf(nft, tokenId);
+        return owner != address(0) && owner == recorded;
     }
 
     function swapUp(BoardTypes.BoardStorage storage $, uint256 tokenId) internal {
@@ -366,6 +497,8 @@ library BoardLib {
 
         while (current != 0) {
             if (remaining != 0) {
+                // TokenId-scoped: a token already in the previous top keeps seatedAt.
+                // Control-transfer reset is Chamber/BoardLib.syncSeatingControl (PMN-H01 A).
                 if ($.seatedAt[current] == 0 && !wasInTop(current, prevTop)) {
                     $.seatedAt[current] = activationBlock;
                 }
@@ -398,5 +531,124 @@ library BoardLib {
             return;
         }
         revert IBoard.OnlyProposerCanCancel();
+    }
+
+    function collectDelegations(
+        BoardTypes.BoardStorage storage $b,
+        mapping(address => mapping(uint256 => uint256)) storage holderDelegation,
+        mapping(address => uint256) storage totalHolderDelegations,
+        mapping(address => EnumerableSet.UintSet) storage holderDelegatedTokenIds,
+        address holder
+    ) external view returns (uint256[] memory tokenIds, uint256[] memory amounts) {
+        EnumerableSet.UintSet storage tracked = holderDelegatedTokenIds[holder];
+        uint256[] memory setIds = tracked.values();
+        uint256 setLen = setIds.length;
+
+        uint256 trackedTotal;
+        for (uint256 i = 0; i < setLen;) {
+            trackedTotal += holderDelegation[holder][setIds[i]];
+            unchecked {
+                ++i;
+            }
+        }
+
+        if (trackedTotal == totalHolderDelegations[holder]) {
+            tokenIds = setIds;
+            amounts = new uint256[](setLen);
+            for (uint256 i = 0; i < setLen;) {
+                amounts[i] = holderDelegation[holder][setIds[i]];
+                unchecked {
+                    ++i;
+                }
+            }
+            return (tokenIds, amounts);
+        }
+
+        uint256 maxLen = setLen + uint256($b.size) + $b.evictedTokenIds.length();
+        uint256[] memory tmpIds = new uint256[](maxLen);
+        uint256[] memory tmpAmts = new uint256[](maxLen);
+        uint256 n;
+
+        for (uint256 i = 0; i < setLen;) {
+            uint256 id = setIds[i];
+            uint256 amount = holderDelegation[holder][id];
+            if (amount > 0) {
+                tmpIds[n] = id;
+                tmpAmts[n] = amount;
+                unchecked {
+                    ++n;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        uint256 tokenId = $b.head;
+        while (tokenId != 0) {
+            uint256 amount = holderDelegation[holder][tokenId];
+            if (amount > 0 && !tracked.contains(tokenId)) {
+                tmpIds[n] = tokenId;
+                tmpAmts[n] = amount;
+                unchecked {
+                    ++n;
+                }
+            }
+            tokenId = uint256($b.nodes[tokenId].next);
+        }
+
+        uint256 evictedLen = $b.evictedTokenIds.length();
+        for (uint256 i = 0; i < evictedLen;) {
+            uint256 evictedId = $b.evictedTokenIds.at(i);
+            uint256 amount = holderDelegation[holder][evictedId];
+            if (amount > 0 && !tracked.contains(evictedId) && $b.nodes[evictedId].tokenId != evictedId) {
+                tmpIds[n] = evictedId;
+                tmpAmts[n] = amount;
+                unchecked {
+                    ++n;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        tokenIds = new uint256[](n);
+        amounts = new uint256[](n);
+        for (uint256 i = 0; i < n;) {
+            tokenIds[i] = tmpIds[i];
+            amounts[i] = tmpAmts[i];
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function syncTrackedDelegations(
+        BoardTypes.BoardStorage storage $b,
+        mapping(address => mapping(uint256 => uint256)) storage holderDelegation,
+        mapping(address => EnumerableSet.UintSet) storage holderDelegatedTokenIds,
+        address holder
+    ) external {
+        EnumerableSet.UintSet storage tracked = holderDelegatedTokenIds[holder];
+
+        uint256 tokenId = $b.head;
+        while (tokenId != 0) {
+            if (holderDelegation[holder][tokenId] > 0) {
+                tracked.add(tokenId);
+            }
+            tokenId = uint256($b.nodes[tokenId].next);
+        }
+
+        uint256 evictedLen = $b.evictedTokenIds.length();
+        for (uint256 i = 0; i < evictedLen;) {
+            uint256 evictedId = $b.evictedTokenIds.at(i);
+            if (holderDelegation[holder][evictedId] > 0) {
+                tracked.add(evictedId);
+            }
+            unchecked {
+                ++i;
+            }
+        }
     }
 }

--- a/contracts/src/libraries/BoardLib.sol
+++ b/contracts/src/libraries/BoardLib.sol
@@ -358,6 +358,7 @@ library BoardLib {
     }
 
     function tryOwnerOf(IERC721 nft, uint256 tokenId) internal view returns (address owner) {
+        if (address(nft) == address(0) || address(nft).code.length == 0) return address(0);
         try nft.ownerOf(tokenId) returns (address o) {
             return o;
         } catch {

--- a/contracts/src/types/BoardTypes.sol
+++ b/contracts/src/types/BoardTypes.sol
@@ -50,6 +50,8 @@ library BoardTypes {
         uint32 seats;
         mapping(uint256 tokenId => uint256 seatedAtBlock) seatedAt;
         EnumerableSet.UintSet evictedTokenIds;
+        /// @dev `ownerOf` snapshotted when seating last bound. Appended so existing ERC-7201 slots stay stable.
+        mapping(uint256 tokenId => address) seatedOwner;
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("erc7201:loreum.Board")) - 1)) & ~bytes32(uint256(0xff))

--- a/contracts/test/findings/Finding_M03_UpgradeSafeDelegations.t.sol
+++ b/contracts/test/findings/Finding_M03_UpgradeSafeDelegations.t.sol
@@ -39,7 +39,7 @@ contract ChamberDelegationHarness is Chamber {
     }
 
     function exposedBoardDelegate(uint256 tokenId, uint256 amount) external {
-        _delegate(tokenId, amount);
+        _delegate(tokenId, amount, this.nft());
     }
 
     function exposedSetLength(address holder) external view returns (uint256) {

--- a/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
+++ b/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {IERC1271} from "lib/openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+
+/// @dev Contract NFT owner used to register a session key (same pattern as Chamber.t.sol).
+contract MockERC1271Wallet {
+    address public authorizedAddress;
+
+    constructor(address _authorized) {
+        authorizedAddress = _authorized;
+    }
+
+    function isValidSignature(bytes32, bytes memory signature) external view returns (bytes4) {
+        if (signature.length == 32) {
+            address decoded = abi.decode(signature, (address));
+            if (decoded == authorizedAddress) {
+                return IERC1271.isValidSignature.selector;
+            }
+        }
+        return bytes4(0xffffffff);
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok, bytes memory ret) = target.call(data);
+        if (!ok) {
+            assembly {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+}
+
+/**
+ * @title PMN-H01: seating delay must bind NFT control transfer (Solution A)
+ * @notice `SEATING_DELAY` applies when a tokenId newly enters the top-seat set (H-02)
+ *         and when `ownerOf` of an already-seated tokenId changes. Session keys stay
+ *         stale on transfer. Confirm/cancel bits recorded under the previous owner
+ *         do not count for quorum/execute.
+ */
+contract FindingPMNH01ControlTransferTest is Test {
+    Chamber public chamber;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public user3 = address(0x3);
+    address public userB = address(0xB);
+
+    uint256 public constant SEATS = 3;
+    uint256 public constant SEATING_DELAY = 1;
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), SEATS, "vERC20", "VLT", address(0x9));
+
+        _seat(user1, 1, 100 ether);
+        _seat(user2, 2, 100 ether);
+        vm.roll(block.number + SEATING_DELAY);
+    }
+
+    /// @notice H-02 regression: a tokenId that newly enters the top-seat set waits the delay.
+    function test_PMNH01_newTopSeatStillWaitsDelay() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        _seat(user3, 3, 50 ether);
+
+        assertEq(chamber.getSeatedAt(3), block.number + SEATING_DELAY, "new top-seat token activates next block");
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.submitTransaction(3, address(0x3), 0, "");
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.confirmTransaction(3, 0);
+
+        vm.prank(user3);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.executeTransaction(3, 0, "");
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        assertTrue(chamber.getConfirmation(2, 0), "existing seated director can still confirm");
+    }
+
+    /// @notice Keep current session-key behavior: transfer clears the previous operator.
+    function test_PMNH01_sessionKeyClearsOnTransfer() public {
+        address sessionKey = address(0xB0B);
+        MockERC1271Wallet wallet = new MockERC1271Wallet(address(0xDEAD));
+
+        nft.mintWithTokenId(address(wallet), 4);
+        token.mint(user1, 50 ether);
+        vm.startPrank(user1);
+        token.approve(address(chamber), 50 ether);
+        chamber.deposit(50 ether, user1);
+        chamber.delegate(4, 50 ether);
+        vm.stopPrank();
+        vm.roll(block.number + SEATING_DELAY);
+
+        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (4, sessionKey)));
+        assertEq(chamber.getDirectorOperator(4), sessionKey);
+        assertTrue(chamber.isTokenAuthorized(4, sessionKey));
+
+        MockERC1271Wallet newWallet = new MockERC1271Wallet(address(0xBEEF));
+        vm.prank(address(wallet));
+        nft.transferFrom(address(wallet), address(newWallet), 4);
+
+        assertEq(chamber.getDirectorOperator(4), address(0), "session key is stale after transfer");
+        assertFalse(chamber.isTokenAuthorized(4, sessionKey));
+        assertTrue(chamber.isTokenAuthorized(4, address(newWallet)), "only the new owner is authorized");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(4, address(0x3), 0, "");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.setDirectorOperator(4, address(0xFEE1));
+
+        address newKey = address(0xA11);
+        newWallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (4, newKey)));
+        assertEq(chamber.getDirectorOperator(4), newKey, "only the new owner can register a session key");
+    }
+
+    /// @notice Solution A: transferring a mature seated token resets the seating clock.
+    function test_PMNH01_controlTransfer_caseA_resetsClock() public {
+        uint256 seatedAtBefore = chamber.getSeatedAt(1);
+        assertTrue(block.number >= seatedAtBefore, "precondition: token 1 is mature");
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        vm.prank(user1);
+        nft.transferFrom(user1, userB, 1);
+
+        uint256 seatedAtAfter = chamber.getSeatedAt(1);
+        assertGt(seatedAtAfter, seatedAtBefore, "getSeatedAt moves forward on control transfer");
+        assertEq(seatedAtAfter, block.number + SEATING_DELAY);
+
+        chamber.syncSeating(1);
+        assertEq(chamber.getSeatedAt(1), block.number + SEATING_DELAY, "sync persists the new clock");
+
+        vm.prank(userB);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        vm.prank(userB);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.confirmTransaction(1, 0);
+
+        vm.prank(userB);
+        vm.expectRevert(IChamber.DirectorNotSeated.selector);
+        chamber.executeTransaction(1, 0, "");
+
+        vm.roll(block.number + SEATING_DELAY);
+        assertTrue(block.number >= chamber.getSeatedAt(1));
+
+        vm.prank(userB);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+        assertEq(chamber.getTransactionCount(), 2, "new controller can submit after the reset delay");
+    }
+
+    /// @notice Solution A: prior-owner confirm bits do not count for the new controller.
+    function test_PMNH01_controlTransfer_caseA_dropsPriorFlags() public {
+        deal(address(chamber), 1 ether);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x4), 1 ether, "");
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+        assertTrue(chamber.getConfirmation(1, 0), "A confirmed before transfer");
+        assertTrue(chamber.getConfirmation(2, 0));
+
+        vm.prank(user1);
+        nft.transferFrom(user1, userB, 1);
+
+        chamber.syncSeating(1);
+        vm.roll(block.number + SEATING_DELAY);
+        assertTrue(block.number >= chamber.getSeatedAt(1), "B has waited the new delay");
+
+        vm.prank(userB);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(1, 0, "");
+
+        vm.prank(user2);
+        vm.expectRevert(IChamber.NotEnoughConfirmations.selector);
+        chamber.executeTransaction(2, 0, "");
+
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertFalse(executed, "A's confirm must not satisfy quorum after control transfer");
+    }
+
+    function _seat(address user, uint256 tokenId, uint256 amount) internal {
+        try nft.ownerOf(tokenId) returns (address owner) {
+            if (owner != user) revert("token already minted to another owner");
+        } catch {
+            nft.mintWithTokenId(user, tokenId);
+        }
+
+        token.mint(user, amount);
+        vm.startPrank(user);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, amount);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/mock/MockBoard.sol
+++ b/contracts/test/mock/MockBoard.sol
@@ -3,14 +3,15 @@ pragma solidity ^0.8.24;
 
 import {Board} from "src/Board.sol";
 import {BoardTypes} from "src/types/BoardTypes.sol";
+import {IERC721} from "lib/openzeppelin-contracts/contracts/interfaces/IERC721.sol";
 
 contract MockBoard is Board {
     function exposed_delegate(uint256 tokenId, uint256 amount) public nonReentrant {
-        _delegate(tokenId, amount);
+        _delegate(tokenId, amount, IERC721(address(0)));
     }
 
     function exposed_undelegate(uint256 tokenId, uint256 amount) public nonReentrant {
-        _undelegate(tokenId, amount);
+        _undelegate(tokenId, amount, IERC721(address(0)));
     }
 
     function insert(uint256 tokenId, uint256 amount) public {
@@ -46,7 +47,7 @@ contract MockBoard is Board {
     }
 
     function executeSeatsUpdate(uint256 tokenId) public {
-        _executeSeatsUpdate(tokenId);
+        _executeSeatsUpdate(tokenId, IERC721(address(0)));
     }
 
     function cancelSeatUpdate(uint256 tokenId) public {

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1627,7 +1627,7 @@ contract ChamberTest is Test {
     }
 
     function test_Chamber_Version() public view {
-        assertEq(chamber.VERSION(), bytes32("1.1.6"));
+        assertEq(chamber.VERSION(), bytes32("1.1.7"));
     }
 
     // ─── acceptAdmin (no-op) ───────────────────────────────────────────

--- a/docs/protocol/director-authorization.md
+++ b/docs/protocol/director-authorization.md
@@ -30,7 +30,10 @@ All of the following must hold:
   it was `ownerOf(tokenId)` and `msg.sender` (the wallet must register the key
   itself).
 - The stored session is still bound to the **current** owner. Transferring the
-  NFT invalidates the key.
+  NFT invalidates the key. Transfer also resets that tokenId's seating clock
+  (`SEATING_DELAY`); call `syncSeating(tokenId)` so the new checkpoint is stored
+  (a reverting director call does not persist it). Confirm/cancel bits recorded
+  under the previous owner are ignored for quorum and execute (PMN-H01 Solution A).
 - `msg.sender == operator` and `operator != address(0)`.
 
 A session key may exercise the same **token-gated** Chamber actions as the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #208](https://github.com/loreum-org/chamber/issues/208) **Solution A** (default): bind `SEATING_DELAY` and confirm/cancel flags to an `ownerOf` / control change, not only to a tokenId entering the top-seat set.

**Not Solution B.** This PR does not accept “transferring a seated NFT transfers a live signer,” and it does not ship the Solution B acceptance test as green.

Closes #208.

## Behavior (Solution A)

- Snapshot `ownerOf` when seating last binds (`BoardStorage.seatedOwner`, appended so existing ERC-7201 slots stay stable).
- On control change, `getSeatedAt` moves to `block.number + SEATING_DELAY`. `syncSeating(tokenId)` (permissionless) persists that checkpoint — a reverting director call cannot, because the revert rolls back the write.
- Confirm/cancel bits recorded under the previous owner are ignored for quorum and execute.
- Session keys still go stale on transfer (`directorSession.owner != ownerOf`). Unchanged.

## Tests

`contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol` (DeployChamber + MockERC721, same style as `FindingH02_SeatingDelay.t.sol`):

1. `test_PMNH01_newTopSeatStillWaitsDelay` — H-02 regression (`DirectorNotSeated`)
2. `test_PMNH01_sessionKeyClearsOnTransfer` — keep current session-key clear-on-transfer
3. `test_PMNH01_controlTransfer_caseA_resetsClock` — new controller waits a new delay; `getSeatedAt` moves forward
4. `test_PMNH01_controlTransfer_caseA_dropsPriorFlags` — prior-owner confirm bits do not satisfy quorum

No Solution B acceptance test. No exploit PoCs.

## Version

`Chamber.VERSION` is **`1.1.7`** on this branch (main is `1.1.6`).

Open [#213](https://github.com/loreum-org/chamber/pull/213) (eviction hot path) also bumps Chamber to `1.1.7` and touches `Chamber.sol`. This PR is focused on PMN-H01. If #213 merges first, rebase and bump this to `1.1.8` (or the next free patch).

## Deploy / mainnet

This does **not** unblock mainnet deploy. Production still needs #209–#212 (or written product acceptance) in addition to this seating-control fix. Do not treat this PR as clearing the pre-mainnet gate.

## Test plan

- [x] `Finding_PMN_H01_ControlTransfer` + `FindingH02_SeatingDelay`
- [x] `forge test --no-match-test symbolic` — 409 passed, 1 skipped (mainnet fork)
- [x] CI (Forge Tests + Halmos, 3 checks green)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcd0db24-ceed-4d98-ac47-1be47dd07c0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcd0db24-ceed-4d98-ac47-1be47dd07c0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

