### PR TITLE
fix(contracts): session-key expiry, scope, and set delay (PMN-M04 A+B+C)

### DIFF
--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -380,6 +380,24 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
     }
 
     /**
+     * @notice `scope` of the live session, or `0` if none / stale / expired / burned.
+     */
+    function getDirectorOperatorScope(uint256 tokenId) public view override returns (uint32) {
+        (bool live,) = _liveSessionKey(tokenId);
+        if (!live) return 0;
+        return _getChamberStorage().directorSession[tokenId].scope;
+    }
+
+    /**
+     * @notice Confirm/execute unlock block of the live session, or `0` if none / stale / expired / burned.
+     */
+    function getDirectorOperatorLiveAt(uint256 tokenId) public view override returns (uint256) {
+        (bool live,) = _liveSessionKey(tokenId);
+        if (!live) return 0;
+        return _getChamberStorage().directorSession[tokenId].liveAt;
+    }
+
+    /**
      * @notice Stored session fields for `tokenId` (raw; not liveness-filtered).
      */
     function getDirectorSession(uint256 tokenId)

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -32,9 +32,16 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
     using EnumerableSet for EnumerableSet.UintSet;
 
     /// @dev Bound to the approving contract owner so an NFT transfer drops the key.
+    ///      Packed into two slots: `owner`/`expiry`/`scope` then `operator`/`liveAt`.
+    ///      `expiry == 0` is not live (rejected at set; leftover zero-expiry rows are inert).
+    ///      `scope == 0` grants no actions. `SESSION_SCOPE_UNSCOPED` is explicit full access.
+    ///      `liveAt` is the first block the key may confirm or execute (PMN-M04 C).
     struct DirectorSession {
         address owner;
+        uint64 expiry;
+        uint32 scope;
         address operator;
+        uint64 liveAt;
     }
 
     /**
@@ -51,7 +58,8 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         mapping(address => uint256) totalHolderDelegations;
         /// @dev Per-holder set of tokenIds with a positive delegation, including board-evicted ids.
         mapping(address => EnumerableSet.UintSet) holderDelegatedTokenIds;
-        /// @dev Session key for a contract-owned membership NFT. Stale if `owner` != current `ownerOf`.
+        /// @dev Session key for a contract-owned membership NFT. Stale if `owner` != current `ownerOf`,
+        ///      expired, or (for confirm/execute) `block.number < liveAt`.
         mapping(uint256 tokenId => DirectorSession) directorSession;
         /// @dev `ownerOf` when the confirm bit was last written. Mismatch is ignored for quorum (PMN-H01 A).
         mapping(uint256 nonce => mapping(uint256 tokenId => address)) confirmOwner;
@@ -72,6 +80,21 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
 
     /// Constants
     uint256 private constant MAX_SEATS = 20;
+
+    /// @notice Session scope bit: submit (including batch and metadata variants)
+    uint32 public constant SESSION_SCOPE_SUBMIT = 1 << 0;
+    /// @notice Session scope bit: confirm (including batch)
+    uint32 public constant SESSION_SCOPE_CONFIRM = 1 << 1;
+    /// @notice Session scope bit: execute (including batch)
+    uint32 public constant SESSION_SCOPE_EXECUTE = 1 << 2;
+    /// @notice Session scope bit: updateSeats / executeSeatsUpdate / cancelSeatUpdate
+    uint32 public constant SESSION_SCOPE_UPDATE_SEATS = 1 << 3;
+    /// @notice Session scope bit: revokeConfirmation
+    uint32 public constant SESSION_SCOPE_REVOKE = 1 << 4;
+    /// @notice Session scope bit: cancelTransaction
+    uint32 public constant SESSION_SCOPE_CANCEL = 1 << 5;
+    /// @notice Explicit unscoped sentinel. Scope `0` is rejected at set and grants nothing.
+    uint32 public constant SESSION_SCOPE_UNSCOPED = type(uint32).max;
 
     /**
      * @notice Implementation version stored as a bytes32 constant.
@@ -316,8 +339,14 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
     /**
      * @notice Registers or clears the session key for a contract-owned membership NFT.
      * @dev Only the current contract owner may call. Never consults ERC-1271 (M-01).
+     *      `expiry == 0` is rejected (PMN-M04 A). `scope == 0` is rejected; unscoped is
+     *      `SESSION_SCOPE_UNSCOPED` (PMN-M04 B). Confirm/execute wait `SEATING_DELAY` (PMN-M04 C).
      */
