### PR TITLE
fix(app): gate Overview upgrade CTAs on seated director

### DIFF
--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -237,6 +237,17 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
 
   const upgradeProposalHref = `/chamber/${chamberAddress}/transactions?proposal=upgrade`
 
+  const copyUpgradeProposalLink = () => {
+    const url = new URL(upgradeProposalHref, window.location.origin).href
+    void navigator.clipboard.writeText(url).then(
+      () => toast.success('Upgrade proposal link copied'),
+      () => toast.error('Could not copy link'),
+    )
+  }
+
+  const showImplMismatch =
+    implSync.implMismatch && !implSync.isLoading && !!implSync.registryImplementation
+
   return (
     <div className="space-y-6">
       {chamberInfo.paused && (
@@ -263,7 +274,7 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
           </div>
         </motion.div>
       )}
-      {implSync.implMismatch && !implSync.isLoading && implSync.registryImplementation && (
+      {showImplMismatch && (
         <motion.div
           initial={{ opacity: 0, y: -6 }}
           animate={{ opacity: 1, y: 0 }}
@@ -305,12 +316,36 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
                   View Registry <FiExternalLink className="w-3.5 h-3.5" aria-hidden />
                 </a>
               )}
-              <div className="flex flex-wrap gap-2 mt-4">
-                <Link to={upgradeProposalHref} className="btn btn-primary inline-flex gap-2 shrink-0">
-                  <FiUpload className="w-4 h-4" aria-hidden />
-                  Propose upgrade
-                </Link>
-              </div>
+              {directorGate.canAct ? (
+                <div className="flex flex-wrap gap-2 mt-4">
+                  <Link to={upgradeProposalHref} className="btn btn-primary inline-flex gap-2 shrink-0">
+                    <FiUpload className="w-4 h-4" aria-hidden />
+                    Propose upgrade
+                  </Link>
+                </div>
+              ) : directorGate.seatingPending ? (
+                <p className="mt-4 text-amber-100/90 leading-relaxed">
+                  You hold a live board seat, but director actions unlock at block{' '}
+                  {directorGate.seatedAt?.toString() ?? '…'}.
+                </p>
+              ) : (
+                <div className="mt-4 space-y-2">
+                  <p className="text-amber-100/85 leading-relaxed">
+                    Ask a director to open this link (with{' '}
+                    <span className="font-mono">?proposal=upgrade</span>
+                    ), review the prefilled multisig proposal, then submit.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={copyUpgradeProposalLink}
+                    className="btn btn-secondary inline-flex gap-2 shrink-0"
+                    title="Copy upgrade proposal link"
+                  >
+                    <FiCopy className="w-4 h-4" aria-hidden />
+                    Ask a director
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         </motion.div>
@@ -363,12 +398,6 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
-            {implSync.implMismatch && implSync.registryImplementation && (
-              <Link to={upgradeProposalHref} className="btn btn-primary gap-2">
-                <FiUpload className="w-4 h-4" aria-hidden />
-                Upgrade
-              </Link>
-            )}
             <Link
               to={`/chamber/${chamberAddress}/transactions`}
               className="btn btn-secondary relative"

--- a/app/src/pages/ChamberDetail.tsx
+++ b/app/src/pages/ChamberDetail.tsx
@@ -245,8 +245,9 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
     )
   }
 
+  const registryImplementation = implSync.registryImplementation
   const showImplMismatch =
-    implSync.implMismatch && !implSync.isLoading && !!implSync.registryImplementation
+    implSync.implMismatch && !implSync.isLoading && !!registryImplementation
 
   return (
     <div className="space-y-6">
@@ -274,7 +275,7 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
           </div>
         </motion.div>
       )}
-      {showImplMismatch && (
+      {showImplMismatch && registryImplementation && (
         <motion.div
           initial={{ opacity: 0, y: -6 }}
           animate={{ opacity: 1, y: 0 }}
@@ -290,7 +291,7 @@ function ChamberDetailContent({ chamberAddress }: { chamberAddress: `0x${string}
                 <span className="font-mono tabular-nums">
                   v{implSync.registryImplementationVersionLabel ?? '—'}
                 </span>{' '}
-                ({shortenAddress(implSync.registryImplementation, 6)}
+                ({shortenAddress(registryImplementation, 6)}
                 ). This chamber proxy still uses{' '}
                 <span className="font-mono tabular-nums">
                   {chamberVersionTag === '…' ? '—' : chamberVersionTag}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #232.

Overview advertised **Propose upgrade** (mismatch banner) and **Upgrade** (header) as `btn-primary` for any visitor when `implSync.implMismatch`. Queue already gates New Proposal on `useDirectorActionGate.canAct`. This matches that gate on `/chamber/:address` and drops the second primary next to Transactions.

## Changes
- Single upgrade control lives in the impl-mismatch banner (header **Upgrade** removed).
- **Director (`canAct`):** primary **Propose upgrade** → `/transactions?proposal=upgrade`.
- **Seated but immature (`seatingPending`):** no primary; copy matches Queue (“director actions unlock at block …”).
- **Non-director:** Queue-style “Ask a director” sentence plus secondary **Ask a director** that copies the same `?proposal=upgrade` link. No invented addresses.

## Test notes (director vs non-director)

| Role | Upgrade control | Header |
| --- | --- | --- |
| Non-director / disconnected | Secondary **Ask a director** copies `{origin}/chamber/{address}/transactions?proposal=upgrade` | **Transactions** only — no Upgrade |
| Director (`canAct`) | One primary **Propose upgrade** in the banner | **Transactions** only |
| Seating-pending | Banner copy: unlock at `getSeatedAt` block; no primary | **Transactions** only |
| No impl mismatch | No upgrade banner / CTAs | **Transactions** unchanged |

### Verified in this PR (browser, disconnected = non-director)
Sepolia Registry leftover (v1.1.4 proxy vs Factory/Registry v1.1.5): `0xe68EED02C7d0455368E429051Ef5BfAb77022589` (from on-chain `ChamberCreated` on committed Registry `0x7AECf59e…`, not invented).

- Banner: Ask a director (`btn-secondary`); no **Propose upgrade**.
- Header: **Transactions** only.
- Copy link: `http://localhost:5173/chamber/0xe68EED02C7d0455368E429051Ef5BfAb77022589/transactions?proposal=upgrade`.
- ~375px: same gating; no primary Upgrade.
- Matching-impl Factory chamber `0x441A0D81EA16E01259C766B72Bd7230c7f6fDCeD` (v1.1.5): no banner, no upgrade CTAs.

Director `canAct` and seating-pending were not live-wallet tested here (no seated director session in the agent browser). Those branches follow Queue’s `useDirectorActionGate` the same way.

`tsc --noEmit` and eslint on `ChamberDetail.tsx` passed. Forge CI on the branch is green.

![Non-director mismatch banner with secondary Ask a director and Transactions only](https://cursor.com/artifacts/c/art-8c89f5f4-f8d5-4168-8a7d-669dbb247ce9)
![Non-director mobile 375px: Ask a director secondary, no header Upgrade](https://cursor.com/artifacts/c/art-05dfad43-b32a-4c28-beaa-9445da921cb4)
![Matching-impl chamber: no upgrade banner or CTA](https://cursor.com/artifacts/c/art-b683ec80-9708-4a49-aded-0b8d278beea6)

<a href="https://cursor.com/agents/bc-e5c92b5a-5c3b-46bb-9f38-9243d62813d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview_upgrade_cta_non_director.mp4"><img src="https://cursor.com/artifacts/c/art-9f398940-d264-4f2a-a5a4-a7d048828b8f" alt="overview_upgrade_cta_non_director.mp4" /></a>

Do not merge. Do not invent mainnet addresses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c92b5a-5c3b-46bb-9f38-9243d62813d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c92b5a-5c3b-46bb-9f38-9243d62813d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

