### PR TITLE
fix(app): show wrong network on chamber routes instead of “Not a Chamber”

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test:discovery": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts"
+    "test:discovery": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-route-gate.ts"
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.1.0",

--- a/app/scripts/verify-chamber-route-gate.ts
+++ b/app/scripts/verify-chamber-route-gate.ts
@@ -1,0 +1,120 @@
+/**
+ * Offline checks for chamber-route wrong-network vs “Not a Chamber”.
+ * Run: npx tsx --tsconfig tsconfig.json scripts/verify-chamber-route-gate.ts
+ */
+import assert from 'node:assert/strict'
+import { classifyChamberRoute } from '../src/lib/chamberRoute.ts'
+
+function testUnconfiguredIsWrongNetwork() {
+  const decision = classifyChamberRoute({
+    hasAddress: true,
+    currentChainId: 1,
+    configValid: false,
+    supportedChainIds: [11_155_111],
+    isChamber: false,
+    foundOnOtherChainId: null,
+  })
+  assert.equal(decision.status, 'wrong-network')
+  if (decision.status !== 'wrong-network') return
+  assert.equal(decision.reason, 'unconfigured')
+  assert.equal(decision.targetChainId, 11_155_111)
+}
+
+function testChamberOnOtherConfiguredChain() {
+  const decision = classifyChamberRoute({
+    hasAddress: true,
+    currentChainId: 1,
+    configValid: true,
+    supportedChainIds: [1, 11_155_111],
+    isChamber: false,
+    foundOnOtherChainId: 11_155_111,
+  })
+  assert.equal(decision.status, 'wrong-network')
+  if (decision.status !== 'wrong-network') return
+  assert.equal(decision.reason, 'chamber-on-other-chain')
+  assert.equal(decision.targetChainId, 11_155_111)
+}
+
+function testGenuineNotAChamber() {
+  const decision = classifyChamberRoute({
+    hasAddress: true,
+    currentChainId: 11_155_111,
+    configValid: true,
+    supportedChainIds: [11_155_111],
+    isChamber: false,
+    foundOnOtherChainId: null,
+  })
+  assert.equal(decision.status, 'not-chamber')
+}
+
+function testReadyAndLoading() {
+  assert.equal(
+    classifyChamberRoute({
+      hasAddress: true,
+      currentChainId: 11_155_111,
+      configValid: true,
+      supportedChainIds: [11_155_111],
+      isChamber: true,
+      foundOnOtherChainId: null,
+    }).status,
+    'ready',
+  )
+  assert.equal(
+    classifyChamberRoute({
+      hasAddress: true,
+      currentChainId: 11_155_111,
+      configValid: true,
+      supportedChainIds: [11_155_111],
+      isChamber: undefined,
+      foundOnOtherChainId: undefined,
+    }).status,
+    'loading',
+  )
+  assert.equal(
+    classifyChamberRoute({
+      hasAddress: true,
+      currentChainId: 1,
+      configValid: true,
+      supportedChainIds: [1, 11_155_111],
+      isChamber: false,
+      foundOnOtherChainId: undefined,
+    }).status,
+    'loading',
+  )
+}
+
+function testPrefersSepoliaWhenSeveralConfigured() {
+  const decision = classifyChamberRoute({
+    hasAddress: true,
+    currentChainId: 8453,
+    configValid: false,
+    supportedChainIds: [11_155_111, 31337],
+    isChamber: undefined,
+    foundOnOtherChainId: undefined,
+  })
+  assert.equal(decision.status, 'wrong-network')
+  if (decision.status !== 'wrong-network') return
+  assert.equal(decision.targetChainId, 11_155_111)
+}
+
+function testInvalidAddress() {
+  assert.equal(
+    classifyChamberRoute({
+      hasAddress: false,
+      currentChainId: 11_155_111,
+      configValid: true,
+      supportedChainIds: [11_155_111],
+      isChamber: undefined,
+      foundOnOtherChainId: undefined,
+    }).status,
+    'invalid-address',
+  )
+}
+
+testUnconfiguredIsWrongNetwork()
+testChamberOnOtherConfiguredChain()
+testGenuineNotAChamber()
+testReadyAndLoading()
+testPrefersSepoliaWhenSeveralConfigured()
+testInvalidAddress()
+console.log('verify-chamber-route-gate: ok')

--- a/app/src/components/ChamberRouteGate.tsx
+++ b/app/src/components/ChamberRouteGate.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useAccount, useChainId, useSwitchChain } from 'wagmi'
 import { isAddress } from 'viem'