-    function setDirectorOperator(uint256 tokenId, address operator) external override nonReentrant {
+    function setDirectorOperator(uint256 tokenId, address operator, uint256 expiry, uint32 scope)
+        external
+        override
+        nonReentrant
+    {
         if (tokenId == 0) revert IChamber.NotDirector();
         address owner = _getChamberStorage().nft.ownerOf(tokenId);
         if (owner != msg.sender) revert IChamber.NotDirector();
@@ -326,18 +355,45 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         ChamberStorage storage $ = _getChamberStorage();
         if (operator == address(0)) {
             delete $.directorSession[tokenId];
-        } else {
-            $.directorSession[tokenId] = DirectorSession({owner: owner, operator: operator});
+            emit IChamber.DirectorOperatorSet(tokenId, owner, operator, 0, 0);
+            return;
         }
-        emit IChamber.DirectorOperatorSet(tokenId, owner, operator);
+
+        if (expiry == 0 || expiry > type(uint64).max || expiry <= block.timestamp) {
+            revert IChamber.InvalidSessionExpiry();
+        }
+        if (scope == 0) revert IChamber.InvalidSessionScope();
+
+        uint256 liveAt = block.number + BoardTypes.SEATING_DELAY;
+        $.directorSession[tokenId] = DirectorSession({
+            owner: owner,
+            expiry: uint64(expiry),
+            scope: scope,
+            operator: operator,
+            liveAt: uint64(liveAt)
+        });
+        emit IChamber.DirectorOperatorSet(tokenId, owner, operator, expiry, scope);
     }
 
     /**
-     * @notice Live session key for `tokenId`, or zero if unset, stale, or EOA-owned.
+     * @notice Live session key for `tokenId`, or zero if unset, stale, expired, or EOA-owned.
      */
     function getDirectorOperator(uint256 tokenId) public view override returns (address) {
         (bool authorized, address operator) = _liveSessionKey(tokenId);
         return authorized ? operator : address(0);
+    }
+
+    /**
+     * @notice Stored session fields for `tokenId` (raw; not liveness-filtered).
+     */
+    function getDirectorSession(uint256 tokenId)
+        public
+        view
+        override
+        returns (address sessionOwner, address operator, uint256 expiry, uint32 scope, uint256 liveAt)
+    {
+        DirectorSession storage session = _getChamberStorage().directorSession[tokenId];
+        return (session.owner, session.operator, session.expiry, session.scope, session.liveAt);
     }
 
     /**
@@ -773,11 +829,12 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
 
     /// @dev NFT owner of `tokenId`, or the live session key on a contract-owned NFT.
     ///      Never consults ERC-1271 (M-01). `ownerOf` reverts if the token is burned.
+    ///      Session keys are also gated by expiry, optional scope, and confirm/execute delay.
     function _requireTokenAuthorized(uint256 tokenId) internal view {
         if (tokenId == 0) revert IChamber.NotDirector();
         address owner = _getChamberStorage().nft.ownerOf(tokenId);
         if (owner == msg.sender) return;
-        if (_isLiveSessionKey(tokenId, owner, msg.sender)) return;
+        if (_isLiveSessionKey(tokenId, owner, msg.sender) && _sessionMayAct(tokenId, msg.sig)) return;
         revert IChamber.NotDirector();
     }
 
@@ -792,20 +849,65 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
         }
     }
 
-    /// @dev Session key is live only for the current contract owner that registered it.
+    /// @dev Session key is live only for the current contract owner that registered it,
+    ///      and only while `block.timestamp <= expiry`. `expiry == 0` is not live.
     function _isLiveSessionKey(uint256 tokenId, address owner, address account) internal view returns (bool) {
         if (account == address(0) || owner.code.length == 0) return false;
         DirectorSession storage session = _getChamberStorage().directorSession[tokenId];
-        return session.owner == owner && session.operator == account;
+        if (session.owner != owner || session.operator != account) return false;
+        if (session.expiry == 0 || block.timestamp > session.expiry) return false;
+        return true;
     }
 
-    /// @dev `(true, operator)` when a live session exists; otherwise `(false, 0)`.
+    /// @dev Scope and post-set delay for a live session key. Owner callers skip this.
+    ///      Unknown selectors fail closed unless the owner passed `SESSION_SCOPE_UNSCOPED`.
+    function _sessionMayAct(uint256 tokenId, bytes4 selector) internal view returns (bool) {
+        DirectorSession storage session = _getChamberStorage().directorSession[tokenId];
+        (uint32 bit, bool delayed) = _sessionScopeForSelector(selector);
+        if (delayed && block.number < session.liveAt) return false;
+        if (session.scope == SESSION_SCOPE_UNSCOPED) return true;
+        return bit != 0 && (session.scope & bit) != 0;
+    }
+
+    /// @dev Maps Chamber director entry points to a scope bit and the C delay flag.
+    function _sessionScopeForSelector(bytes4 selector) internal pure returns (uint32 bit, bool delayed) {
+        if (
+            selector == bytes4(keccak256("submitTransaction(uint256,address,uint256,bytes)"))
+                || selector == bytes4(keccak256("submitTransaction(uint256,address,uint256,bytes,uint256)"))
+                || selector == bytes4(keccak256("submitTransactionWithMetadata(uint256,address,uint256,bytes,string)"))
+                || selector
+                    == bytes4(keccak256("submitTransactionWithMetadata(uint256,address,uint256,bytes,string,uint256)"))
+                || selector == bytes4(keccak256("submitBatchTransactions(uint256,address[],uint256[],bytes[])"))
+        ) {
+            return (SESSION_SCOPE_SUBMIT, false);
+        }
+        if (selector == IWallet.confirmTransaction.selector || selector == IWallet.confirmBatchTransactions.selector) {
+            return (SESSION_SCOPE_CONFIRM, true);
+        }
+        if (selector == IWallet.executeTransaction.selector || selector == IWallet.executeBatchTransactions.selector) {
+            return (SESSION_SCOPE_EXECUTE, true);
+        }
+        if (selector == IChamber.executeSeatsUpdate.selector) {
+            return (SESSION_SCOPE_UPDATE_SEATS, true);
+        }
+        if (selector == IChamber.updateSeats.selector || selector == IChamber.cancelSeatUpdate.selector) {
+            return (SESSION_SCOPE_UPDATE_SEATS, false);
+        }
+        if (selector == IWallet.revokeConfirmation.selector) {
+            return (SESSION_SCOPE_REVOKE, false);
+        }
+        if (selector == IWallet.cancelTransaction.selector) {
+            return (SESSION_SCOPE_CANCEL, false);
+        }
+        return (0, false);
+    }
+
+    /// @dev `(true, operator)` when a live (unexpired) session exists; otherwise `(false, 0)`.
     function _liveSessionKey(uint256 tokenId) internal view returns (bool, address) {
         if (tokenId == 0) return (false, address(0));
         try _getChamberStorage().nft.ownerOf(tokenId) returns (address owner) {
-            if (owner.code.length == 0) return (false, address(0));
             DirectorSession storage session = _getChamberStorage().directorSession[tokenId];
-            if (session.owner != owner || session.operator == address(0)) return (false, address(0));
+            if (!_isLiveSessionKey(tokenId, owner, session.operator)) return (false, address(0));
             return (true, session.operator);
         } catch {
             return (false, address(0));

--- a/contracts/src/Chamber.sol
+++ b/contracts/src/Chamber.sol
@@ -366,11 +366,7 @@ contract Chamber is ERC4626Upgradeable, PausableUpgradeable, Board, Wallet, ICha
 
         uint256 liveAt = block.number + BoardTypes.SEATING_DELAY;
         $.directorSession[tokenId] = DirectorSession({
-            owner: owner,
-            expiry: uint64(expiry),
-            scope: scope,
-            operator: operator,
-            liveAt: uint64(liveAt)
+            owner: owner, expiry: uint64(expiry), scope: scope, operator: operator, liveAt: uint64(liveAt)
         });
         emit IChamber.DirectorOperatorSet(tokenId, owner, operator, expiry, scope);
     }

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -86,14 +86,30 @@ interface IChamber is IERC4626, IBoard, IWallet {
 
     /**
      * @notice Live session key for `tokenId`, or `address(0)` if none, stale, or expired.
-     * @dev Stale after NFT transfer, while the current owner is an EOA, or after `expiry`.
-     *      Does not check scope or the post-set confirm/execute delay.
+     * @dev Stale after NFT transfer, while the current owner is an EOA, after `expiry`, or if burned.
+     *      Does not apply scope or the post-set confirm/execute delay. See
+     *      {getDirectorOperatorScope} and {getDirectorOperatorLiveAt}.
      */
     function getDirectorOperator(uint256 tokenId) external view returns (address operator);
 
     /**
+     * @notice `scope` of the live session for `tokenId`, or `0` if none / stale / expired / burned.
+     * @dev Same liveness as {getDirectorOperator}. `0` here means no live session, not unscoped
+     *      (`type(uint32).max`). Raw leftover scope is on {getDirectorSession}.
+     */
+    function getDirectorOperatorScope(uint256 tokenId) external view returns (uint32 scope);
+
+    /**
+     * @notice First block the live session may confirm or execute, or `0` if none / stale / expired / burned.
+     * @dev Same liveness as {getDirectorOperator}. Confirm/execute require `block.number >= liveAt`.
+     *      Raw leftover `liveAt` is on {getDirectorSession}.
+     */
+    function getDirectorOperatorLiveAt(uint256 tokenId) external view returns (uint256 liveAt);
+
+    /**
      * @notice Stored session fields for `tokenId` (raw; not liveness-filtered).
-     * @dev `operator` here may be stale or expired. Use {getDirectorOperator} for the live key.
+     * @dev `operator` / `scope` / `liveAt` here may be stale or expired. Use {getDirectorOperator},
+     *      {getDirectorOperatorScope}, and {getDirectorOperatorLiveAt} for the live session.
      */
     function getDirectorSession(uint256 tokenId)
         external

--- a/contracts/src/interfaces/IChamber.sol
+++ b/contracts/src/interfaces/IChamber.sol
@@ -73,20 +73,37 @@ interface IChamber is IERC4626, IBoard, IWallet {
      * @notice Registers or clears the session key for a contract-owned membership NFT.
      * @dev Only `ownerOf(tokenId)` may call, and only when that owner is a contract.
      *      Chamber never consults ERC-1271. See docs/protocol/director-authorization.md.
+     *      Non-zero `operator` requires a future `expiry` (`0` is rejected) and a non-zero
+     *      `scope`. Pass `type(uint32).max` for explicit unscoped access. Scope `0` is rejected.
+     *      A newly set key cannot confirm or execute until `SEATING_DELAY` elapses.
+     *      Clear with `operator == address(0)` (expiry and scope are ignored).
      * @param tokenId Membership token the caller owns
      * @param operator Session key that may act for `tokenId`, or `address(0)` to clear
+     * @param expiry Exclusive-after unix timestamp; rejected if `0` or not in the future
+     * @param scope Bitmask of Chamber director entry points, or `type(uint32).max` (unscoped)
      */
-    function setDirectorOperator(uint256 tokenId, address operator) external;
+    function setDirectorOperator(uint256 tokenId, address operator, uint256 expiry, uint32 scope) external;
 
     /**
-     * @notice Live session key for `tokenId`, or `address(0)` if none or stale.
-     * @dev Stale after NFT transfer or while the current owner is an EOA.
+     * @notice Live session key for `tokenId`, or `address(0)` if none, stale, or expired.
+     * @dev Stale after NFT transfer, while the current owner is an EOA, or after `expiry`.
+     *      Does not check scope or the post-set confirm/execute delay.
      */
     function getDirectorOperator(uint256 tokenId) external view returns (address operator);
 
     /**
+     * @notice Stored session fields for `tokenId` (raw; not liveness-filtered).
+     * @dev `operator` here may be stale or expired. Use {getDirectorOperator} for the live key.
+     */
+    function getDirectorSession(uint256 tokenId)
+        external
+        view
+        returns (address sessionOwner, address operator, uint256 expiry, uint32 scope, uint256 liveAt);
+
+    /**
      * @notice Whether `account` may act for `tokenId` (owner or live session key).
-     * @dev Does not check board seats or seating delay. Burned tokens return false.
+     * @dev Does not check board seats, seating delay, session scope, or the post-set
+     *      confirm/execute delay. Expired keys return false. Burned tokens return false.
      */
     function isTokenAuthorized(uint256 tokenId, address account) external view returns (bool);
 
@@ -218,8 +235,12 @@ interface IChamber is IERC4626, IBoard, IWallet {
      * @param tokenId Membership token
      * @param owner Owner that registered the key (`ownerOf` at the time of the call)
      * @param operator Session key, or `address(0)` when cleared
+     * @param expiry Exclusive-after unix timestamp (`0` when cleared)
+     * @param scope Bitmask or `type(uint32).max` unscoped sentinel (`0` when cleared)
      */
-    event DirectorOperatorSet(uint256 indexed tokenId, address indexed owner, address indexed operator);
+    event DirectorOperatorSet(
+        uint256 indexed tokenId, address indexed owner, address indexed operator, uint256 expiry, uint32 scope
+    );
 
     /// Errors
     /// @notice Thrown when there is insufficient delegated amount
@@ -275,4 +296,10 @@ interface IChamber is IERC4626, IBoard, IWallet {
     /// @notice Thrown when the vault's observed asset delta does not equal the requested amount
     /// @dev Rejects fee-on-transfer / deflating tokens on deposit and mint
     error AssetAmountMismatch();
+
+    /// @notice Thrown when a session-key expiry is zero, not in the future, or exceeds `uint64`
+    error InvalidSessionExpiry();
+
+    /// @notice Thrown when a session-key scope is zero (unscoped must be `type(uint32).max`)
+    error InvalidSessionScope();
 }

--- a/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
+++ b/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
@@ -110,7 +110,8 @@ contract FindingPMNH01ControlTransferTest is Test {
         wallet.execute(
             address(chamber),
             abi.encodeCall(
-                chamber.setDirectorOperator, (4, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+                chamber.setDirectorOperator,
+                (4, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
             )
         );
         assertEq(chamber.getDirectorOperator(4), sessionKey);
@@ -128,9 +129,10 @@ contract FindingPMNH01ControlTransferTest is Test {
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.submitTransaction(4, address(0x3), 0, "");
 
+        uint32 unscoped = type(uint32).max;
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(4, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        chamber.setDirectorOperator(4, address(0xFEE1), block.timestamp + 30 days, unscoped);
 
         address newKey = address(0xA11);
         newWallet.execute(

--- a/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
+++ b/contracts/test/findings/Finding_PMN_H01_ControlTransfer.t.sol
@@ -107,7 +107,12 @@ contract FindingPMNH01ControlTransferTest is Test {
         vm.stopPrank();
         vm.roll(block.number + SEATING_DELAY);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (4, sessionKey)));
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
+                chamber.setDirectorOperator, (4, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            )
+        );
         assertEq(chamber.getDirectorOperator(4), sessionKey);
         assertTrue(chamber.isTokenAuthorized(4, sessionKey));
 
@@ -125,10 +130,15 @@ contract FindingPMNH01ControlTransferTest is Test {
 
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(4, address(0xFEE1));
+        chamber.setDirectorOperator(4, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
 
         address newKey = address(0xA11);
-        newWallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (4, newKey)));
+        newWallet.execute(
+            address(chamber),
+            abi.encodeCall(
+                chamber.setDirectorOperator, (4, newKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            )
+        );
         assertEq(chamber.getDirectorOperator(4), newKey, "only the new owner can register a session key");
     }
 

--- a/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
+++ b/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IChamber} from "src/interfaces/IChamber.sol";
+import {IERC1271} from "lib/openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
+import {MockERC20} from "test/mock/MockERC20.sol";
+import {MockERC721} from "test/mock/MockERC721.sol";
+import {DeployChamber} from "test/utils/DeployChamber.sol";
+import {BoardTypes} from "src/types/BoardTypes.sol";
+
+/// @dev Contract NFT owner used to register a session key (same pattern as Chamber.t.sol).
+contract MockERC1271Wallet {
+    uint256 public signatureCalls;
+    address public authorizedAddress;
+
+    constructor(address _authorized) {
+        authorizedAddress = _authorized;
+    }
+
+    function isValidSignature(bytes32, bytes memory signature) external returns (bytes4) {
+        signatureCalls += 1;
+        if (signature.length == 32) {
+            address decoded = abi.decode(signature, (address));
+            if (decoded == authorizedAddress) {
+                return IERC1271.isValidSignature.selector;
+            }
+        }
+        return bytes4(0xffffffff);
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok, bytes memory ret) = target.call(data);
+        if (!ok) {
+            assembly {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+}
+
+/**
+ * @title PMN-M04: session keys are unscoped, non-expiring, full-seat equivalents
+ * @notice Solutions A (expiry), B (explicit scope), and C (`SEATING_DELAY` before
+ *         confirm/execute). Not D. ERC-1271 stays unconsulted. No exploit PoCs.
+ */
+contract FindingPMNM04SessionKeyScopeTest is Test {
+    Chamber public chamber;
+    MockERC20 public token;
+    MockERC721 public nft;
+
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public sessionKey = address(0xB0B);
+
+    MockERC1271Wallet public wallet;
+
+    uint256 public constant SEATS = 3;
+    uint256 public constant TOKEN_WALLET = 3;
+    uint256 public constant SEATING_DELAY = BoardTypes.SEATING_DELAY;
+
+    function setUp() public {
+        token = new MockERC20("Mock Token", "MCK", 0);
+        nft = new MockERC721("Mock NFT", "MNFT");
+        chamber = DeployChamber.deploy(address(token), address(nft), SEATS, "vERC20", "VLT", address(0x9));
+        wallet = new MockERC1271Wallet(address(0xDEAD));
+
+        _seat(user1, 1, 100 ether);
+        _seat(user2, 2, 100 ether);
+        _seat(address(wallet), TOKEN_WALLET, 100 ether);
+        vm.roll(block.number + SEATING_DELAY);
+    }
+
+    /// @notice Only the NFT owner sets the key. The key cannot replace itself.
+    ///         Clear to `address(0)` means the old key is not a director.
+    function test_PMNM04_ownerOnlySetsAndClears() public {
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.setDirectorOperator(
+            TOKEN_WALLET, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
+        );
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.setDirectorOperator(
+            TOKEN_WALLET, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
+        );
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey, "key cannot replace itself");
+
+        wallet.execute(
+            address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0))
+        );
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0));
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+    }
+
+    /// @notice Transfer stales the key in the same transaction. The new owner starts with no operator.
+    function test_PMNM04_transferClearsKey() public {
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
+
+        MockERC1271Wallet newWallet = new MockERC1271Wallet(address(0xBEEF));
+        vm.prank(address(wallet));
+        nft.transferFrom(address(wallet), address(newWallet), TOKEN_WALLET);
+
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "session key is stale after transfer");
+        assertFalse(chamber.isTokenAuthorized(TOKEN_WALLET, sessionKey));
+        assertTrue(chamber.isTokenAuthorized(TOKEN_WALLET, address(newWallet)), "new owner starts with no operator");
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0));
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+    }
+
+    /// @notice An EOA-owned token cannot register a session key. ERC-1271 is not called.
+    function test_PMNM04_eoaOwnedNftHasNoSessionPath() public {
+        uint256 eoaToken = 10;
+        nft.mintWithTokenId(user1, eoaToken);
+
+        uint256 callsBefore = wallet.signatureCalls();
+        vm.expectCall(address(wallet), abi.encodeWithSelector(IERC1271.isValidSignature.selector), 0);
+        vm.prank(user1);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.setDirectorOperator(eoaToken, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+
+        assertEq(wallet.signatureCalls(), callsBefore, "ERC-1271 is not consulted");
+        assertEq(chamber.getDirectorOperator(eoaToken), address(0));
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        vm.prank(address(wallet));
+        nft.transferFrom(address(wallet), user1, TOKEN_WALLET);
+
+        vm.expectCall(address(wallet), abi.encodeWithSelector(IERC1271.isValidSignature.selector), 0);
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "leftover mapping ignored on EOA owner");
+    }
+
+    /// @notice After the recorded expiry, the key cannot submit, confirm, execute, or update seats.
+    ///         The owner can set a new expiry. Expiry zero is rejected at set (not no-expiry).
+    function test_PMNM04_caseA_expiredKeyCannotAct() public {
+        uint256 expiry = block.timestamp + 1 days;
+        _setKey(sessionKey, expiry, chamber.SESSION_SCOPE_UNSCOPED());
+        (, , uint256 storedExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(storedExpiry, expiry, "every set stores an expiry");
+
+        vm.expectRevert(IChamber.InvalidSessionExpiry.selector);
+        _setKey(sessionKey, 0, chamber.SESSION_SCOPE_UNSCOPED());
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        vm.warp(expiry + 1);
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "expired key is not live");
+        assertFalse(chamber.isTokenAuthorized(TOKEN_WALLET, sessionKey));
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeTransaction(TOKEN_WALLET, 0, "");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.updateSeats(TOKEN_WALLET, 4);
+
+        uint256 refreshed = block.timestamp + 7 days;
+        _setKey(sessionKey, refreshed, chamber.SESSION_SCOPE_UNSCOPED());
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey, "owner can refresh expiry");
+        (, , uint256 newExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(newExpiry, refreshed);
+    }
+
+    /// @notice A scoped key registered for confirm-only cannot execute or update seats.
+    ///         Unscoped is an explicit owner choice (`SESSION_SCOPE_UNSCOPED`), not scope `0`.
+    function test_PMNM04_caseB_scopeBlocksUndeclaredAction() public {
+        vm.expectRevert(IChamber.InvalidSessionScope.selector);
+        _setKey(sessionKey, block.timestamp + 30 days, 0);
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_CONFIRM());
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        vm.prank(sessionKey);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+        assertTrue(chamber.getConfirmation(TOKEN_WALLET, 0), "confirm-only may confirm");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeTransaction(TOKEN_WALLET, 0, "");
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.updateSeats(TOKEN_WALLET, 4);
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        (, , , uint32 scope,) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(scope, chamber.SESSION_SCOPE_UNSCOPED(), "unscoped is an explicit owner choice");
+    }
+
+    /// @notice A key set in block N cannot confirm or execute until `SEATING_DELAY`.
+    ///         The owner can clear immediately.
+    function test_PMNM04_caseC_newKeyWaitsDelay() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        (, , , , uint256 liveAt) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(liveAt, block.number + SEATING_DELAY);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeTransaction(TOKEN_WALLET, 0, "");
+
+        wallet.execute(
+            address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0))
+        );
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "owner can clear immediately");
+
+        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(sessionKey);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+        assertTrue(chamber.getConfirmation(TOKEN_WALLET, 0));
+
+        vm.prank(user2);
+        chamber.confirmTransaction(2, 0);
+
+        vm.prank(sessionKey);
+        chamber.executeTransaction(TOKEN_WALLET, 0, "");
+        (bool executed,,,,) = chamber.getTransaction(0);
+        assertTrue(executed, "key may execute after SEATING_DELAY");
+    }
+
+    /// @notice Solution D only after written acceptance on #212. Not shipped in this PR.
+    function test_PMNM04_accepted_unscopedUntilOwnerClears() public {
+        // D: product acceptance that the key equals the seat until clear/transfer.
+        // No written acceptance on #212. Tests 1–6 cover A+B+C instead.
+        vm.skip(true);
+    }
+
+    function _setKey(address operator, uint256 expiry, uint32 scope) internal {
+        wallet.execute(
+            address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, operator, expiry, scope))
+        );
+    }
+
+    function _seat(address user, uint256 tokenId, uint256 amount) internal {
+        nft.mintWithTokenId(user, tokenId);
+        token.mint(user, amount);
+        vm.startPrank(user);
+        token.approve(address(chamber), amount);
+        chamber.deposit(amount, user);
+        chamber.delegate(tokenId, amount);
+        vm.stopPrank();
+    }
+}

