### PR TITLE
blog: seating control-transfer changelog (2026-09-11)

### DIFF
--- a/landing/content/blog/2026-09-11-seating-control-transfer.md
+++ b/landing/content/blog/2026-09-11-seating-control-transfer.md
@@ -1,0 +1,13 @@
+---
+title: Seating delay binds to NFT control transfer
+date: 2026-09-11
+summary: Transferring a seated membership NFT now resets the seating clock and drops the prior owner's confirm/cancel bits.
+---
+
+11 September 2026. Seating delay binds to NFT control transfer.
+
+- Seating delay now binds to who controls the NFT (`ownerOf`), not only to a tokenId entering the top seats.
+- On control change, the new controller waits a fresh `SEATING_DELAY` before they can act as seated.
+- Confirm/cancel flags recorded under the previous owner no longer count toward quorum or execute.
+- Session keys still go stale on transfer (unchanged).
+- Chamber contracts version `1.1.7`. This does not clear the pre-mainnet gate by itself.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the 11 September 2026 Chamber changelog post for seating delay bound to NFT control transfer.

**Live URL after merge:** https://www.loreum.org/blog/2026-09-11-seating-control-transfer

**Source:** loreum-org/chamber #220 (merged; PMN-H01 Solution A, Chamber 1.1.7).

The landing blog eager-loads `landing/content/blog/*.md` via `import.meta.glob` in `landing/src/posts.ts`. This PR only adds the markdown file. Sibling posts already use `title`, `date`, and `summary`; no extra frontmatter key or generated index update is required.

- Seating delay now binds to who controls the NFT (`ownerOf`), not only to a tokenId entering the top seats
- On control change, the new controller waits a fresh `SEATING_DELAY` before they can act as seated
- Confirm/cancel flags recorded under the previous owner no longer count toward quorum or execute
- Session keys still go stale on transfer (unchanged)
- Chamber contracts version `1.1.7`. This does not clear the pre-mainnet gate by itself

Verified locally: `npm run build` in `landing/` succeeded. The Vite bundle includes all four dated files (`2026-09-11-seating-control-transfer.md`, `2026-09-09-docs-deeplinks.md`, `2026-09-01-session-key-director.md`, `2026-08-26-factory-my-chambers.md`). Preview at `/blog` listed the new post first in the same card layout as the siblings; `/blog/2026-09-11-seating-control-transfer` rendered the post (not 404).

![Blog index with the new seating control-transfer post first](https://cursor.com/artifacts/c/art-43fef8e4-97a7-4c0e-bbf7-ad976c9d9c29)

![Blog index listing all four changelog posts](https://cursor.com/artifacts/c/art-20ea294e-f765-4a5e-a95a-60c26c9597fc)

![Seating control-transfer changelog post page](https://cursor.com/artifacts/c/art-7c17d3ba-6fe8-42c8-8008-9bb91c9adc7e)

<a href="https://cursor.com/agents/bc-355e6610-f73f-437e-8ba7-a79f04f15311/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_seating_control_transfer_changelog.mp4"><img src="https://cursor.com/artifacts/c/art-8a47124d-d465-402e-9bf4-ed92ecfd833e" alt="blog_seating_control_transfer_changelog.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-355e6610-f73f-437e-8ba7-a79f04f15311?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-355e6610-f73f-437e-8ba7-a79f04f15311&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