-import { useChainModal } from '@rainbow-me/rainbowkit'
+import { useChainModal, useConnectModal } from '@rainbow-me/rainbowkit'
 import { FiAlertTriangle, FiLoader, FiRefreshCw } from 'react-icons/fi'
 import { useChamberRouteDecision } from '@/hooks/useChamberRouteGate'
 import {
@@ -54,6 +54,7 @@ export function WrongNetworkPanel({
   const { isConnected } = useAccount()
   const { switchChainAsync, isPending } = useSwitchChain()
   const { openChainModal } = useChainModal()
+  const { openConnectModal } = useConnectModal()
 
   const currentName = getNetworkName(currentChainId)
   const supportedNames = supportedChainIds.map((id) => getNetworkName(id))
@@ -62,7 +63,11 @@ export function WrongNetworkPanel({
   const targetName = targetId != null ? getNetworkName(targetId) : undefined
 
   const onSwitch = async () => {
-    if (targetId && isConnected && switchChainAsync) {
+    if (!isConnected) {
+      openConnectModal?.()
+      return
+    }
+    if (targetId && switchChainAsync) {
       try {
         await switchChainAsync({ chainId: targetId })
         return
@@ -71,10 +76,12 @@ export function WrongNetworkPanel({
         return
       }
     }
-    openChainModal?.()
+    openChainModal?.() ?? openConnectModal?.()
   }
 
-  const canSwitch = Boolean((targetId && isConnected) || openChainModal)
+  const canSwitch = Boolean(
+    openConnectModal || openChainModal || (isConnected && targetId && switchChainAsync),
+  )
 
   return (
     <div className="flex flex-col items-center justify-center min-h-64 px-4">

--- a/app/src/components/ChamberRouteGate.tsx
+++ b/app/src/components/ChamberRouteGate.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useAccount, useChainId, useSwitchChain } from 'wagmi'
+import { isAddress } from 'viem'
+import { useChainModal } from '@rainbow-me/rainbowkit'
+import { FiAlertTriangle, FiLoader, FiRefreshCw } from 'react-icons/fi'
+import { useChamberRouteDecision } from '@/hooks/useChamberRouteGate'
+import {
+  getNetworkName,
+  isMainnetConfigured,
+} from '@/lib/wagmi'
+import type { ChamberRouteDecision } from '@/lib/chamberRoute'
+
+function VerifyingChamber() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
+      <FiLoader className="w-10 h-10 text-accent-400 animate-spin" />
+      <p className="text-slate-400 text-sm">Verifying chamber…</p>
+    </div>
+  )
+}
+
+function InvalidChamberAddress() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
+      <FiAlertTriangle className="w-12 h-12 text-red-400" />
+      <h2 className="font-heading text-xl font-bold text-slate-100">Invalid Address</h2>
+      <p className="text-slate-400">The address in this URL is not a valid Ethereum address.</p>
+      <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
+    </div>
+  )
+}
+
+function NotAChamber({ chainId }: { chainId: number }) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
+      <FiAlertTriangle className="w-12 h-12 text-red-400" />
+      <h2 className="font-heading text-xl font-bold text-slate-100">Not a Chamber</h2>
+      <p className="text-slate-400 max-w-md">
+        This address does not look like a Chamber contract on{' '}
+        <strong className="text-slate-200">{getNetworkName(chainId)}</strong>.
+      </p>
+      <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
+    </div>
+  )
+}
+
+export function WrongNetworkPanel({
+  currentChainId,
+  supportedChainIds,
+  targetChainId,
+  reason,
+}: Extract<ChamberRouteDecision, { status: 'wrong-network' }>) {
+  const { isConnected } = useAccount()
+  const { switchChainAsync, isPending } = useSwitchChain()
+  const { openChainModal } = useChainModal()
+
+  const currentName = getNetworkName(currentChainId)
+  const supportedNames = supportedChainIds.map((id) => getNetworkName(id))
+  const targetId =
+    targetChainId ?? (supportedChainIds.length === 1 ? supportedChainIds[0] : undefined)
+  const targetName = targetId != null ? getNetworkName(targetId) : undefined
+
+  const onSwitch = async () => {
+    if (targetId && isConnected && switchChainAsync) {
+      try {
+        await switchChainAsync({ chainId: targetId })
+        return
+      } catch {
+        openChainModal?.()
+        return
+      }
+    }
+    openChainModal?.()
+  }
+
+  const canSwitch = Boolean((targetId && isConnected) || openChainModal)
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-64 px-4">
+      <div className="panel w-full max-w-lg p-8 text-center">
+        <div className="w-12 h-12 rounded-2xl bg-amber-500/10 border border-amber-500/25 flex items-center justify-center mx-auto mb-5">
+          <FiAlertTriangle className="w-6 h-6 text-amber-400" aria-hidden />
+        </div>
+        <h2 className="font-heading text-xl font-bold text-slate-100">Wrong network</h2>
+        <div className="mt-3 space-y-3 text-sm text-slate-400 leading-relaxed">
+          <p>
+            You&apos;re connected to{' '}
+            <strong className="text-slate-200">{currentName}</strong>
+            {currentChainId !== 31337 ? (
+              <>
+                {' '}
+                <span className="text-slate-500">(Chain ID: {currentChainId})</span>
+              </>
+            ) : null}
+            .
+          </p>
+          {reason === 'chamber-on-other-chain' && targetName ? (
+            <p>
+              This address is a Chamber on{' '}
+              <strong className="text-slate-200">{targetName}</strong>. Switch networks to
+              keep this deep link.
+            </p>
+          ) : currentChainId === 1 && !isMainnetConfigured ? (
+            <p>
+              This deployment does not include <strong className="text-slate-200">Ethereum mainnet</strong>.
+              Use your wallet to switch to <strong className="text-slate-200">Sepolia</strong>
+              {supportedNames.filter((name) => name !== 'Sepolia').length > 0
+                ? ' (or another supported network)'
+                : ''}
+              .
+            </p>
+          ) : (
+            <p>
+              No Factory or Registry address configured for{' '}
+              <strong className="text-slate-200">{currentName}</strong>.
+              {currentChainId === 31337 ? (
+                <>
+                  {' '}
+                  Deploy contracts to Anvil and set{' '}
+                  <code className="text-accent-400">VITE_LOCALHOST_FACTORY</code> or{' '}
+                  <code className="text-accent-400">VITE_LOCALHOST_REGISTRY</code>, or switch
+                  to a supported network.
+                </>
+              ) : null}
+            </p>
+          )}
+          {supportedNames.length > 0 && (
+            <p className="text-slate-500">
+              Supported: <span className="text-slate-300">{supportedNames.join(', ')}</span>
+            </p>
+          )}
+        </div>
+        <div className="mt-6 flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3">
+          {canSwitch ? (
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => void onSwitch()}
+              disabled={isPending}
+            >
+              {isPending ? (
+                <FiLoader className="w-4 h-4 animate-spin" aria-hidden />
+              ) : (
+                <FiRefreshCw className="w-4 h-4" aria-hidden />
+              )}
+              {targetName ? `Switch to ${targetName}` : 'Switch network'}
+            </button>
+          ) : null}
+          <Link to="/" className={canSwitch ? 'btn btn-secondary' : 'btn btn-primary'}>
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ChamberRouteGate({
+  address,
+  children,
+}: {
+  address: string | undefined
+  children: (chamberAddress: `0x${string}`) => ReactNode
+}) {
+  const chainId = useChainId()
+  const validAddress = !!address && isAddress(address)
+  const chamberAddr = validAddress ? (address as `0x${string}`) : undefined
+  const decision = useChamberRouteDecision(chamberAddr)
+
+  if (!validAddress || decision.status === 'invalid-address') {
+    return <InvalidChamberAddress />
+  }
+  if (decision.status === 'wrong-network') {
+    return <WrongNetworkPanel {...decision} />
+  }
+  if (decision.status === 'loading') {
+    return <VerifyingChamber />
+  }
+  if (decision.status === 'not-chamber') {
+    return <NotAChamber chainId={chainId} />
+  }
+  return <>{children(chamberAddr!)}</>
+}

--- a/app/src/components/ChamberRouteGate.tsx
+++ b/app/src/components/ChamberRouteGate.tsx
@@ -76,7 +76,11 @@ export function WrongNetworkPanel({
         return
       }
     }
-    openChainModal?.() ?? openConnectModal?.()
+    if (openChainModal) {
+      openChainModal()
+      return
+    }
+    openConnectModal?.()
   }
 
   const canSwitch = Boolean(

--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Layout } from './Layout'
+export { ChamberRouteGate, WrongNetworkPanel } from './ChamberRouteGate'
 export { default as ChamberCard } from './ChamberCard'
 export { default as BoardVisualization } from './BoardVisualization'
 export { default as TreasuryOverview } from './TreasuryOverview'

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useChamber'
 export * from './useRegistry'
+export * from './useChamberRouteGate'
 export * from './useMyChambers'
 export * from './useTransactionStatus'
 export * from './useChamberEvents'

--- a/app/src/hooks/useChamberRouteGate.ts
+++ b/app/src/hooks/useChamberRouteGate.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPublicClient } from 'wagmi/actions'
+import { useChainId } from 'wagmi'
+import type { PublicClient } from 'viem'
+import { chamberAbi, registryAbi } from '@/contracts/abis'
+import { classifyChamberRoute, type ChamberRouteDecision } from '@/lib/chamberRoute'
+import {
+  config,
+  getConfiguredChainIds,
+  getContractAddresses,
+  hasValidAddresses,
+  isNonZeroAddress,
+} from '@/lib/wagmi'
+import { useIsChamber } from './useRegistry'
+
+async function probeLooksLikeChamber(
+  client: PublicClient,
+  address: `0x${string}`,
+  chainId: number,
+): Promise<boolean> {
+  const results = await Promise.allSettled([
+    client.readContract({ address, abi: chamberAbi, functionName: 'VERSION' }),
+    client.readContract({ address, abi: chamberAbi, functionName: 'nft' }),
+    client.readContract({ address, abi: chamberAbi, functionName: 'getSeats' }),
+  ])
+  if (results.some((r) => r.status === 'fulfilled' && r.value !== undefined)) return true
+
+  const registry = getContractAddresses(chainId)?.registry
+  if (!isNonZeroAddress(registry)) return false
+  try {
+    const hint = await client.readContract({
+      address: registry,
+      abi: registryAbi,
+      functionName: 'isChamber',
+      args: [address],
+    })
+    return hint === true
+  } catch {
+    return false
+  }
+}
+
+function useChamberOnOtherConfiguredChain(
+  address: `0x${string}` | undefined,
+  enabled: boolean,
+) {
+  const chainId = useChainId()
+  const otherIds = getConfiguredChainIds().filter((id) => id !== chainId)
+
+  return useQuery({
+    queryKey: ['chamber-on-other-configured-chain', address, chainId, otherIds],
+    enabled: !!address && enabled && otherIds.length > 0,
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!address) return null
+      for (const id of otherIds) {
+        const client = getPublicClient(config, { chainId: id })
+        if (!client) continue
+        try {
+          if (await probeLooksLikeChamber(client, address, id)) return id
+        } catch {
+          // RPC down or chain unused in this environment — try the next configured chain.
+        }
+      }
+      return null
+    },
+  })
+}
+
+export function useChamberRouteDecision(
+  address: `0x${string}` | undefined,
+): ChamberRouteDecision {
+  const chainId = useChainId()
+  const configValid = hasValidAddresses(chainId)
+  const supportedChainIds = getConfiguredChainIds()
+  const isChamber = useIsChamber(address, { enabled: configValid })
+  const otherConfigured = supportedChainIds.filter((id) => id !== chainId)
+  const shouldProbeOthers = configValid && isChamber === false && otherConfigured.length > 0
+  const { data: foundOnOtherChainId, isFetched } = useChamberOnOtherConfiguredChain(
+    address,
+    shouldProbeOthers,
+  )
+
+  return classifyChamberRoute({
+    hasAddress: !!address,
+    currentChainId: chainId,
+    configValid,
+    supportedChainIds,
+    isChamber: configValid ? isChamber : undefined,
+    foundOnOtherChainId: shouldProbeOthers
+      ? isFetched
+        ? (foundOnOtherChainId ?? null)
+        : undefined
+      : null,
+  })
+}