--- a/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
+++ b/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
@@ -78,18 +78,14 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
     function test_PMNM04_ownerOnlySetsAndClears() public {
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(
-            TOKEN_WALLET, sessionKey, block.timestamp + 30 days, UNSCOPED
-        );
+        chamber.setDirectorOperator(TOKEN_WALLET, sessionKey, block.timestamp + 30 days, UNSCOPED);
 
         _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
 
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(
-            TOKEN_WALLET, address(0xFEE1), block.timestamp + 30 days, UNSCOPED
-        );
+        chamber.setDirectorOperator(TOKEN_WALLET, address(0xFEE1), block.timestamp + 30 days, UNSCOPED);
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey, "key cannot replace itself");
 
         wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0)));
@@ -251,6 +247,150 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         chamber.executeTransaction(TOKEN_WALLET, 0, "");
         (bool executed,,,,) = chamber.getTransaction(0);
         assertTrue(executed, "key may execute after SEATING_DELAY");
+    }
+
+    /// @notice Live getters expose scope and liveAt. Raw getDirectorSession may retain leftovers.
+    function test_PMNM04_viewsExposeScopeAndLiveAt() public {
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), 0);
+        assertEq(chamber.getDirectorOperatorLiveAt(TOKEN_WALLET), 0);
+
+        uint32 confirmOnly = chamber.SESSION_SCOPE_CONFIRM();
+        _setKey(sessionKey, block.timestamp + 30 days, confirmOnly);
+        uint256 expectedLiveAt = block.number + SEATING_DELAY;
+
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), confirmOnly);
+        assertEq(chamber.getDirectorOperatorLiveAt(TOKEN_WALLET), expectedLiveAt);
+
+        (,,, uint32 rawScope, uint256 rawLiveAt) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(rawScope, confirmOnly);
+        assertEq(rawLiveAt, expectedLiveAt);
+
+        vm.warp(block.timestamp + 31 days);
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "expired key is not live");
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), 0);
+        assertEq(chamber.getDirectorOperatorLiveAt(TOKEN_WALLET), 0);
+        (,,, uint32 leftoverScope,) = chamber.getDirectorSession(TOKEN_WALLET);
+        assertEq(leftoverScope, confirmOnly, "raw session retains leftover scope");
+    }
+
+    /// @notice Burning the membership NFT drops the live key. Leftover storage is not a director.
+    function test_PMNM04_burnDropsLiveKey() public {
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), UNSCOPED);
+
+        nft.burn(TOKEN_WALLET);
+
+        assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0));
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), 0);
+        assertEq(chamber.getDirectorOperatorLiveAt(TOKEN_WALLET), 0);
+        assertFalse(chamber.isTokenAuthorized(TOKEN_WALLET, sessionKey));
+        assertFalse(chamber.isTokenAuthorized(TOKEN_WALLET, address(wallet)));
+
+        vm.prank(sessionKey);
+        vm.expectRevert();
+        chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+    }
+
+    /// @notice Confirm-only cannot revoke. A revoke-scoped key may revoke immediately (no C delay).
+    function test_PMNM04_revokeRespectsScope() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        uint32 confirmOnly = chamber.SESSION_SCOPE_CONFIRM();
+        _setKey(sessionKey, block.timestamp + 30 days, confirmOnly);
+        vm.roll(block.number + SEATING_DELAY);
+
+        vm.prank(sessionKey);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+        assertTrue(chamber.getConfirmation(TOKEN_WALLET, 0));
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.revokeConfirmation(TOKEN_WALLET, 0);
+
+        uint32 revokeOnly = chamber.SESSION_SCOPE_REVOKE();
+        _setKey(sessionKey, block.timestamp + 30 days, revokeOnly);
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), revokeOnly);
+
+        vm.prank(sessionKey);
+        chamber.revokeConfirmation(TOKEN_WALLET, 0);
+        assertFalse(chamber.getConfirmation(TOKEN_WALLET, 0), "revoke-scoped key may revoke immediately");
+    }
+
+    /// @notice Batch confirm/execute wait `SEATING_DELAY`. Confirm-only cannot executeBatch.
+    function test_PMNM04_batchRespectsScopeAndDelay() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        bytes[] memory execData = new bytes[](1);
+
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
+        assertEq(chamber.getDirectorOperatorLiveAt(TOKEN_WALLET), block.number + SEATING_DELAY);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.confirmBatchTransactions(TOKEN_WALLET, ids);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeBatchTransactions(TOKEN_WALLET, ids, execData);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x4);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory data = new bytes[](1);
+        vm.prank(sessionKey);
+        chamber.submitBatchTransactions(TOKEN_WALLET, targets, values, data);
+
+        vm.roll(block.number + SEATING_DELAY);
+        vm.prank(sessionKey);
+        chamber.confirmBatchTransactions(TOKEN_WALLET, ids);
+        assertTrue(chamber.getConfirmation(TOKEN_WALLET, 0));
+
+        uint32 confirmOnly = chamber.SESSION_SCOPE_CONFIRM();
+        _setKey(sessionKey, block.timestamp + 30 days, confirmOnly);
+        vm.roll(block.number + SEATING_DELAY);
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeBatchTransactions(TOKEN_WALLET, ids, execData);
+    }
+
+    /// @notice Refreshing the key restarts `liveAt`. Confirm/execute wait the delay again.
+    function test_PMNM04_refreshRestartsLiveAt() public {
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x3), 0, "");
+
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
+        uint256 firstLiveAt = chamber.getDirectorOperatorLiveAt(TOKEN_WALLET);
+        vm.roll(firstLiveAt);
+        vm.prank(sessionKey);
+        chamber.confirmTransaction(TOKEN_WALLET, 0);
+
+        vm.prank(user1);
+        chamber.submitTransaction(1, address(0x5), 0, "");
+
+        _setKey(sessionKey, block.timestamp + 60 days, UNSCOPED);
+        uint256 secondLiveAt = chamber.getDirectorOperatorLiveAt(TOKEN_WALLET);
+        assertGt(secondLiveAt, firstLiveAt, "refresh restarts liveAt");
+        assertEq(secondLiveAt, firstLiveAt + SEATING_DELAY, "refresh liveAt is prior liveAt plus SEATING_DELAY");
+        assertEq(chamber.getDirectorOperatorScope(TOKEN_WALLET), UNSCOPED);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.confirmTransaction(TOKEN_WALLET, 1);
+
+        vm.prank(sessionKey);
+        vm.expectRevert(IChamber.NotDirector.selector);
+        chamber.executeTransaction(TOKEN_WALLET, 1, "");
+
+        vm.roll(secondLiveAt);
+        vm.prank(sessionKey);
+        chamber.confirmTransaction(TOKEN_WALLET, 1);
+        assertTrue(chamber.getConfirmation(TOKEN_WALLET, 1));
     }
 
     /// @notice Solution D only after written acceptance on #212. Not shipped in this PR.

