### PR TITLE
docs: sync whitepaper and app /docs to one Chamber truth table (#221)

### DIFF
--- a/app/src/docs/README.md
+++ b/app/src/docs/README.md
@@ -9,7 +9,7 @@ Open the docs in the app at **`/docs`**. Start here:
 1. **[What is a Chamber?](./introduction/overview.md)** — the idea in one sitting  
 2. **[Why not just a multisig?](./introduction/why-not-multisig.md)** — Chamber vs a classic treasury wallet  
 3. **[Founder exit via Chamber](./introduction/founder-exit.md)** — gradual operational handoff while retaining token stake  
-4. **[Chambers and Sub-Chambers](./introduction/chamber-and-sub-chambers.md)** — one treasury, many specialized groups  
+4. **[Chambers and Sub-Chambers](./introduction/chamber-and-sub-chambers.md)** — what Create deploys; nested chambers as a contemplated pattern  
 5. **[Getting started](./introduction/getting-started.md)** — connect a wallet and use the app  
 
 Then, as you need detail:
@@ -26,7 +26,7 @@ Then, as you need detail:
 | Topic | Page |
 |--------|------|
 | Design goals | **[Vision](./protocol/vision.md)** |
-| Contracts and Registry | **[Architecture](./protocol/architecture.md)** |
+| Contracts and Factory | **[Architecture](./protocol/architecture.md)** |
 | Limits and implementation notes | **[Design notes](./protocol/design-notes.md)** |
 | Who may act for a director NFT | **[Director authorization](./protocol/director-authorization.md)** |
 | Deploy with Foundry | **[Deployment](./guides/deployment.md)** |

--- a/app/src/docs/guides/app-routes.md
+++ b/app/src/docs/guides/app-routes.md
@@ -21,7 +21,7 @@ This is a **map of screens** in the Chamber web app. Pair it with **[Getting sta
 |--------|-----|
 | Deposit, withdraw, delegate | Anyone with tokens and shares |
 | Submit / confirm / execute proposals | **Directors** only (top-seat NFT controllers) |
-| Deploy a Chamber | Anyone on a network where Registry is configured |
+| Deploy a Chamber | Anyone on a network where Factory is configured |
 
 The app checks **onchain** whether your wallet controls a seated NFT before showing director controls.
 

--- a/app/src/docs/guides/deployment.md
+++ b/app/src/docs/guides/deployment.md
@@ -15,20 +15,46 @@ cd contracts
 forge install
 ```
 
-## What Registry deploy does
+## What Factory deploy does
 
-`script/Registry.s.sol` (via `DeployRegistry` helper):
+`script/Factory.s.sol` (`DeployFactory`):
+
+1. Deploy or reuse a **Chamber** implementation (`CHAMBER_IMPLEMENTATION`, or a new `Chamber`).  
+2. Deploy **Factory** with that implementation and an **owner** (`ADMIN`, or `msg.sender`).  
+3. Return the **Factory address** the app should use (`VITE_*_FACTORY` env vars).
+
+Each **`Factory.createChamber`** then:
+
+- Spawns a **Chamber proxy** initialized with your ERC‑20, ERC‑721, seats, name, symbol.  
+- Transfers **ProxyAdmin ownership** to the Chamber (upgrades go through director queue).  
+- Emits **`ChamberCreated`** for indexers / `getLogs`. It does **not** write parent/child tables.
+
+Example:
+
+```bash
+cd contracts
+forge script script/Factory.s.sol:DeployFactory \
+  --rpc-url "$RPC_URL" \
+  --broadcast \
+  --private-key "$PRIVATE_KEY"
+```
+
+Set **`ADMIN`** in the environment if the owner should not be `msg.sender`.
+
+## What leftover Registry deploy does
+
+`script/Registry.s.sol` (via `DeployRegistry` helper) is the **deprecated** factory + index. It is not what Create uses when Factory is configured.
 
 1. Deploy **Registry** implementation.  
 2. Deploy **Chamber** implementation.  
 3. Deploy **Registry proxy** with `initialize(chamberImplementation, admin)`.  
-4. Return the **Registry address** your app should use (`VITE_*_REGISTRY` env vars).
+4. Return the **Registry address** (`VITE_*_REGISTRY` env vars).
 
-Each **`createChamber`** then:
+Each leftover **`Registry.createChamber`** then:
 
 - Spawns a **Chamber proxy** initialized with your ERC‑20, ERC‑721, seats, name, symbol.  
-- Transfers **ProxyAdmin ownership** to the Chamber (upgrades go through director queue).  
-- Optionally links **parent/child** if the asset token is another registered Chamber.
+- Transfers **ProxyAdmin ownership** to the Chamber.  
+- Optionally links **parent/child** if the asset token is another registered Chamber. That nested wiring is leftover — not the live architecture.
 
 Example:
 
@@ -44,7 +70,7 @@ Set **`ADMIN`** in the environment if the admin should not be `msg.sender`.
 
 ## Standalone Chamber script (local only)
 
-`script/Chamber.s.sol` deploys a Chamber proxy **without** Registry semantics (ProxyAdmin may stay with a separate admin EOA). Prefer **Registry** for production documentation and the app.
+`script/Chamber.s.sol` deploys a Chamber proxy **without** Factory semantics (ProxyAdmin may stay with a separate admin EOA). Prefer **Factory** for production documentation and the app. Registry remains a leftover index + create path.
 
 ## Post-create board bootstrap (Anvil or Sepolia)
 

--- a/app/src/docs/introduction/chamber-and-sub-chambers.md
+++ b/app/src/docs/introduction/chamber-and-sub-chambers.md
@@ -1,53 +1,57 @@
 # Chambers and Sub-Chambers
 
-Large communities rarely want **one wallet** for everything. Chambers let you split responsibility while keeping rules **visible onchain**.
+Create deploys **one Chamber**: a Factory-built ERC‑4626 vault, a liquid-delegated ranked board of membership NFTs, and a quorum wallet. That object is **standalone**. It is not a child of another Chamber, and it does not open a parent↔child tree.
 
-## Root Chamber — the main group
+**Sub-Chambers** — nested treasuries with Registry parent↔child wiring — are a **contemplated pattern**, not what Create deploys today. The leftover Registry can still record those links for older deployments. They are not the live architecture.
 
-A **root Chamber** is the primary treasury for your project:
+## What you get from Create
 
-- Holds the **main vault** (the shared pot of tokens).  
-- Runs the **main board** (who leads by delegation).  
-- Uses the **main transaction queue** for big outbound actions.
+A new Chamber is one proxy address that combines:
 
-Think of it as the **city council** for your protocol or DAO — cross-cutting decisions and the flagship treasury live here.
+- **Vault** — the shared ERC‑4626 pot (deposit the configured token, receive shares).
+- **Board** — a ranked leaderboard of membership NFT token IDs; the top seats are directors.
+- **Quorum wallet** — directors submit, confirm, cancel, and execute outbound actions.
 
-## Sub-Chamber — a focused working group
+Think of it as the **city council** for your protocol or DAO — cross-cutting decisions and the flagship treasury live on this one object.
 
-A **Sub-Chamber** is another Chamber deployment with its **own vault, board, and queue**, usually tied to a **narrow mandate**:
+## Nested chambers (contemplated)
 
-| Example Sub-Chamber | Typical mandate |
-|---------------------|-----------------|
+Large communities sometimes want **more than one wallet**. A contemplated pattern would split responsibility across several Chamber deployments while keeping the same rules **visible onchain**:
+
+| Example mandate | Why a separate Chamber |
+|-----------------|------------------------|
 | **Treasury** | Grants, payroll, stablecoin policy |
 | **Operations** | Vendor payments, infrastructure |
 | **R&D** | Experiments, smaller budgets |
 
-Each Sub-Chamber still follows the same rules: **deposit → delegate → directors → quorum → execute**. Contributors can see **which pot** and **which directors** own which decisions.
+Each deployment would still follow **deposit → delegate → directors → quorum → execute**. That structure is **not** what Create wires today. You can deploy more than one Chamber if you want separate pots, but the app does not treat them as parent and child.
 
-## Why split instead of one multisig?
+## Why people talk about splitting
 
 With a single multisig, every committee shares **one signer list** and **one approval flow**. That encourages either:
 
-- **Too many signers** on one Safe (slow, cluttered), or  
+- **Too many signers** on one Safe (slow, cluttered), or
 - **Hidden committees** that “just use the founder keys” off the record.
 
-Sub-Chambers make **structure explicit**: different vaults, different seats, different queues — without pretending one informal council represents everyone.
+Multiple Chambers would make **structure explicit**: different vaults, different seats, different queues — without pretending one informal council represents everyone. Until that nested pattern ships, the live product is **one Factory-deployed Chamber per Create**.
 
-## How Sub-Chambers connect (conceptually)
+## Registry leftover (not the factory)
 
-The **Registry** can record **parent ↔ child** relationships when a new Chamber uses **another Chamber’s share token** as its underlying asset. That models organizations where a sub-group’s treasury is denominated in the parent Chamber’s shares.
+An earlier model used the **Registry** as a factory (`createChamber()`, `getAllChambers()`) and recorded **parent ↔ child** when a new Chamber used another Chamber’s share token as its asset.
 
-You do not need to master that wiring to use the app — it matters when you **design** how treasury flows between layers. Builders: **[Architecture](../protocol/architecture.md)**.
+Create today calls **Factory** `createChamber()`. The Factory does **not** index a world list, does **not** write parent/child tables, and does **not** expose `createAgent()` — that function does not exist on Factory or Registry.
 
-## Directors can be people, multisigs, or agents
+You do not need that leftover wiring to use the app. Builders: **[Architecture](../protocol/architecture.md)**.
 
-A **director** is whoever controls a **membership NFT token ID** in a **top seat**:
+## Directors: people, contract wallets, session keys
 
-- **Individual** — wallet holds the NFT.  
-- **Multisig** — the NFT sits in a Safe; directors act through **EIP‑1271** signatures the Chamber understands.  
-- **Agent (future-facing)** — automated systems that still must pass the same **submit / confirm / execute** gates.
+A **director** is whoever is authorized for a **membership NFT token ID** in a **top seat**:
 
-The point is **one rulebook** for every seat type, not a special admin lane.
+- **Individual** — wallet holds the NFT; `msg.sender` is the owner.
+- **Multisig / contract wallet** — the NFT sits in a Safe (or similar); the wallet calls Chamber as itself. Chamber does **not** use EIP‑1271 for Safe directors.
+- **Session key (live agent path)** — the contract owner registers an operator with `setDirectorOperator`. That operator may then call Chamber directly for that tokenId.
+
+See **[Director authorization](../protocol/director-authorization.md)**. The point is **one rulebook** for every seat type, not a special admin lane.
 
 ## Read next
 

--- a/app/src/docs/introduction/getting-started.md
+++ b/app/src/docs/introduction/getting-started.md
@@ -21,7 +21,7 @@ Skim **[What is a Chamber?](./overview.md)** first if the ideas are new.
 
 **Go to:** **Deploy** (`/deploy`)
 
-You are launching a new treasury + governance ruleset through the **Factory** (Registry if Factory is unset).
+You are launching a new treasury + governance ruleset through the **Factory**. That is the intended create path. Registry `createChamber` is leftover — the app falls back to it only if Factory is unset.
 
 | Field | What it means |
 |--------|----------------|
@@ -46,7 +46,7 @@ Happy path on **Sepolia** or **Anvil**:
    - **Your own collection:** receive or already hold a token. Chamber does not mint third-party NFTs and does not auto-seat strangers.
 3. **Deposit shares** — **Staking** tab. Delegation needs Chamber shares.
 4. **Delegate** to a token ID you hold — **Delegation** tab (the CTA prefills a token you own when it can).
-5. **Wait `SEATING_DELAY`** — **1 block**. Then the creator is a seated director and the queue can run.
+5. **Wait `SEATING_DELAY`** — **1 block**. Then the creator is a seated director and the queue can run. The same 1-block delay applies when `ownerOf` changes for an already-seated token.
 
 Quorum stays `1 + (seats * 51) / 100` (I-02). Seating delay stays 1 block (H-02).
 

--- a/app/src/docs/introduction/overview.md
+++ b/app/src/docs/introduction/overview.md
@@ -8,7 +8,7 @@ If you have used a **multisig wallet** (like Gnosis Safe), think of a Chamber as
 2. **Who actually leads day to day?** — the **top delegated membership NFTs** on a public leaderboard, not a founder’s spreadsheet.  
 3. **What exactly was approved to run?** — each outbound action is **proposed, confirmed to quorum, then executed** with calldata checked against a stored hash.
 
-Those rules live in **audited smart contracts**, not in a Discord poll or a hidden admin key.
+Those rules live in **smart contracts**, not in a Discord poll or a hidden admin key. There is no named public audit of Chamber as of this writing.
 
 ## What you can do with a Chamber
 
@@ -17,15 +17,17 @@ Those rules live in **audited smart contracts**, not in a Discord poll or a hidd
 | Pool assets | An **ERC‑4626 vault** — deposit the configured token, receive **share tokens** representing your slice. |
 | Influence leadership | **Delegation** — point your share weight at **membership NFT token IDs** you trust. |
 | See who leads | A **Board** — the highest-weight token IDs fill a fixed number of **seats** (directors). |
-| Move the treasury | A **transaction queue** — directors **submit**, **confirm**, and **execute** outbound calls only after **quorum**. |
+| Move the treasury | A **transaction queue** — directors **submit**, **confirm**, and **execute** outbound calls only after **quorum**. Directors can also **vote to cancel** a proposal at quorum. |
 
 ## Who is a “director”?
 
 A **director** is whoever controls a **membership NFT token ID** that currently sits in the **top seats** on the board. That can be:
 
-- A person with a normal wallet  
-- A **multisig contract** (still one seat on the board)  
-- Over time, **software agents** that follow the same onchain rules as everyone else  
+- A person with a normal wallet (`msg.sender` is the NFT owner)  
+- A **multisig or other contract wallet** that **holds** the NFT and calls Chamber as itself  
+- A **session key** the contract owner registered with `setDirectorOperator` (the live agent path)  
+
+Chamber **never** calls ERC-1271. See **[Director authorization](../protocol/director-authorization.md)**.
 
 There is no separate “admin bypass” for day-to-day spending — the queue is the path.
 
@@ -56,9 +58,11 @@ flowchart LR
 - **Board** — delegation ranks **NFT token IDs**; top **N** seats are directors.  
 - **Wallet** — directors queue **transactions** (send ETH, call contracts) with **quorum**.
 
-## Sub-Chambers (bigger organizations)
+Create deploys this object through the **Factory**. Registry create is leftover — not the product default.
 
-One **root Chamber** can anchor the main treasury. **Sub-Chambers** are additional Chambers with their own vault and directors for focused mandates (treasury committee, operations, experiments). See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
+## Nested chambers (contemplated)
+
+**Sub-Chambers** — nested treasuries with Registry parent↔child wiring — are a **contemplated pattern**, not live architecture. Create deploys one standalone Factory Chamber. See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
 
 ## Where to go next
 

--- a/app/src/docs/introduction/why-not-multisig.md
+++ b/app/src/docs/introduction/why-not-multisig.md
@@ -84,11 +84,11 @@ Consider a Chamber if:
 - **Many people** deposit into a shared treasury and need **transparent share accounting**.  
 - Leadership should **track delegation**, not a one-time signer CSV.  
 - You want **proposal → quorum → execution** entirely **onchain** for major outbound actions.  
-- You may grow into **Sub-Chambers** (treasury vs ops vs R&D) without one Safe holding everything.
+- You may later want **more than one Chamber** (treasury vs ops vs R&D). Nested Sub-Chambers with Registry parent/child links are a **contemplated pattern**, not a shipped product surface — you can still deploy separate standalone Chambers today.
 
 ## Can you use both?
 
-Yes. A **multisig contract** can **own a membership NFT** and act as one **director seat** on the board. Humans might still use Safe internally; Chamber sees one **seat** with one voting path on the queue. See **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
+Yes. A **multisig contract** can **own a membership NFT** and act as one **director seat** on the board. The Safe (or other contract wallet) calls Chamber as `msg.sender`, or registers a **session key** with `setDirectorOperator`. Chamber does **not** call EIP-1271. See **[Director authorization](../protocol/director-authorization.md)** and **[Chambers and Sub-Chambers](./chamber-and-sub-chambers.md)**.
 
 ## Read next
 

--- a/app/src/docs/protocol/architecture.md
+++ b/app/src/docs/protocol/architecture.md
@@ -9,12 +9,12 @@ A Chamber is **one proxy address** that combines:
 | **Vault** | ERC‑4626 in `Chamber` | Share accounting |
 | **Board** | `Board` mixin | Delegation leaderboard + seats |
 | **Wallet** | `Wallet` mixin | Proposal queue |
-| **Registry** | `Registry` | Deploy new Chamber proxies |
+| **Factory** | `Factory` | Deploy new Chamber proxies (intended create path) |
 
 ```mermaid
 flowchart TB
-  R[Registry]
-  R -->|createChamber| P[Chamber proxy]
+  F[Factory]
+  F -->|createChamber| P[Chamber proxy]
   P --> V[ERC-4626 vault]
   P --> B[Board storage]
   P --> W[Wallet storage]
@@ -24,25 +24,35 @@ flowchart TB
 
 - Initialized with **underlying ERC‑20**, **membership ERC‑721**, **seat count**, and share **name/symbol**.  
 - **Upgradeable** — logic changes go through **`upgradeImplementation`**, normally as a queued transaction.  
-- **`ProxyAdmin` ownership** is transferred to the Chamber itself after Registry deploy (so upgrades are also director-gated).
+- **`ProxyAdmin` ownership** is transferred to the Chamber itself after Factory deploy (so upgrades are also director-gated).
 
-## Registry
+## Factory (intended create path)
 
-- Stores the **implementation** used for new Chambers.  
-- **`createChamber`** deploys a new transparent proxy, initializes it, indexes it, and wires optional **parent/child** links.  
-- **`ADMIN_ROLE`** can update the implementation pointer for **future** deploys (does not auto-upgrade existing Chambers).
+- Thin, **non-proxy** deployer. Stores the **implementation** used for new Chambers.  
+- **`createChamber`** deploys a new transparent proxy, initializes it, transfers **ProxyAdmin** to the chamber, and emits **`ChamberCreated`**.  
+- Does **not** store a world directory, asset index, or parent/child tables. Discover chambers via logs or an indexer.  
+- **`setImplementation`** is owner-gated and applies to **future** deploys only (does not auto-upgrade existing Chambers).  
+- There is no **`createAgent()`** — that function does not exist.
+
+## Registry (leftover)
+
+- Historical factory + enumerable index. **`createChamber`** still deploys a proxy the same way and may record **parent/child** if the vault asset is another registered Chamber.  
+- That nested wiring is leftover — not the product default and not a shipped Sub-Chamber surface.  
+- **`ADMIN_ROLE`** can update the implementation pointer for **future** leftover creates.  
+- **`getAllChambers` / `getParentChamber` / `getChildChambers`** remain for already-indexed addresses only.
 
 ## Offchain app
 
-The web app (`app/`) reads Registry and Chamber state and sends transactions users sign in their wallet — deposit, delegate, queue actions.
+The web app (`app/`) prefers Factory when configured. It reads Chamber state and sends transactions users sign in their wallet — deposit, delegate, queue actions. Registry create is used only if Factory is unset.
 
-## Registry vs lab deploy scripts
+## Factory vs lab deploy scripts
 
-Production-shaped flows use **`Registry.createChamber`**. Standalone Chamber deploy scripts in `contracts/script/` may leave **ProxyAdmin** with a different owner — fine for local experiments; **not** the product default.
+Production-shaped flows use **`Factory.createChamber`**. Standalone Chamber deploy scripts in `contracts/script/` may leave **ProxyAdmin** with a different owner — fine for local experiments; **not** the product default. Prefer Factory over leftover Registry for new deploys.
 
 ## Read next
 
 - **[Governance](./governance.md)** — behavior in plain language  
-- **[Design notes](./design-notes.md)** — storage layout and limits  
+- **[Director authorization](./director-authorization.md)** — owner and session keys  
+- **[Design notes](./design-notes.md)** — storage layout and limits (`MAX_NODES` = 50)  
 - **[Deployment](../guides/deployment.md)** — Foundry commands  
 - **[API reference](../reference/api-reference.md)**  

--- a/app/src/docs/protocol/director-authorization.md
+++ b/app/src/docs/protocol/director-authorization.md
@@ -30,7 +30,9 @@ All of the following must hold:
   it was `ownerOf(tokenId)` and `msg.sender` (the wallet must register the key
   itself).
 - The stored session is still bound to the **current** owner. Transferring the
-  NFT invalidates the key.
+  NFT invalidates the key. A newly seated token (or a control transfer of an
+  already-seated token) waits `SEATING_DELAY` (1 block) before director
+  actions apply.
 - `msg.sender == operator` and `operator != address(0)`.
 
 A session key may exercise the same **token-gated** Chamber actions as the

--- a/app/src/docs/protocol/governance.md
+++ b/app/src/docs/protocol/governance.md
@@ -78,9 +78,9 @@ This stops a quick flash of votes from resizing the board without giving the com
 
 Directors can **vote to cancel** a queued transaction. If cancel votes reach **quorum**, the proposal is dead — it cannot be confirmed or executed afterward.
 
-## Sub-Chambers
+## Nested chambers (contemplated)
 
-If a Chamber’s vault asset is **another Chamber’s share token**, the Registry can record **parent / child** links. Each child still has its **own** board and queue. See **[Chambers and Sub-Chambers](../introduction/chamber-and-sub-chambers.md)**.
+**Sub-Chambers** with Registry **parent / child** links are a contemplated pattern, not live architecture. Leftover Registry `createChamber` can still record those links when the vault asset is another registered Chamber; Factory create does not. Each Chamber you deploy still has its **own** board and queue. See **[Chambers and Sub-Chambers](../introduction/chamber-and-sub-chambers.md)**.
 
 ## Read next
 

--- a/app/src/docs/protocol/vision.md
+++ b/app/src/docs/protocol/vision.md
@@ -38,7 +38,7 @@ flowchart TB
 - **Legibility** — an outsider can read seats, quorum, and queued proposals from chain data.  
 - **Liquidity of influence** — delegation changes without redeploying a Safe.  
 - **Enforced execution** — approvals are **confirmations on a nonce**, not a separate offchain vote.  
-- **Composable orgs** — Sub-Chambers and Registry indexing for teams that outgrow one pot.  
+- **Composable orgs (contemplated)** — nested Sub-Chambers and Registry parent/child indexing are design work, not a shipped product surface. Live create is one Factory Chamber per deploy.  
 
 Agents, analytics, and dashboards sit **around** these interfaces. They do not replace onchain quorum or vault accounting.
 
@@ -46,5 +46,5 @@ Agents, analytics, and dashboards sit **around** these interfaces. They do not r
 
 - **[What is a Chamber?](../introduction/overview.md)**  
 - **[Why not just a multisig?](../introduction/why-not-multisig.md)**  
-- **[Architecture](./architecture.md)** — contracts and Registry (builders)  
+- **[Architecture](./architecture.md)** — contracts and Factory (builders)  
 - **[Whitepaper](https://loreum.org/whitepaper)** — long-form narrative  

--- a/app/src/docs/reference/api-reference.md
+++ b/app/src/docs/reference/api-reference.md
@@ -2,11 +2,37 @@
 
 > **Audience:** developers integrating with or auditing contracts. New users should start with **[What is a Chamber?](../introduction/overview.md)** and **[Governance](../protocol/governance.md)**.
 
-Generated from interfaces in `contracts/src/` (`Registry`, `Chamber` / `IChamber`, plus **`IWallet`**, **`IBoard`**, **`IERC4626`**). Prefer NatSpec in-repo for exact wording.
+Generated from interfaces in `contracts/src/` (`Factory` / leftover `Registry`, `Chamber` / `IChamber`, plus **`IWallet`**, **`IBoard`**, **`IERC4626`**). Prefer NatSpec in-repo for exact wording.
 
-## `Registry`
+## `Factory` (intended create path)
 
-Upgradeable registry behind a **`TransparentUpgradeableProxy`** in the production deploy script pattern (`contracts/test/utils/DeployRegistry.sol`). `Registry.initialize` pins the **Chamber implementation** and grants **`DEFAULT_ADMIN_ROLE`** and **`ADMIN_ROLE`** to `admin`.
+Thin, non-proxy deployer (`contracts/src/Factory.sol`, `script/Factory.s.sol`). Constructor pins the **Chamber implementation** and **owner**. Does **not** store a world directory, asset index, or parent/child tables. There is no `createAgent()`.
+
+### Write
+
+| Function | Notes |
+|---------|--------|
+| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, transfers **ProxyAdmin ownership to `chamber`**, emits **`ChamberCreated`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). |
+| **`setImplementation(address newImplementation)`** | **Owner only**; updates pointer for **future** `createChamber` only. Same-address updates are a no-op. |
+
+### Read
+
+| Function | Returns |
+|---------|---------|
+| **`implementation()`** | Chamber logic for the next proxy. |
+| **`owner()`** | Ownable owner (`setImplementation`). |
+
+### Events / errors
+
+- **`ChamberCreated(chamber, asset, nft, seats, name, symbol, creator)`**  
+- **`ChamberImplementationUpdated(previous, newImplementation)`**  
+- **`ZeroAddress()`**, **`InvalidSeats()`**
+
+---
+
+## `Registry` (leftover)
+
+Deprecated world directory and leftover create path. Existing chambers stay valid. Prefer **Factory** for new deploys. Upgradeable registry behind a **`TransparentUpgradeableProxy`** (`contracts/test/utils/DeployRegistry.sol`). `Registry.initialize` pins the **Chamber implementation** and grants **`DEFAULT_ADMIN_ROLE`** and **`ADMIN_ROLE`** to `admin`.
 
 ### Write
 
@@ -14,7 +40,7 @@ Upgradeable registry behind a **`TransparentUpgradeableProxy`** in the productio
 |---------|--------|
 | **`initialize(address _implementation, address admin)`** | One-time; stores implementation address and `admin`; reverts `ZeroAddress`. |
 | **`setChamberImplementation(address newImplementation)`** | **`ADMIN_ROLE` only**; updates pointer for **future** `createChamber` only. |
-| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, registers listing, transfers **ProxyAdmin ownership to `chamber`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). If `isChamber(erc20Token)`, sets **parent** / **child** links. `erc20Token` must be a **standard ERC-20** (no factory allowlist; fee-on-transfer / rebasing unsupported). |
+| **`createChamber(address erc20Token, address erc721Token, uint256 seats, string name, string symbol) → address payable chamber`** | Leftover create. Deploys **Chamber `TransparentUpgradeableProxy`**, runs **`Chamber.initialize`**, registers listing, transfers **ProxyAdmin ownership to `chamber`**. Reverts on zero addresses, `implementation == 0`, or invalid **seats** (must be **1–20**). If `isChamber(erc20Token)`, sets leftover **parent** / **child** links (not a shipped Sub-Chamber surface). `erc20Token` must be a **standard ERC-20** (no factory allowlist; fee-on-transfer / rebasing unsupported). |
 
 ### Read
 
@@ -28,8 +54,8 @@ Upgradeable registry behind a **`TransparentUpgradeableProxy`** in the productio
 | **`isChamber(address)`** | Registry membership flag. |
 | **`getAssets()`** | Distinct underlying ERC‑20s observed. |
 | **`getChambersByAsset(address asset)`** | Chambers using that asset. |
-| **`getParentChamber(address chamber)`** | Sub-chamber → parent, or `address(0)`. |
-| **`getChildChambers(address chamber)`** | Parent → children. |
+| **`getParentChamber(address chamber)`** | Leftover parent link, or `address(0)`. |
+| **`getChildChambers(address chamber)`** | Leftover children list. |
 
 ### Events / errors
 
@@ -109,19 +135,19 @@ Read helpers: **`getTransactionCount`**, **`getNextTransactionId`**, **`getTrans
 |---------|------|
 | **`getProxyAdmin() → address`** | Reads ERC‑1967 admin slot (OZ **ProxyAdmin** contract). |
 | **`upgradeImplementation(address newImplementation, bytes calldata data)`** | Requires **`msg.sender == address(this)`** (e.g. via **`executeTransaction`**); **`ProxyAdmin.owner() == address(this)`**; invokes **`upgradeAndCall`**. |
-| **`acceptAdmin()`** | No-op; registry transfers ProxyAdmin ownership directly. |
+| **`acceptAdmin()`** | No-op; Factory (or leftover Registry) transfers ProxyAdmin ownership directly. |
 
 ---
 
 ## Events (high-signal)
 
-From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IRegistry`** (non-exhaustive):
+From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IFactory`** / leftover **`IRegistry`** (non-exhaustive):
 
 - **Delegation / board:** `DelegationUpdated`, `Delegate`, `Undelegate`, `SetSeats`, `SeatUpdateCancelled`, `ExecuteSetSeats`  
 - **Wallet:** `SubmitTransaction`, `ProposalMetadataSet`, `ConfirmTransaction`, `RevokeConfirmation`, `ExecuteTransaction`, `CancelTransaction`, `TransactionCancelled`  
 - **Chamber-level wallet wraps:** `TransactionSubmitted`, `TransactionConfirmed`, `TransactionExecuted`, `TransactionCancelVoted`  
 - **Treasury receive:** `Received`, `ReceivedERC721`  
-- **Registry:** `ChamberCreated`, `ChamberImplementationUpdated`  
+- **Factory / leftover Registry:** `ChamberCreated`, `ChamberImplementationUpdated`  
 
 ---
 
@@ -129,7 +155,7 @@ From **`IChamber`** / **`IBoard`** / **`IWallet`** / **`IRegistry`** (non-exhaus
 
 | Area | Examples |
 |------|-----------|
-| Registry | `ZeroAddress`, `InvalidSeats` |
+| Factory / leftover Registry | `ZeroAddress`, `InvalidSeats` |
 | Chamber / IChamber | `InsufficientChamberBalance`, `ExceedsDelegatedAmount`, `AssetAmountMismatch`, `NotDirector`, `NotEnoughConfirmations`, `InvalidTransaction`, `NotAuthorized`, seat / token errors |
 | Board | `CircuitBreakerActive`, `TokenIdTooLarge`, `MaxNodesReached`, seat proposal / timelock errors |
 | Wallet / IWallet | `TransactionDoesNotExist`, `TransactionAlreadyExecuted`, `TransactionAlreadyConfirmed`, `TransactionNotConfirmed`, `TransactionAlreadyCancelled`, `DataHashMismatch`, `TransactionFailed`, `InvalidTarget` |
@@ -140,8 +166,8 @@ See interface files for full enumerations.
 
 ## Minimal integration checklist
 
-1. Discover **`Registry`** address for your chain.  
-2. Enumerate chambers via **`getChambers`** or subgraph.  
+1. Discover **`Factory`** address for your chain.  
+2. Enumerate chambers via **`ChamberCreated`** logs, indexer, or leftover Registry **`getChambers`**.  
 3. For a Chamber: read **`asset()`**, **`nft()`**, **`getSeats()`, `getQuorum()`, `getTop`/`getDirectors`**.  
 4. For wallets / indexers: subscribe to **`SubmitTransaction`** to persist **`bytes data`** alongside **`nonce`**.  
 5. For execution UI: reconstruct calldata matching stored hash before calling **`executeTransaction`**.  

--- a/app/src/docs/reference/sequence-diagrams.md
+++ b/app/src/docs/reference/sequence-diagrams.md
@@ -234,31 +234,30 @@ flowchart LR
 
 ## Chamber Deployment
 
-This diagram shows how a new Chamber is deployed through the Registry.
+This diagram shows how Create deploys a new Chamber through the **Factory**. The leftover Registry can still `createChamber` and write parent/child links; that is not the live path.
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant Registry
+    participant Factory
     participant ChamberImpl
     participant ChamberProxy
 
-    Note over User,ChamberProxy: Chamber deployment via Registry
+    Note over User,ChamberProxy: Chamber deployment via Factory
 
-    User->>Registry: createChamber(erc20Token, erc721Token, seats, name, symbol)
+    User->>Factory: createChamber(erc20Token, erc721Token, seats, name, symbol)
 
-    Registry->>Registry: Validate tokens non-zero, seats in 1..20, implementation set
+    Factory->>Factory: Validate tokens non-zero, seats in 1..20, implementation set
 
-    Registry->>ChamberProxy: new TransparentUpgradeableProxy(implementation, address(this), initData)
+    Factory->>ChamberProxy: new TransparentUpgradeableProxy(implementation, address(this), initData)
     Note over ChamberProxy: initData encodes Chamber.initialize(erc20, erc721, seats, name, symbol)
 
     ChamberProxy->>ChamberImpl: delegatecall initialize(...)
     ChamberImpl-->>ChamberProxy: ERC-4626 + Board + Wallet storage ready
 
-    Registry->>Registry: index chamber, parent/child if asset is chamber
-    Registry->>Registry: transfer Chamber ProxyAdmin ownership to address(chamber)
+    Factory->>Factory: transfer Chamber ProxyAdmin ownership to address(chamber)
 
-    Registry-->>User: ChamberCreated + return chamber proxy
+    Factory-->>User: ChamberCreated + return chamber proxy
 ```
 
 ---

--- a/app/src/docs/security/security-review.md
+++ b/app/src/docs/security/security-review.md
@@ -1,8 +1,8 @@
 # Security review (methodology)
 
-> **Audience:** auditors and developers running structured reviews. Product users should rely on published audit reports and **[What is a Chamber?](../introduction/overview.md)** for trust assumptions.
+> **Audience:** auditors and developers running structured reviews. Product users should read **[What is a Chamber?](../introduction/overview.md)** for trust assumptions. There is no named public audit of Chamber as of this writing.
 
-Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Chamber`, `Board`, `Wallet`, `Registry`). This page summarizes how to review it systematically.
+Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Factory`, `Chamber`, `Board`, `Wallet`, leftover `Registry`). This page summarizes how to review it systematically.
 
 ## What to protect
 