--- a/app/src/hooks/useRegistry.ts
+++ b/app/src/hooks/useRegistry.ts
@@ -163,9 +163,13 @@ export function useChamberCount() {
  * Probe the address (`VERSION` / `nft` / `getSeats`) instead of requiring Registry.isChamber.
  * Registry.isChamber remains a soft hint for chambers that are still in the deprecated index.
  */
-export function useIsChamber(address: `0x${string}` | undefined) {
+export function useIsChamber(
+  address: `0x${string}` | undefined,
+  opts?: { enabled?: boolean },
+) {
   const registryAddress = useRegistryAddress()
   const registryOk = isNonZeroAddress(registryAddress)
+  const enabled = (opts?.enabled ?? true) && !!address
 
   const {
     data: probe,
@@ -179,7 +183,7 @@ export function useIsChamber(address: `0x${string}` | undefined) {
           { address, abi: chamberAbi, functionName: 'getSeats' as const },
         ]
       : [],
-    query: { enabled: !!address, retry: 1 },
+    query: { enabled, retry: 1 },
   })
 
   const { data: registryHint, isFetched: hintFetched } = useReadContract({
@@ -187,10 +191,10 @@ export function useIsChamber(address: `0x${string}` | undefined) {
     abi: registryAbi,
     functionName: 'isChamber',
     args: address ? [address] : undefined,
-    query: { enabled: !!address && registryOk },
+    query: { enabled: enabled && registryOk },
   })
 
-  if (!address) return undefined
+  if (!address || !enabled) return undefined
 
   const looksLikeChamber = !!probe?.some((r) => r.status === 'success' && r.result !== undefined)
   if (looksLikeChamber) return true

--- a/app/src/lib/chamberRoute.ts
+++ b/app/src/lib/chamberRoute.ts
@@ -1,0 +1,73 @@
+export type ChamberRouteDecision =
+  | { status: 'invalid-address' }
+  | { status: 'loading' }
+  | { status: 'ready' }
+  | { status: 'not-chamber' }
+  | {
+      status: 'wrong-network'
+      reason: 'unconfigured' | 'chamber-on-other-chain'
+      currentChainId: number
+      supportedChainIds: number[]
+      targetChainId?: number
+    }
+
+/**
+ * Decide chamber-route chrome before treating a failed probe as “Not a Chamber”.
+ * Unconfigured chains win immediately. Other configured chains are probed only
+ * after the active-chain probe fails.
+ */
+export function classifyChamberRoute(input: {
+  hasAddress: boolean
+  currentChainId: number
+  configValid: boolean
+  supportedChainIds: number[]
+  isChamber: boolean | undefined
+  foundOnOtherChainId: number | null | undefined
+}): ChamberRouteDecision {
+  const {
+    hasAddress,
+    currentChainId,
+    configValid,
+    supportedChainIds,
+    isChamber,
+    foundOnOtherChainId,
+  } = input
+
+  if (!hasAddress) return { status: 'invalid-address' }
+
+  if (!configValid) {
+    const sepoliaId = 11_155_111
+    const preferred =
+      supportedChainIds.includes(sepoliaId)
+        ? sepoliaId
+        : supportedChainIds.length === 1
+          ? supportedChainIds[0]
+          : undefined
+    return {
+      status: 'wrong-network',
+      reason: 'unconfigured',
+      currentChainId,
+      supportedChainIds,
+      targetChainId: preferred,
+    }
+  }
+
+  if (isChamber === undefined) return { status: 'loading' }
+  if (isChamber) return { status: 'ready' }
+
+  const otherConfigured = supportedChainIds.filter((id) => id !== currentChainId)
+  if (otherConfigured.length > 0) {
+    if (foundOnOtherChainId === undefined) return { status: 'loading' }
+    if (foundOnOtherChainId != null) {
+      return {
+        status: 'wrong-network',
+        reason: 'chamber-on-other-chain',
+        currentChainId,
+        supportedChainIds,
+        targetChainId: foundOnOtherChainId,
+      }
+    }
+  }
+
+  return { status: 'not-chamber' }
+}

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './wagmi'
 export * from './chamberGovernance'
+export * from './chamberRoute'
 export * from './indexer'
 export * from './chamberDiscovery'

--- a/app/src/lib/wagmi.ts
+++ b/app/src/lib/wagmi.ts
@@ -240,3 +240,33 @@ export function hasValidAddresses(chainId: number): boolean {
   if (!addresses) return false
   return isNonZeroAddress(addresses.factory) || isNonZeroAddress(addresses.registry)
 }
+
+/** Display name for wallet/config banners. Matches Dashboard copy. */
+export function getNetworkName(chainId: number): string {
+  switch (chainId) {
+    case 1:
+      return 'Mainnet'
+    case 11155111:
+      return 'Sepolia'
+    case 8453:
+      return 'Base'
+    case 42161:
+      return 'Arbitrum'
+    case 31337:
+      return 'Localhost'
+    default:
+      return config.chains.find((chain) => chain.id === chainId)?.name ?? `Chain ${chainId}`
+  }
+}
+
+/** RainbowKit/wagmi chains that already have a Factory or Registry address. */
+export function getConfiguredChainIds(): number[] {
+  const seen = new Set<number>()
+  const ids: number[] = []
+  for (const chain of config.chains) {
+    if (seen.has(chain.id) || !hasValidAddresses(chain.id)) continue
+    seen.add(chain.id)
+    ids.push(chain.id)
+  }
+  return ids
+}

--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAccount, useBalance, useReadContract, useReadContracts, useChainId } from 'wagmi'
-import { formatUnits, isAddress, zeroAddress } from 'viem'
+import { formatUnits, zeroAddress } from 'viem'
 import { erc20Abi } from '@/contracts'
 import { chamberAbi } from '@/contracts/abis'
 import {
@@ -19,7 +19,6 @@ import {
   FiCheck,
   FiStar,
   FiAlertTriangle,
-  FiLoader,
   FiUpload,
 } from 'react-icons/fi'
 import toast from 'react-hot-toast'
@@ -34,7 +33,6 @@ import {
   useChambersByAsset,
   useParentChamber,
   useChildChambers,
-  useIsChamber,
   useNftImageMap,
   useChamberRegistryImplementationSync,
   useDirectorActionGate,
@@ -46,6 +44,7 @@ import DelegationManager from '@/components/DelegationManager'
 import SeatTheBoard from '@/components/SeatTheBoard'
 import ChamberAssetsAlchemy from '@/components/ChamberAssetsAlchemy'
 import { NftRetryableImage } from '@/components/NftRetryableImage'
+import { ChamberRouteGate } from '@/components/ChamberRouteGate'
 import { addRecentChamber } from '@/lib/recentChambers'
 import { getBlockExplorerAddressUrl, shortenAddress } from '@/lib/utils'
 import type { SeatUpdate } from '@/types'
@@ -56,42 +55,11 @@ const validTabs: Tab[] = ['overview', 'board', 'staking', 'delegation']
 
 export default function ChamberDetail() {
   const { address } = useParams<{ address: string; tab?: string }>()
-  const validAddress = address && isAddress(address)
-  const chamberAddr = validAddress ? (address as `0x${string}`) : undefined
-  const isChamber = useIsChamber(chamberAddr)
-
-  if (!validAddress) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiAlertTriangle className="w-12 h-12 text-red-400" />
-        <h2 className="font-heading text-xl font-bold text-slate-100">Invalid Address</h2>
-        <p className="text-slate-400">The address in this URL is not a valid Ethereum address.</p>
-        <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
-      </div>
-    )
-  }
-
-  if (isChamber === undefined) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiLoader className="w-10 h-10 text-accent-400 animate-spin" />
-        <p className="text-slate-400 text-sm">Verifying chamber…</p>
-      </div>
-    )
-  }
-
-  if (isChamber === false) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiAlertTriangle className="w-12 h-12 text-red-400" />
-        <h2 className="font-heading text-xl font-bold text-slate-100">Not a Chamber</h2>
-        <p className="text-slate-400">This address does not look like a Chamber contract.</p>
-        <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
-      </div>
-    )
-  }
-
-  return <ChamberDetailContent chamberAddress={chamberAddr!} />
+  return (
+    <ChamberRouteGate address={address}>
+      {(chamberAddress) => <ChamberDetailContent chamberAddress={chamberAddress} />}
+    </ChamberRouteGate>
+  )
 }
 
 function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}` }) {

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { formatUnits, isAddress } from 'viem'
 import { FiLayers, FiPlus, FiAlertTriangle, FiUser, FiBriefcase, FiShield, FiArrowRight } from 'react-icons/fi'
 import { useHasValidConfig, useMyChambers, useOrganizationsByNFT } from '@/hooks'
 import { erc721Abi } from '@/contracts'
-import { isMainnetConfigured } from '@/lib/wagmi'
+import { getNetworkName, isMainnetConfigured } from '@/lib/wagmi'
 import ChamberCard from '@/components/ChamberCard'
 
 export default function Dashboard() {
@@ -37,15 +37,6 @@ export default function Dashboard() {
       refetchMine()
     }
   }, [location.pathname, refetchMine])
-
-  const getNetworkName = (id: number) => {
-    switch (id) {
-      case 1: return 'Mainnet'
-      case 11155111: return 'Sepolia'
-      case 31337: return 'Localhost'
-      default: return `Chain ${id}`
-    }
-  }
 
   const handleOpenAddress = (e: React.FormEvent) => {
     e.preventDefault()

--- a/app/src/pages/DirectorProfile.tsx
+++ b/app/src/pages/DirectorProfile.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAccount, useReadContract, useReadContracts, useChainId, usePublicClient } from 'wagmi'
 import { useQuery } from '@tanstack/react-query'
-import { formatEther, formatUnits, isAddress, parseAbiItem, zeroAddress } from 'viem'
+import { formatEther, formatUnits, parseAbiItem, zeroAddress } from 'viem'
 import {
   FiArrowLeft,
   FiShield,
@@ -25,6 +25,7 @@ import { chamberAbi, erc721Abi } from '@/contracts/abis'
 import { useChamberInfo, useBoardMembers, useNftTokenImage } from '@/hooks'
 import { getBlockExplorerAddressUrl } from '@/lib/utils'
 import { NftRetryableImage } from '@/components/NftRetryableImage'
+import { ChamberRouteGate } from '@/components/ChamberRouteGate'
 
 // Minimal generated-abi event fragments for log queries
 const SUBMIT_TX_EVENT = parseAbiItem('event SubmitTransaction(uint256 indexed tokenId, uint256 indexed nonce, address indexed to, uint256 value, bytes data)')
@@ -139,12 +140,25 @@ function ActivityRow({ action, nonce, detail, href }: {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function DirectorProfile() {
-  const { address, tokenId: tokenIdParam } = useParams<{ address: string; tokenId: string }>()
+  const { address, tokenId } = useParams<{ address: string; tokenId: string }>()
+  return (
+    <ChamberRouteGate address={address}>
+      {(chamberAddress) => (
+        <DirectorProfileContent chamberAddress={chamberAddress} tokenIdParam={tokenId} />
+      )}
+    </ChamberRouteGate>
+  )
+}
+
+function DirectorProfileContent({
+  chamberAddress,
+  tokenIdParam,
+}: {
+  chamberAddress: `0x${string}`
+  tokenIdParam: string | undefined
+}) {
   const { address: userAddress } = useAccount()
   const chainId = useChainId()
-
-  const validAddress = address && isAddress(address)
-  const chamberAddress = (validAddress ? address : zeroAddress) as `0x${string}`
   const tokenId = useMemo(() => {
     try { return tokenIdParam ? BigInt(tokenIdParam) : 0n } catch { return 0n }
   }, [tokenIdParam])
@@ -159,7 +173,7 @@ export default function DirectorProfile() {
     abi: chamberAbi,
     functionName: 'getMember',
     args: [tokenId],
-    query: { enabled: tokenId > 0n && !!validAddress },
+    query: { enabled: tokenId > 0n },
   })
 
   // NFT owner
@@ -197,7 +211,7 @@ export default function DirectorProfile() {
       functionName: 'getConfirmation' as const,
       args: [tokenId, BigInt(id)],
     })),
-    query: { enabled: tokenId > 0n && txIds.length > 0 && !!validAddress },
+    query: { enabled: tokenId > 0n && txIds.length > 0 },
   })
 
   // Log-based activity (events filtered by tokenId)
@@ -239,12 +253,12 @@ export default function DirectorProfile() {
   }, [logs])
 
   // Guards
-  if (!validAddress || tokenId === 0n) {
+  if (tokenId === 0n) {
     return (
       <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
         <FiAlertTriangle className="w-12 h-12 text-red-400" />
         <h2 className="font-heading text-xl font-bold text-slate-100">Invalid URL</h2>
-        <p className="text-slate-400">Chamber address or token ID is missing.</p>
+        <p className="text-slate-400">Token ID is missing.</p>
         <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
       </div>
     )

--- a/app/src/pages/TransactionQueue.tsx
+++ b/app/src/pages/TransactionQueue.tsx
@@ -33,7 +33,6 @@ import {
   useTransactionCancelConfirmation,
   useChamberEvents,
   useReceiptRefresh,
-  useIsChamber,
   useSeatUpdate,
   useUpdateSeats,
   useExecuteSeatsUpdate,
@@ -55,6 +54,7 @@ import {
   hasProposalCalldata,
   shortenAddress,
 } from '@/lib/utils'
+import { ChamberRouteGate } from '@/components/ChamberRouteGate'
 import { DirectorCallerStatus } from '@/components/DirectorCallerStatus'
 import {
   UPGRADE_SELECTOR,
@@ -257,42 +257,11 @@ function classifyTransactionRiskFromDataHash(
 
 export default function TransactionQueue() {
   const { address } = useParams<{ address: string }>()
-  const validAddress = address && isAddress(address)
-  const chamberAddr = validAddress ? (address as `0x${string}`) : undefined
-  const isChamber = useIsChamber(chamberAddr)
-
-  if (!validAddress) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiAlertCircle className="w-12 h-12 text-red-400" />
-        <h2 className="font-heading text-xl font-bold text-slate-100">Invalid Address</h2>
-        <p className="text-slate-400">The address in this URL is not a valid Ethereum address.</p>
-        <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
-      </div>
-    )
-  }
-
-  if (isChamber === undefined) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiLoader className="w-10 h-10 text-accent-400 animate-spin" />
-        <p className="text-slate-400 text-sm">Verifying chamber…</p>
-      </div>
-    )
-  }
-
-  if (isChamber === false) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-64 gap-4 text-center">
-        <FiAlertCircle className="w-12 h-12 text-red-400" />
-        <h2 className="font-heading text-xl font-bold text-slate-100">Not a Chamber</h2>
-        <p className="text-slate-400">This address does not look like a Chamber contract.</p>
-        <Link to="/" className="btn btn-primary">Back to Dashboard</Link>
-      </div>
-    )
-  }
-
-  return <TransactionQueueContent chamberAddress={chamberAddr!} />
+  return (
+    <ChamberRouteGate address={address}>
+      {(chamberAddress) => <TransactionQueueContent chamberAddress={chamberAddress} />}
+    </ChamberRouteGate>
+  )
 }
 
 function TransactionQueueContent({ chamberAddress }: { chamberAddress: `0x${string}` }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #228.

Chamber deep links (`/chamber/:address` and staking / delegation / board / transactions / director children) treated a failed `useIsChamber` probe as **Not a Chamber**. The probe only runs on the wallet’s active chain, so a chain mismatch looked like an invalid contract and offered no switch path.

## What changed
- Shared `ChamberRouteGate` on those routes.
- If the connected chain has no Factory/Registry (`hasValidAddresses`) — including Mainnet when it is not configured — show a **Wrong network** panel (current chain name + supported options).
- If the address is a Chamber on another *already configured* chain, show the same panel targeting that chain. No invented mainnet/factory addresses.
- Primary CTA: RainbowKit/wagmi **Switch to {network}** (connect modal if disconnected; `switchChain` / chain modal once connected). Secondary: Back to Dashboard.
- After a successful switch the same URL re-probes and the chamber loads.
- Genuine misses on a configured chain still show **Not a Chamber**, now naming the active network.

## How to test
1. **Wrong chain (unconfigured):** Connect a wallet on Mainnet (or Base/Arbitrum in a dev build) while only Sepolia has addresses. Open `/chamber/<valid-sepolia-chamber>`. Expect **Wrong network** (Sepolia in the supported list + Switch), not “Not a Chamber”. Switch networks — the same URL should load the chamber.
2. **Wrong chain (configured elsewhere):** With two configured chains, open an address that is a Chamber only on the other one. Expect **Wrong network** naming that chain.
3. **Correct chain, not a chamber:** On Sepolia, open `/chamber/0x000000000000000000000000000000000000dEaD`. Expect **Not a Chamber** on Sepolia.
4. **Correct chain, real chamber:** Open a known Sepolia chamber. Overview / staking / delegation / board / transactions / director tabs still work.
5. **Invalid URL:** `/chamber/not-an-address` still shows Invalid Address.

## Verified in this PR
- Invalid address, Not a Chamber (dead address on Sepolia), Wrong network panel + Switch → RainbowKit connect, and Loreum DAO deep link + staking tab after the gate.
- Offline classifier: `cd app && npx tsx --tsconfig tsconfig.json scripts/verify-chamber-route-gate.ts`
- `tsc` and eslint pass on the touched app files (pre-existing TransactionQueue lint is unchanged).

![Wrong network panel with Switch network and Back to Dashboard](https://cursor.com/artifacts/c/art-785a9798-6d65-454f-858d-9caa96bb3d0b)
![Not a Chamber on Sepolia for a non-chamber address](https://cursor.com/artifacts/c/art-57a28cee-78ba-4474-9bda-a10a2abaa2fd)
![Loreum DAO chamber still loads on the correct chain](https://cursor.com/artifacts/c/art-d4849bf4-a6fb-4fff-b3d0-12c1882ad1ac)
<a href="https://cursor.com/agents/bc-b4a0e6c0-9370-43ec-ac3b-5a20df19907c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchamber_wrong_network_vs_not_a_chamber.mp4"><img src="https://cursor.com/artifacts/c/art-941bdf8c-9a8e-4313-9825-a838f620a9b9" alt="chamber_wrong_network_vs_not_a_chamber.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4a0e6c0-9370-43ec-ac3b-5a20df19907c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4a0e6c0-9370-43ec-ac3b-5a20df19907c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