--- a/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
+++ b/contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol
@@ -59,6 +59,7 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
     uint256 public constant SEATS = 3;
     uint256 public constant TOKEN_WALLET = 3;
     uint256 public constant SEATING_DELAY = BoardTypes.SEATING_DELAY;
+    uint32 internal constant UNSCOPED = type(uint32).max;
 
     function setUp() public {
         token = new MockERC20("Mock Token", "MCK", 0);
@@ -78,22 +79,20 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.setDirectorOperator(
-            TOKEN_WALLET, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
+            TOKEN_WALLET, sessionKey, block.timestamp + 30 days, UNSCOPED
         );
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
 
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.setDirectorOperator(
-            TOKEN_WALLET, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
+            TOKEN_WALLET, address(0xFEE1), block.timestamp + 30 days, UNSCOPED
         );
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey, "key cannot replace itself");
 
-        wallet.execute(
-            address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0))
-        );
+        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0)));
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0));
 
         vm.prank(sessionKey);
@@ -103,7 +102,7 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
 
     /// @notice Transfer stales the key in the same transaction. The new owner starts with no operator.
     function test_PMNM04_transferClearsKey() public {
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey);
 
         MockERC1271Wallet newWallet = new MockERC1271Wallet(address(0xBEEF));
@@ -126,15 +125,14 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         nft.mintWithTokenId(user1, eoaToken);
 
         uint256 callsBefore = wallet.signatureCalls();