@@ -12,9 +12,9 @@ Chamber’s **trust surface** is the Solidity in **`contracts/src/`** (`Chamber`
 
 ## Review phases
 
-1. **Architecture** — inheritance, storage slots, Registry → Chamber deploy path.  
+1. **Architecture** — inheritance, storage slots, Factory → Chamber deploy path.  
 2. **Per-function analysis** — access control, reentrancy, arithmetic, external calls.  
-3. **Cross-contract** — delegation vs transfers, stale confirmations, ERC‑1271 director auth.  
+3. **Cross-contract** — delegation vs transfers, stale confirmations, owner / session-key director auth.  
 4. **Tooling** — Slither, Foundry tests/fuzz, manual threat modeling.
 
 ## Common question areas

--- a/landing/src/Whitepaper.tsx
+++ b/landing/src/Whitepaper.tsx
@@ -56,7 +56,7 @@ function Whitepaper() {
           <div className="mb-12 text-center">
             <h1 className="text-5xl md:text-6xl font-display mb-4">Chamber Protocol</h1>
             <p className="text-xl text-gray-400 font-light">A Technical Framework for Agentic Organizational Governance</p>
-            <p className="text-sm text-gray-500 mt-4">Version 1.2.0 | April 2026</p>
+            <p className="text-sm text-gray-500 mt-4">Version 1.3.0 | September 2026</p>
           </div>
         </FadeIn>
 
@@ -86,8 +86,11 @@ function Whitepaper() {
               </p>
               <p className="text-gray-300 leading-relaxed">
                 Technical contributions include: (1) NFT-based directorship (live auth is the
-                membership NFT owner as <code className="text-space-accent">msg.sender</code>;
-                EIP-1271 contract-agent directors remain a design path, not shipped),
+                membership NFT owner as <code className="text-space-accent">msg.sender</code>,
+                or a session key registered with{" "}
+                <code className="text-space-accent">setDirectorOperator</code> for
+                contract-owned NFTs; Chamber never calls ERC-1271 — EIP-1271 contract-agent
+                directors remain research, not shipped),
                 (2) liquid delegation without governance lockups, subject to solvency checks on delegated balances, 
                 (3) circuit-safe linked list repositioning for the governance leaderboard, and (4) self-sovereign
                 upgrade paths executed only through quorum-approved transactions. We provide specifications, security
@@ -137,9 +140,11 @@ function Whitepaper() {
                 Chamber&apos;s published solidity; <strong className="text-space-accent font-normal">dispersed authority</strong>{" "}
                 (cf. § 104(c)(2)(E–G)) — liquid delegation to a ranked board plus majority quorum on execution resists
                 single-actor capture when parameters and seat counts are tuned to policy; <strong className="text-space-accent font-normal">
-                agent parity</strong> — a designed EIP-1271 path would let smart-contract directors participate under the
-                same validation rules as EOAs. That path is not shipped; live director auth requires
-                {" "}<code className="text-space-accent">msg.sender</code> to be the membership NFT owner.
+                agent parity</strong> — contract-owned membership NFTs register a session key
+                via <code className="text-space-accent">setDirectorOperator</code> so an agent
+                can call Chamber as <code className="text-space-accent">msg.sender</code>{" "}
+                without Chamber consulting ERC-1271. A designed EIP-1271 path remains
+                research; it is not shipped.
               </p>
 
               <h3 className="text-2xl font-display mb-4 mt-10 text-white">1.2 Chamber as protocol response</h3>
@@ -172,18 +177,26 @@ function Whitepaper() {
               
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">2.1 System Components</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                The Chamber Protocol consists of four primary contracts:
+                The shipped object is a Factory-deployed ERC-4626 vault, a liquid-delegated
+                ranked board of membership NFTs, and a quorum wallet. Create deploys that
+                standalone Chamber. Nested Sub-Chambers and Registry parent↔child wiring
+                are a contemplated pattern — not the live architecture. The primary
+                contracts are Factory, Chamber, Board, and Wallet.
               </p>
               
               <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
-                <h4 className="text-xl font-display mb-3 text-space-accent">Registry</h4>
+                <h4 className="text-xl font-display mb-3 text-space-accent">Factory</h4>
                 <p className="text-gray-300 leading-relaxed mb-3">
-                  A factory contract that deploys Chamber instances using the TransparentUpgradeableProxy pattern. 
-                  The Registry maintains an index of all deployed chambers and their associated assets. Upon deployment, 
-                  each Chamber receives ownership of its ProxyAdmin, enabling self-governed upgrades.
+                  A thin, non-proxy deployer that creates Chamber instances using the
+                  TransparentUpgradeableProxy pattern. Upon deployment, each Chamber
+                  receives ownership of its ProxyAdmin, enabling self-governed upgrades.
+                  The Factory does not store a world directory, asset index, or parent/child
+                  tables. Discover chambers via <code className="text-space-accent">ChamberCreated</code> logs.
+                  There is no <code className="text-space-accent">createAgent()</code> API —
+                  that function does not exist on Factory or Registry.
                 </p>
                 <p className="text-gray-400 text-sm font-mono">
-                  Key Functions: createChamber(), createAgent(), getAllChambers()
+                  Key Functions: createChamber(), setImplementation(), implementation()
                 </p>
               </div>
 
@@ -220,7 +233,23 @@ function Whitepaper() {
                   (CEI) pattern and supports batch operations for gas efficiency.
                 </p>
                 <p className="text-gray-400 text-sm font-mono">
-                  Key Functions: _submitTransaction(), _confirmTransaction(), _executeTransaction()
+                  Key Functions: _submitTransaction(), _confirmTransaction(), _cancelTransaction(), _executeTransaction()
+                </p>
+              </div>
+
+              <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
+                <h4 className="text-xl font-display mb-3 text-space-accent">Registry (leftover)</h4>
+                <p className="text-gray-300 leading-relaxed mb-3">
+                  Historical factory and enumerable index. An earlier create path used
+                  Registry <code className="text-space-accent">createChamber()</code> and
+                  {" "}<code className="text-space-accent">getAllChambers()</code>, and could
+                  record parent↔child links when a Chamber&apos;s asset was another Chamber&apos;s
+                  share token. Create today uses Factory. Registry remains in-repo as leftover
+                  / historical — not the product default.{" "}
+                  <code className="text-space-accent">createAgent()</code> was never a shipped API.
+                </p>
+                <p className="text-gray-400 text-sm font-mono">
+                  Leftover: createChamber(), getAllChambers(), getParentChamber(), getChildChambers()
                 </p>
               </div>
             </section>
@@ -267,6 +296,15 @@ function Whitepaper() {
                 burned or transferred, the function returns <code className="text-space-accent">address(0)</code> 
                 for that position.
               </p>
+              <p className="text-gray-300 leading-relaxed mb-4">
+                A newly seated tokenId cannot exercise director rights until{" "}
+                <code className="text-space-accent">SEATING_DELAY</code> elapses. Live value
+                is <strong className="text-white font-normal">1 block</strong>. After{" "}
+                <code className="text-space-accent">ownerOf</code> changes for an already-seated
+                token, the effective clock moves to{" "}
+                <code className="text-space-accent">block.number + SEATING_DELAY</code> until
+                the new controller&apos;s delay elapses.
+              </p>
 
               <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
                 <p className="text-gray-300 leading-relaxed mb-2">
@@ -311,23 +349,99 @@ function Whitepaper() {
           <FadeIn delay={0.5}>
             <section className="mb-16">
               <h2 className="text-3xl font-display mb-6 text-space-accent">4. Agent Integration</h2>
-              <p className="text-gray-400 leading-relaxed mb-4 text-sm md:text-base">
-                This section is a design specification for contract-agent directors, not the live
-                authorization path. Shipped Chamber requires{" "}
-                <code className="text-space-accent">msg.sender</code> to be the membership NFT
-                owner. EIP-1271 agent directors are research; they are not a Chamber capability
-                until that path ships.
+              <p className="text-gray-300 leading-relaxed mb-4">
+                Live director authorization is owner-as-
+                <code className="text-space-accent">msg.sender</code>, or a session key
+                registered with <code className="text-space-accent">setDirectorOperator</code>{" "}
+                for <strong className="text-white font-normal">contract-owned</strong> membership
+                NFTs. Chamber <strong className="text-white font-normal">never</strong> calls
+                ERC-1271 / <code className="text-space-accent">isValidSignature</code>. EIP-1271
+                agent directors stay research (§4.3); they are not a shipped capability.
               </p>
               
-              <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.1 EIP-1271 Signature Validation</h3>
+              <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.1 Live authorization: owner and session keys</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                The design would enable smart contract agents to act as directors through EIP-1271
-                signature validation. When a director function is called, the specified check is:
+                For a seated <code className="text-space-accent">tokenId</code>, Chamber
+                authorizes <code className="text-space-accent">msg.sender</code> if and only if
+                one of the following holds:
+              </p>
+              
+              <ol className="list-decimal list-inside text-gray-300 space-y-2 mb-4 ml-4">
+                <li>
+                  <code className="text-space-accent">msg.sender == nft.ownerOf(tokenId)</code>{" "}
+                  — the NFT owner (EOA or contract wallet) acts as itself.
+                </li>
+                <li>
+                  The owner is a contract, previously called{" "}
+                  <code className="text-space-accent">setDirectorOperator(tokenId, operator)</code>{" "}
+                  while it was <code className="text-space-accent">ownerOf</code> and{" "}
+                  <code className="text-space-accent">msg.sender</code>, the session is still
+                  bound to the current owner, and{" "}
+                  <code className="text-space-accent">msg.sender == operator</code>.
+                </li>
+              </ol>
+
+              <p className="text-gray-300 leading-relaxed mb-4">
+                A Safe, ERC-4337 account, or other contract wallet that holds the membership NFT
+                calls Chamber as itself (for example Safe{" "}
+                <code className="text-space-accent">execTransaction</code>). To let an agent
+                call Chamber directly, that owner wallet registers the operator. Transferring
+                the NFT invalidates the key. EOA-owned NFTs cannot register a session key.
+                Only the current owner may set or clear the key.
+              </p>
+
+              <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.2 Agent delegation patterns</h3>
+              <p className="text-gray-300 leading-relaxed mb-4">
+                Agents participate in governance through these live patterns:
+              </p>
+              
+              <div className="space-y-4 mb-6">
+                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
+                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 1: Direct ownership</h4>
+                  <p className="text-gray-300 text-sm">
+                    An agent contract owns an NFT tokenId and calls Chamber as{" "}
+                    <code className="text-space-accent">msg.sender</code>. The token must
+                    accumulate enough delegations to enter the top N seats, then wait{" "}
+                    <code className="text-space-accent">SEATING_DELAY</code> (1 block).
+                  </p>
+                </div>
+                
+                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
+                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 2: Session key (live agent path)</h4>
+                  <p className="text-gray-300 text-sm">
+                    A contract wallet holds the NFT and calls{" "}
+                    <code className="text-space-accent">setDirectorOperator(tokenId, operator)</code>.
+                    The operator may then call Chamber directly for that tokenId. This is an
+                    explicit Chamber allowlist — not EIP-1271, not Safe{" "}
+                    <code className="text-space-accent">isModuleEnabled</code>, and not EntryPoint
+                    validation.
+                  </p>
+                </div>
+                
+                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
+                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 3: Voting power delegation</h4>
+                  <p className="text-gray-300 text-sm">
+                    Agents delegate their Chamber tokens to specific tokenIds, influencing director selection without 
+                    holding NFTs themselves. This enables liquid democracy where agents can redelegate based on 
+                    performance or policy alignment.
+                  </p>
+                </div>
+              </div>
+
+              <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.3 EIP-1271 (research — not shipped)</h3>
+              <p className="text-gray-400 leading-relaxed mb-4 text-sm md:text-base">
+                The following is a design specification only. Chamber does not call{" "}
+                <code className="text-space-accent">isValidSignature</code>. Safe-owned NFTs
+                do not use this path.
+              </p>
+              <p className="text-gray-300 leading-relaxed mb-4">
+                A researched alternative would enable smart contract agents to act as directors
+                through EIP-1271 signature validation. The specified check would be:
               </p>
               
               <ol className="list-decimal list-inside text-gray-300 space-y-2 mb-4 ml-4">
                 <li>If <code className="text-space-accent">msg.sender</code> directly owns the tokenId</li>
-                <li>If not, and the owner is a contract, constructs a "DirectorAuth" hash</li>
+                <li>If not, and the owner is a contract, constructs a &quot;DirectorAuth&quot; hash</li>
                 <li>Calls <code className="text-space-accent">IERC1271(owner).isValidSignature()</code></li>
                 <li>If valid, grants directorship to the agent</li>
               </ol>
@@ -345,42 +459,10 @@ if (IERC1271(owner).isValidSignature(hash, abi.encode(msg.sender))
               </div>
 
               <p className="text-gray-300 leading-relaxed mb-4">
-                This mechanism allows an Agent contract to hold an NFT and authorize other contracts (or EOAs) 
-                to act on its behalf, enabling complex delegation patterns and multi-signature agent configurations.
+                That scheme was removed (M-01): a promiscuous 1271 contract that returned the
+                magic for arbitrary data would authorize every caller. Session keys never
+                consult the owner&apos;s signature interface.
               </p>
-
-              <h3 className="text-2xl font-display mb-4 mt-8 text-white">4.2 Agent Delegation Patterns</h3>
-              <p className="text-gray-300 leading-relaxed mb-4">
-                Agents can participate in governance through multiple patterns:
-              </p>
-              
-              <div className="space-y-4 mb-6">
-                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
-                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 1: Direct Ownership</h4>
-                  <p className="text-gray-300 text-sm">
-                    An agent contract owns an NFT tokenId and directly calls Chamber functions. The agent must 
-                    accumulate enough delegations to enter the top N seats.
-                  </p>
-                </div>
-                
-                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
-                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 2: Delegated Authority</h4>
-                  <p className="text-gray-300 text-sm">
-                    Design only: an agent contract would hold an NFT and authorize another contract
-                    (via EIP-1271) to act as director. This would separate identity from the
-                    authorized caller. It is not the live path.
-                  </p>
-                </div>
-                
-                <div className="bg-space-800/40 border border-white/10 rounded-lg p-4">
-                  <h4 className="text-lg font-display mb-2 text-space-accent">Pattern 3: Voting Power Delegation</h4>
-                  <p className="text-gray-300 text-sm">
-                    Agents delegate their Chamber tokens to specific tokenIds, influencing director selection without 
-                    holding NFTs themselves. This enables liquid democracy where agents can redelegate based on 
-                    performance or policy alignment.
-                  </p>
-                </div>
-              </div>
             </section>
           </FadeIn>
 
@@ -450,13 +532,14 @@ if (IERC1271(owner).isValidSignature(hash, abi.encode(msg.sender))
                 <li>Balance checks before delegations and transfers</li>
                 <li>NFT existence verification via <code className="text-space-accent">ownerOf()</code> try-catch</li>
                 <li>Seat count bounds (1-20 seats maximum)</li>
-                <li>Node count limits (100 nodes maximum)</li>
+                <li>Node count limits (50 nodes maximum; <code className="text-space-accent">MAX_NODES</code>)</li>
               </ul>
 
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">5.4 Upgrade Safety</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                Chambers use the TransparentUpgradeableProxy pattern with self-ownership. The Registry transfers 
-                ProxyAdmin ownership to each Chamber upon deployment, enabling governance-controlled upgrades. 
+                Chambers use the TransparentUpgradeableProxy pattern with self-ownership. Factory
+                (and leftover Registry create) transfers ProxyAdmin ownership to each Chamber upon
+                deployment, enabling governance-controlled upgrades.
                 Upgrades must be executed through the transaction system, requiring quorum approval.
               </p>
               <p className="text-gray-300 leading-relaxed mb-4">
@@ -482,8 +565,8 @@ if (IERC1271(owner).isValidSignature(hash, abi.encode(msg.sender))
                 <li><strong>Top N retrieval:</strong> O(n) where n = min(N, list size)</li>
               </ul>
               <p className="text-gray-300 leading-relaxed mb-4">
-                The MAX_NODES constant (100) limits worst-case gas costs, making the system predictable for 
-                typical governance scenarios.
+                The <code className="text-space-accent">MAX_NODES</code> constant (50) limits
+                worst-case gas costs, making the system predictable for typical governance scenarios.
               </p>
 
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">6.2 Batch Operations</h3>
@@ -537,7 +620,7 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
 
               <h3 className="text-2xl font-display mb-4 mt-8 text-white">7.2 Transaction Lifecycle</h3>
               <p className="text-gray-300 leading-relaxed mb-4">
-                Transactions follow a three-phase lifecycle:
+                Transactions follow a submit / confirm / cancel-or-execute lifecycle:
               </p>
               <div className="bg-space-800/40 border border-white/10 rounded-xl p-6 mb-6 backdrop-blur-md">
                 <ol className="list-decimal list-inside text-gray-300 space-y-3">
@@ -550,6 +633,11 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
                     <strong className="text-space-accent">Confirmation:</strong> Other directors call 
                     <code className="text-space-accent"> confirmTransaction()</code> until quorum is reached. 
                     Directors can revoke confirmations via <code className="text-space-accent">revokeConfirmation()</code>.
+                  </li>
+                  <li>
+                    <strong className="text-space-accent">Cancel:</strong> Directors can vote to cancel via{" "}
+                    <code className="text-space-accent">cancelTransaction()</code>. When cancel votes
+                    reach quorum, the proposal is dead — it cannot be confirmed or executed afterward.
                   </li>
                   <li>
                     <strong className="text-space-accent">Execution:</strong> Once quorum is reached, any director 
@@ -626,7 +714,7 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
               <ul className="list-disc list-inside text-gray-300 space-y-2 mb-4 ml-4">
                 <li><strong>Single Asset:</strong> Each Chamber manages one ERC20 token. Multi-asset support would require architectural changes.</li>
                 <li><strong>No Scheduling:</strong> Transactions execute immediately when quorum is reached. Time-based execution would require additional infrastructure.</li>
-                <li><strong>No Cancellation:</strong> Transactions cannot be cancelled once submitted, only revoked (reducing confirmations).</li>
+                <li><strong>Cancel is quorum-gated:</strong> Directors may vote to cancel a queued transaction; the proposal dies only when cancel votes reach quorum (same formula as execute). Individual confirmations can still be revoked without cancelling the proposal.</li>
                 <li><strong>Gas Costs:</strong> Linked list operations scale linearly with node count, limiting scalability for very large organizations.</li>
               </ul>
 
@@ -655,7 +743,8 @@ Node: 4 × uint256 = 4 storage slots (optimal for linked list operations)`}
               </p>
               <p className="text-gray-300 leading-relaxed mb-4">
                 Key innovations include the sorted linked list delegation mechanism, liquid
-                delegation patterns, and self-sovereign upgradeability gated by the same transaction
+                delegation patterns, session-key director operators for contract-owned NFTs, and
+                self-sovereign upgradeability gated by the same transaction
                 flow as other chamber actions. EIP-1271 agent directors and Sub-Chamber topologies
                 remain design work — not the live Factory, vault, ranked board, and quorum wallet.
               </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #221.

Whitepaper (`landing/src/Whitepaper.tsx`, loreum.org/whitepaper) and in-app `/docs` now tell the same live Chamber story. No contract changes. No invented addresses.

Open PR #166 (`docs: Factory architecture; Sub-Chambers as contemplated`) overlaps Factory vs Registry and Sub-Chambers. **#166 can be closed as superseded once this merges.** Do not merge either from this note.

Older ready issues #164 (Registry/Sub-Chambers as live architecture) is covered here. #163 / #169 are landing chrome (agent fleet / session-key marketing), not this docs sync.

## Truth table

| Topic | Live claim | What changed |
|-------|------------|--------------|
| **1. Create path** | Factory is the intended create path. Registry create is leftover / not the product default. `createAgent()` does not exist on Factory or Registry. | Whitepaper §2 leads with Factory (`createChamber`, `setImplementation`, `implementation`) and a leftover Registry card. Removed `createAgent()`. `architecture.md`, getting-started, deployment, API reference, and sequence diagrams agree: Factory-first; Registry leftover. |
| **2. Director auth** | Owner as `msg.sender`, or session key via `setDirectorOperator` for contract-owned NFTs. Chamber never calls ERC-1271. | Whitepaper §4 documents session keys as the live agent path; EIP-1271 is a labeled research subsection (not shipped). Abstract / §1.1 / conclusion match. `chamber-and-sub-chambers.md` no longer says Safe directors use EIP-1271. Cross-link to `director-authorization.md`. |
| **3. Sub-Chambers** | Contemplated pattern, not live architecture. | Overview, why-not-multisig, chamber-and-sub-chambers, governance, and vision use the whitepaper’s “design work / contemplated” framing. No selling parent/child Registry links as a shipped product surface. |
| **4. Cancel** | Directors can vote to cancel at quorum before execute. | Whitepaper §9.1 no longer says “No Cancellation.” §7.2 documents `cancelTransaction()` at quorum. App governance / getting-started already correct. |
| **5. MAX_NODES** | 50 (`BoardTypes` / design-notes). | Whitepaper §5.3 and §6.1 say 50, not 100. |
| **6. Audited** | No named public audit. | Overview drops “audited smart contracts.” Security-review audience blurb no longer points readers at published audit reports. |
| **7. Seating delay** | `SEATING_DELAY` = 1 block. After `ownerOf` changes for an already-seated token, the clock restarts (on main after #220). | Whitepaper §3.2 notes the 1-block delay and control-transfer restart. Getting-started and director-authorization stay consistent. No extra PMN-H01 narrative beyond what is on main. |

## How to verify

1. Whitepaper `/whitepaper`: §2 Factory-first; §4 session keys live / EIP-1271 research; §9.1 cancel; `MAX_NODES` 50; seating delay 1 block.
2. In-app `/docs/introduction/overview` — no “audited”; Sub-Chambers contemplated.
3. `/docs/introduction/chamber-and-sub-chambers` — Factory create; no EIP-1271 for Safe directors.
4. `/docs/protocol/architecture` — Factory mermaid; Registry leftover.

## Out of scope

- Contract behavior (#208–#212).
- Inventing mainnet addresses.
- Landing marketing copy (#163 / #169 / #198).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b0193d2-f8dd-4c8c-baed-6003c91ffd25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b0193d2-f8dd-4c8c-baed-6003c91ffd25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