-        vm.expectCall(address(wallet), abi.encodeWithSelector(IERC1271.isValidSignature.selector), 0);
         vm.prank(user1);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(eoaToken, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        chamber.setDirectorOperator(eoaToken, sessionKey, block.timestamp + 30 days, UNSCOPED);
 
-        assertEq(wallet.signatureCalls(), callsBefore, "ERC-1271 is not consulted");
+        assertEq(wallet.signatureCalls(), callsBefore, "ERC-1271 is not consulted on EOA set");
         assertEq(chamber.getDirectorOperator(eoaToken), address(0));
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
         vm.prank(address(wallet));
         nft.transferFrom(address(wallet), user1, TOKEN_WALLET);
 
@@ -142,6 +140,7 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.submitTransaction(TOKEN_WALLET, address(0x3), 0, "");
+        assertEq(wallet.signatureCalls(), callsBefore, "ERC-1271 is not consulted after transfer to EOA");
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "leftover mapping ignored on EOA owner");
     }
 
@@ -149,12 +148,12 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
     ///         The owner can set a new expiry. Expiry zero is rejected at set (not no-expiry).
     function test_PMNM04_caseA_expiredKeyCannotAct() public {
         uint256 expiry = block.timestamp + 1 days;
-        _setKey(sessionKey, expiry, chamber.SESSION_SCOPE_UNSCOPED());
-        (, , uint256 storedExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
+        _setKey(sessionKey, expiry, UNSCOPED);
+        (,, uint256 storedExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
         assertEq(storedExpiry, expiry, "every set stores an expiry");
 
         vm.expectRevert(IChamber.InvalidSessionExpiry.selector);
-        _setKey(sessionKey, 0, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, 0, UNSCOPED);
 
         vm.prank(user1);
         chamber.submitTransaction(1, address(0x3), 0, "");
@@ -180,9 +179,9 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         chamber.updateSeats(TOKEN_WALLET, 4);
 
         uint256 refreshed = block.timestamp + 7 days;
-        _setKey(sessionKey, refreshed, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, refreshed, UNSCOPED);
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), sessionKey, "owner can refresh expiry");
-        (, , uint256 newExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
+        (,, uint256 newExpiry,,) = chamber.getDirectorSession(TOKEN_WALLET);
         assertEq(newExpiry, refreshed);
     }
 
@@ -192,7 +191,8 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.expectRevert(IChamber.InvalidSessionScope.selector);
         _setKey(sessionKey, block.timestamp + 30 days, 0);
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_CONFIRM());
+        uint32 confirmOnly = chamber.SESSION_SCOPE_CONFIRM();
+        _setKey(sessionKey, block.timestamp + 30 days, confirmOnly);
         vm.roll(block.number + SEATING_DELAY);
 
         vm.prank(user1);
@@ -210,9 +210,10 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.updateSeats(TOKEN_WALLET, 4);
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
-        (, , , uint32 scope,) = chamber.getDirectorSession(TOKEN_WALLET);
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
+        (,,, uint32 scope,) = chamber.getDirectorSession(TOKEN_WALLET);
         assertEq(scope, chamber.SESSION_SCOPE_UNSCOPED(), "unscoped is an explicit owner choice");
+        assertEq(scope, UNSCOPED);
     }
 
     /// @notice A key set in block N cannot confirm or execute until `SEATING_DELAY`.
@@ -221,8 +222,8 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.prank(user1);
         chamber.submitTransaction(1, address(0x3), 0, "");
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
-        (, , , , uint256 liveAt) = chamber.getDirectorSession(TOKEN_WALLET);
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
+        (,,,, uint256 liveAt) = chamber.getDirectorSession(TOKEN_WALLET);
         assertEq(liveAt, block.number + SEATING_DELAY);
 
         vm.prank(sessionKey);
@@ -233,12 +234,10 @@ contract FindingPMNM04SessionKeyScopeTest is Test {
         vm.expectRevert(IChamber.NotDirector.selector);
         chamber.executeTransaction(TOKEN_WALLET, 0, "");
 
-        wallet.execute(
-            address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0))
-        );
+        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (TOKEN_WALLET, address(0), 0, 0)));
         assertEq(chamber.getDirectorOperator(TOKEN_WALLET), address(0), "owner can clear immediately");
 
-        _setKey(sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        _setKey(sessionKey, block.timestamp + 30 days, UNSCOPED);
         vm.roll(block.number + SEATING_DELAY);
 
         vm.prank(sessionKey);

--- a/contracts/test/symbolic/ChamberSym.t.sol
+++ b/contracts/test/symbolic/ChamberSym.t.sol
@@ -115,6 +115,8 @@ contract ChamberSymTest is Test, SymTest {
     }
 
     /// @dev Only the registered session key (plus the contract owner) is authorized.
+    ///      Reads the PMN-M04 session ABI (expiry/scope/liveAt). Not a symbolic proof of
+    ///      expiry, scope bits, or the confirm/execute delay.
     function symbolicSessionKeyIsOnlyApprovedOperator() public {
         uint256 tokenId = svm.createUint(128, "tokenId");
         address sessionKey = svm.createAddress("sessionKey");
@@ -136,5 +138,15 @@ contract ChamberSymTest is Test, SymTest {
         assertTrue(chamber.isTokenAuthorized(tokenId, sessionKey));
         assertFalse(chamber.isTokenAuthorized(tokenId, other));
         assertEq(chamber.getDirectorOperator(tokenId), sessionKey);
+        assertEq(chamber.getDirectorOperatorScope(tokenId), type(uint32).max);
+        assertEq(chamber.getDirectorOperatorLiveAt(tokenId), block.number + 1);
+
+        (address sessionOwner, address storedOp, uint256 expiry, uint32 scope, uint256 liveAt) =
+            chamber.getDirectorSession(tokenId);
+        assertEq(sessionOwner, address(wallet));
+        assertEq(storedOp, sessionKey);
+        assertEq(expiry, type(uint64).max);
+        assertEq(scope, type(uint32).max);
+        assertEq(liveAt, block.number + 1);
     }
 }

--- a/contracts/test/symbolic/ChamberSym.t.sol
+++ b/contracts/test/symbolic/ChamberSym.t.sol
@@ -129,9 +129,7 @@ contract ChamberSymTest is Test, SymTest {
         nft.mintWithTokenId(address(wallet), tokenId);
         wallet.execute(
             address(chamber),
-            abi.encodeCall(
-                IChamber.setDirectorOperator, (tokenId, sessionKey, type(uint64).max, type(uint32).max)
-            )
+            abi.encodeCall(IChamber.setDirectorOperator, (tokenId, sessionKey, type(uint64).max, type(uint32).max))
         );
 
         assertTrue(chamber.isTokenAuthorized(tokenId, address(wallet)));

--- a/contracts/test/symbolic/ChamberSym.t.sol
+++ b/contracts/test/symbolic/ChamberSym.t.sol
@@ -127,7 +127,12 @@ contract ChamberSymTest is Test, SymTest {
         vm.assume(other != address(wallet));
 
         nft.mintWithTokenId(address(wallet), tokenId);
-        wallet.execute(address(chamber), abi.encodeCall(IChamber.setDirectorOperator, (tokenId, sessionKey)));
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
+                IChamber.setDirectorOperator, (tokenId, sessionKey, type(uint64).max, type(uint32).max)
+            )
+        );
 
         assertTrue(chamber.isTokenAuthorized(tokenId, address(wallet)));
         assertTrue(chamber.isTokenAuthorized(tokenId, sessionKey));

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1777,7 +1777,10 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, sessionKey)));
+        wallet.execute(address(chamber), abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            ));
         assertEq(chamber.getDirectorOperator(tokenId), sessionKey);
         assertTrue(chamber.isTokenAuthorized(tokenId, sessionKey));
         assertTrue(chamber.isTokenAuthorized(tokenId, address(wallet)));
@@ -1801,7 +1804,10 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, sessionKey)));
+        wallet.execute(address(chamber), abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            ));
 
         vm.prank(random1271Caller);
         vm.expectRevert(IChamber.NotDirector.selector);
@@ -1817,7 +1823,7 @@ contract ChamberTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(tokenId, address(0xB0B));
+        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
     }
 
     function test_Chamber_SetDirectorOperator_NonOwnerReverts() public {
@@ -1827,7 +1833,7 @@ contract ChamberTest is Test {
 
         vm.prank(address(0xB0B));
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(tokenId, address(0xB0B));
+        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
     }
 
     function test_Chamber_SetDirectorOperator_OperatorCannotReplace() public {
@@ -1836,11 +1842,16 @@ contract ChamberTest is Test {
         uint256 tokenId = 17;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, sessionKey)));
+        wallet.execute(address(chamber), abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            ));
 
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(tokenId, address(0xFEE1));
+        chamber.setDirectorOperator(
+            tokenId, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
+        );
     }
 
     function test_Chamber_SessionKey_InvalidatedOnTransfer() public {
@@ -1855,7 +1866,10 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, sessionKey)));
+        wallet.execute(address(chamber), abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            ));
 
         vm.prank(address(wallet));
         nft.transferFrom(address(wallet), user1, tokenId);
@@ -1880,8 +1894,14 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, sessionKey)));
-        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, address(0))));
+        wallet.execute(address(chamber), abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            ));
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(chamber.setDirectorOperator, (tokenId, address(0), 0, 0))
+        );
 
         assertEq(chamber.getDirectorOperator(tokenId), address(0));
         vm.prank(sessionKey);

--- a/contracts/test/unit/Chamber.t.sol
+++ b/contracts/test/unit/Chamber.t.sol
@@ -1777,10 +1777,13 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
                 chamber.setDirectorOperator,
                 (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
-            ));
+            )
+        );
         assertEq(chamber.getDirectorOperator(tokenId), sessionKey);
         assertTrue(chamber.isTokenAuthorized(tokenId, sessionKey));
         assertTrue(chamber.isTokenAuthorized(tokenId, address(wallet)));
@@ -1804,10 +1807,13 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
                 chamber.setDirectorOperator,
                 (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
-            ));
+            )
+        );
 
         vm.prank(random1271Caller);
         vm.expectRevert(IChamber.NotDirector.selector);
@@ -1821,9 +1827,10 @@ contract ChamberTest is Test {
         uint256 tokenId = 1;
         MockERC721(address(nft)).mintWithTokenId(user1, tokenId);
 
+        uint32 unscoped = type(uint32).max;
         vm.prank(user1);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, unscoped);
     }
 
     function test_Chamber_SetDirectorOperator_NonOwnerReverts() public {
@@ -1831,9 +1838,10 @@ contract ChamberTest is Test {
         uint256 tokenId = 14;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
 
+        uint32 unscoped = type(uint32).max;
         vm.prank(address(0xB0B));
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED());
+        chamber.setDirectorOperator(tokenId, address(0xB0B), block.timestamp + 30 days, unscoped);
     }
 
     function test_Chamber_SetDirectorOperator_OperatorCannotReplace() public {
@@ -1842,16 +1850,18 @@ contract ChamberTest is Test {
         uint256 tokenId = 17;
         MockERC721(address(nft)).mintWithTokenId(address(wallet), tokenId);
 
-        wallet.execute(address(chamber), abi.encodeCall(
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
                 chamber.setDirectorOperator,
                 (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
-            ));
+            )
+        );
 
+        uint32 unscoped = type(uint32).max;
         vm.prank(sessionKey);
         vm.expectRevert(IChamber.NotDirector.selector);
-        chamber.setDirectorOperator(
-            tokenId, address(0xFEE1), block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED()
-        );
+        chamber.setDirectorOperator(tokenId, address(0xFEE1), block.timestamp + 30 days, unscoped);
     }
 
     function test_Chamber_SessionKey_InvalidatedOnTransfer() public {
@@ -1866,10 +1876,13 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(
+        wallet.execute(
+            address(chamber),
+            abi.encodeCall(
                 chamber.setDirectorOperator,
                 (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
-            ));
+            )
+        );
 
         vm.prank(address(wallet));
         nft.transferFrom(address(wallet), user1, tokenId);
@@ -1894,14 +1907,14 @@ contract ChamberTest is Test {
         chamber.delegate(tokenId, 1 ether);
         vm.roll(block.number + 1);
 
-        wallet.execute(address(chamber), abi.encodeCall(
-                chamber.setDirectorOperator,
-                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
-            ));
         wallet.execute(
             address(chamber),
-            abi.encodeCall(chamber.setDirectorOperator, (tokenId, address(0), 0, 0))
+            abi.encodeCall(
+                chamber.setDirectorOperator,
+                (tokenId, sessionKey, block.timestamp + 30 days, chamber.SESSION_SCOPE_UNSCOPED())
+            )
         );
+        wallet.execute(address(chamber), abi.encodeCall(chamber.setDirectorOperator, (tokenId, address(0), 0, 0)));
 
         assertEq(chamber.getDirectorOperator(tokenId), address(0));
         vm.prank(sessionKey);

--- a/docs/protocol/director-authorization.md
+++ b/docs/protocol/director-authorization.md
@@ -26,8 +26,9 @@ This is the M-01 rule. It is unchanged.
 All of the following must hold:
 
 - The current NFT owner is a **contract** (`owner.code.length > 0`).
-- That owner previously called `setDirectorOperator(tokenId, operator)` while
-  it was `ownerOf(tokenId)` and `msg.sender` (the wallet must register the key
+- That owner previously called
+  `setDirectorOperator(tokenId, operator, expiry, scope)` while it was
+  `ownerOf(tokenId)` and `msg.sender` (the wallet must register the key
   itself).
 - The stored session is still bound to the **current** owner. Transferring the
   NFT invalidates the key. Transfer also resets that tokenId's seating clock
@@ -35,14 +36,27 @@ All of the following must hold:
   (a reverting director call does not persist it). Confirm/cancel bits recorded
   under the previous owner are ignored for quorum and execute (PMN-H01 Solution A).
 - `msg.sender == operator` and `operator != address(0)`.
+- `block.timestamp <= expiry`. `expiry == 0` is rejected at set and is not live
+  if leftover in storage (PMN-M04 A). This is not a no-expiry sentinel.
+- `scope` allows the Chamber entry point being called, or is the explicit
+  unscoped sentinel `type(uint32).max` (`SESSION_SCOPE_UNSCOPED`). Scope `0`
+  is rejected at set and grants no actions (PMN-M04 B).
+- For `confirm*` / `execute*` (including `executeSeatsUpdate`),
+  `block.number >= liveAt`, where `liveAt` is `block.number + SEATING_DELAY`
+  at set time (PMN-M04 C). Submit and seat-propose are not delayed.
 
-A session key may exercise the same **token-gated** Chamber actions as the
-owner for that `tokenId`: director-gated board and wallet functions, and
-`revokeConfirmation` (which is owner-authorized, not seat-gated).
+A live, in-scope session key may exercise the **token-gated** Chamber actions
+its `scope` allows for that `tokenId`: director-gated board and wallet
+functions, and `revokeConfirmation` (which is owner-authorized, not seat-gated)
+when the revoke bit is set or the key is unscoped. Unscoped is an explicit
+owner choice, not a silent default.
 
-The owner may still act as itself. The owner clears the key by calling
-`setDirectorOperator(tokenId, address(0))`. Only the current owner may set or
-clear the key; the operator cannot replace itself.
+The owner may still act as itself (no expiry, scope, or post-set delay). The
+owner clears the key by calling `setDirectorOperator(tokenId, address(0), 0, 0)`
+and may do so immediately, including during the post-set delay. The owner
+refreshes expiry or scope by calling `setDirectorOperator` again (that reset
+also restarts `liveAt`). Only the current owner may set or clear the key; the
+operator cannot replace itself.
 
 ## Callers that may not act
 
@@ -59,16 +73,23 @@ clear the key; the operator cannot replace itself.
   transferred.
 - A session key on an **EOA-owned** membership NFT. Registration reverts;
   even a leftover mapping is ignored while `owner.code.length == 0`.
+- An **expired** session key (`block.timestamp > expiry`, or stored `expiry == 0`).
+- A **scoped** session key calling a Chamber entry point its bitmask does not
+  allow (unscoped is only `SESSION_SCOPE_UNSCOPED`).
+- A newly set key calling confirm or execute before `SEATING_DELAY` (`liveAt`).
 
 ## How a Safe / 4337 / agent uses the session key
 
 1. The wallet that owns the membership NFT submits a transaction whose
    `msg.sender` on Chamber is the wallet (Safe `execTransaction`, 4337
    account execution, or a direct contract call).
-2. That call is `setDirectorOperator(tokenId, operator)`, where `operator` is
-   the agent EOA, module address, or other session key the owners want to
-   allow.
-3. `operator` may then call Chamber directly with that `tokenId`.
+2. That call is `setDirectorOperator(tokenId, operator, expiry, scope)`, where
+   `operator` is the agent EOA, module address, or other session key the
+   owners want to allow, `expiry` is a future unix timestamp, and `scope` is
+   a Chamber entry-point bitmask or `SESSION_SCOPE_UNSCOPED`.
+3. After `SEATING_DELAY`, `operator` may confirm or execute on Chamber
+   directly with that `tokenId` (submit may proceed in the set block if
+   scoped to allow it).
 
 This is an explicit Chamber allowlist. It is not EIP-1271, not Safe
 `isModuleEnabled`, and not EntryPoint validation.

--- a/docs/protocol/director-authorization.md
+++ b/docs/protocol/director-authorization.md
@@ -58,6 +58,26 @@ refreshes expiry or scope by calling `setDirectorOperator` again (that reset
 also restarts `liveAt`). Only the current owner may set or clear the key; the
 operator cannot replace itself.
 
+## Public session views
+
+These getters are how callers read the session. They match the rules above.
+
+- `getDirectorOperator(tokenId)` — live operator, or zero if unset, stale,
+  expired, EOA-owned, or burned. Does **not** apply `scope` or the
+  confirm/execute delay.
+- `getDirectorOperatorScope(tokenId)` — `scope` of that live session, or
+  `0` if there is no live session. `0` is not unscoped; unscoped is
+  `SESSION_SCOPE_UNSCOPED`.
+- `getDirectorOperatorLiveAt(tokenId)` — first block the live session may
+  confirm or execute (`liveAt`), or `0` if there is no live session.
+  Confirm/execute require `block.number >= liveAt`.
+- `getDirectorSession(tokenId)` — raw stored `(sessionOwner, operator,
+  expiry, scope, liveAt)`. These fields may be stale or expired. Use the
+  live getters above for the current key.
+- `isTokenAuthorized(tokenId, account)` — NFT owner or live (unexpired)
+  session key. Does **not** check board seats, seating delay, `scope`, or
+  the confirm/execute delay. Burned tokens return false.
+
 ## Callers that may not act
 
 - Any address that is neither the current `ownerOf(tokenId)` nor the live


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #212.

Solutions **A** (required), **B**, and **C** for PMN-M04. Session keys are no longer unscoped, non-expiring, full-seat equivalents. Not D (no product acceptance that the key equals the seat until clear/transfer). Reject E: ERC-1271 stays unconsulted; the key cannot set or clear itself. No exploit PoCs. Not merged. Not broadcast.

If #209 / #210 / #211 (PRs #223 / #224 / #225) land, this is the last open PMN medium.

## A — Expiry (required)

Every `setDirectorOperator` for a non-zero operator stores an `expiry` (unix timestamp). After `block.timestamp > expiry`, the key cannot submit, confirm, execute, or update seats. `getDirectorOperator` / `isTokenAuthorized` treat it as not live. The owner can refresh by calling `setDirectorOperator` again.

**Expiry-zero policy: reject at set.** `expiry == 0` reverts `InvalidSessionExpiry` (also rejected if not in the future or above `uint64`). Stored `expiry == 0` (pre-upgrade leftover packing) is not live. This is **not** a no-expiry sentinel.

## B — Scope (optional, shipped with A)

`scope` is a bitmask of Chamber director entry points (`SESSION_SCOPE_SUBMIT`, `CONFIRM`, `EXECUTE`, `UPDATE_SEATS`, `REVOKE`, `CANCEL`). A confirm-only key cannot execute or update seats. Tests assert Chamber entry points only, not arbitrary target calldata.

**Unscoped is an explicit owner choice:** pass `SESSION_SCOPE_UNSCOPED` (`type(uint32).max`). Scope `0` is rejected at set (`InvalidSessionScope`) and grants no actions. It is not a silent full-access default.

## C — Set delay (optional, shipped with A)

A newly set key cannot confirm or execute (including batch variants and `executeSeatsUpdate`) until `SEATING_DELAY` (1 block). `liveAt = block.number + SEATING_DELAY` at set. Submit and seat-propose are not delayed. Refreshing the key restarts `liveAt`. The owner can clear immediately with `setDirectorOperator(tokenId, address(0), 0, 0)`.

## QA nits (this revision)

- Live getters `getDirectorOperatorScope` and `getDirectorOperatorLiveAt` expose scope and the confirm/execute delay. `getDirectorSession` remains the raw leftover tuple. Documented in `docs/protocol/director-authorization.md`.
- Findings tests added for burn, revoke scope, batch confirm/execute, and refresh restarting `liveAt`.
- `ChamberSym` reads the new session ABI fields. That is ABI coverage only, not a symbolic proof of A/B/C. CI Halmos still runs `BoardSymTest` / `WalletSymTest` only.

## Rejected

- **D:** no written acceptance on #212. `test_PMNM04_accepted_unscopedUntilOwnerClears` is skipped.
- **E:** no ERC-1271; key cannot set/clear itself.

## Tests

`contracts/test/findings/Finding_PMN_M04_SessionKeyScope.t.sol`:

1. `test_PMNM04_ownerOnlySetsAndClears`
2. `test_PMNM04_transferClearsKey`
3. `test_PMNM04_eoaOwnedNftHasNoSessionPath`
4. `test_PMNM04_caseA_expiredKeyCannotAct`
5. `test_PMNM04_caseB_scopeBlocksUndeclaredAction`
6. `test_PMNM04_caseC_newKeyWaitsDelay`
7. `test_PMNM04_accepted_unscopedUntilOwnerClears` — skipped (D not accepted)
8. `test_PMNM04_viewsExposeScopeAndLiveAt`
9. `test_PMNM04_burnDropsLiveKey`
10. `test_PMNM04_revokeRespectsScope`
11. `test_PMNM04_batchRespectsScopeAndDelay`
12. `test_PMNM04_refreshRestartsLiveAt`

## Out of scope

- Product acceptance D
- Reopening ERC-1271 director auth (M-01)
- Exploit PoCs, payloads, calldata recipes, attack procedures
- App / CCA
- Merging or broadcasting
- Full Halmos proof of expiry / scope / delay

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c32cac66-a1c2-464b-8d85-e83fee24d820?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c32cac66-a1c2-464b-8d85-e83fee24d820&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

