### PR TITLE
fix(app): add Switch network CTA on Dashboard mainnet banner

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test:discovery": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-route-gate.ts"
+    "test:discovery": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts && npx --yes tsx --tsconfig tsconfig.json scripts/verify-chamber-route-gate.ts",
+    "test:mainnet-banner": "npx --yes tsx --tsconfig tsconfig.json scripts/verify-mainnet-unsupported-banner.ts"
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.1.0",

--- a/app/scripts/verify-mainnet-unsupported-banner.ts
+++ b/app/scripts/verify-mainnet-unsupported-banner.ts
@@ -1,0 +1,60 @@
+/**
+ * Offline checks for Dashboard mainnet-unsupported banner (#233).
+ * Run: npx tsx --tsconfig tsconfig.json scripts/verify-mainnet-unsupported-banner.ts
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  getNetworkName,
+  pickPreferredSupportedChainId,
+  SEPOLIA_CHAIN_ID,
+  showMainnetUnsupportedBanner,
+  switchToSupportedChainLabel,
+} from '../src/lib/supportedChain.ts'
+
+function testBannerVisibility() {
+  assert.equal(showMainnetUnsupportedBanner(1, false), true)
+  assert.equal(showMainnetUnsupportedBanner(1, true), false)
+  assert.equal(showMainnetUnsupportedBanner(SEPOLIA_CHAIN_ID, false), false)
+  assert.equal(showMainnetUnsupportedBanner(31337, false), false)
+}
+
+function testPrefersSepoliaThenFirstConfigured() {
+  assert.equal(pickPreferredSupportedChainId([SEPOLIA_CHAIN_ID, 31337]), SEPOLIA_CHAIN_ID)
+  assert.equal(pickPreferredSupportedChainId([31337, SEPOLIA_CHAIN_ID]), SEPOLIA_CHAIN_ID)
+  assert.equal(pickPreferredSupportedChainId([8453, 42161]), 8453)
+  assert.equal(pickPreferredSupportedChainId([]), undefined)
+  // Never invent mainnet as a switch target when it is not in the configured list.
+  assert.notEqual(pickPreferredSupportedChainId([SEPOLIA_CHAIN_ID]), 1)
+}
+
+function testSwitchLabel() {
+  assert.equal(switchToSupportedChainLabel(SEPOLIA_CHAIN_ID), 'Switch to Sepolia')
+  assert.equal(switchToSupportedChainLabel(8453), 'Switch to Base')
+  assert.equal(switchToSupportedChainLabel(undefined), 'Switch network')
+  assert.equal(getNetworkName(1), 'Mainnet')
+}
+
+function testDashboardWiresExistingHelpers() {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const source = readFileSync(join(here, '../src/pages/Dashboard.tsx'), 'utf8')
+  assert.match(source, /useSwitchChain/)
+  assert.match(source, /useChainModal/)
+  assert.match(source, /getPreferredSupportedChainId/)
+  assert.match(source, /switchToSupportedChainLabel/)
+  assert.match(source, /showMainnetUnsupportedBanner/)
+  assert.match(source, /btn btn-primary/)
+  assert.doesNotMatch(source, /VITE_MAINNET_FACTORY=0x[0-9a-fA-F]{40}/)
+  assert.doesNotMatch(
+    source,
+    /This deployment does not include[\s\S]*0x[0-9a-fA-F]{40}/,
+  )
+}
+
+testBannerVisibility()
+testPrefersSepoliaThenFirstConfigured()
+testSwitchLabel()
+testDashboardWiresExistingHelpers()
+console.log('verify-mainnet-unsupported-banner: ok')

--- a/app/scripts/verify-mainnet-unsupported-banner.ts
+++ b/app/scripts/verify-mainnet-unsupported-banner.ts
@@ -59,6 +59,7 @@ function testDashboardWiresExistingHelpers() {
   const source = readFileSync(join(here, '../src/pages/Dashboard.tsx'), 'utf8')
   assert.match(source, /useSwitchChain/)
   assert.match(source, /useChainModal/)
+  assert.match(source, /useConnectModal/)
   assert.match(source, /getPreferredSupportedChainId/)
   assert.match(source, /switchToSupportedChainLabel/)
   assert.match(source, /showMainnetUnsupportedBanner/)

--- a/app/scripts/verify-mainnet-unsupported-banner.ts
+++ b/app/scripts/verify-mainnet-unsupported-banner.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url'
 import {
   getNetworkName,
   pickPreferredSupportedChainId,
+  readSimulatedChainId,
   SEPOLIA_CHAIN_ID,
   showMainnetUnsupportedBanner,
   switchToSupportedChainLabel,
@@ -30,11 +31,27 @@ function testPrefersSepoliaThenFirstConfigured() {
   assert.notEqual(pickPreferredSupportedChainId([SEPOLIA_CHAIN_ID]), 1)
 }
 
+function testDevSimulateChainId() {
+  assert.equal(readSimulatedChainId('?simulateChainId=1', true), 1)
+  assert.equal(readSimulatedChainId('simulateChainId=1', true), 1)
+  assert.equal(readSimulatedChainId('?simulateChainId=1', false), undefined)
+  assert.equal(readSimulatedChainId('?foo=1', true), undefined)
+  assert.equal(showMainnetUnsupportedBanner(readSimulatedChainId('?simulateChainId=1', true) ?? 11155111, false), true)
+}
+
 function testSwitchLabel() {
   assert.equal(switchToSupportedChainLabel(SEPOLIA_CHAIN_ID), 'Switch to Sepolia')
   assert.equal(switchToSupportedChainLabel(8453), 'Switch to Base')
   assert.equal(switchToSupportedChainLabel(undefined), 'Switch network')
   assert.equal(getNetworkName(1), 'Mainnet')
+}
+
+function testNoInventedMainnetEnv() {
+  assert.equal(process.env.VITE_MAINNET_FACTORY ?? '', '')
+  assert.equal(process.env.VITE_MAINNET_REGISTRY ?? '', '')
+  const here = dirname(fileURLToPath(import.meta.url))
+  const sepoliaTxt = readFileSync(join(here, '../../contracts/deployments/sepolia.txt'), 'utf8')
+  assert.match(sepoliaTxt, /^\s*Factory\s+0x[a-fA-F0-9]{40}/m)
 }
 
 function testDashboardWiresExistingHelpers() {
@@ -45,6 +62,7 @@ function testDashboardWiresExistingHelpers() {
   assert.match(source, /getPreferredSupportedChainId/)
   assert.match(source, /switchToSupportedChainLabel/)
   assert.match(source, /showMainnetUnsupportedBanner/)
+  assert.match(source, /readSimulatedChainId/)
   assert.match(source, /btn btn-primary/)
   assert.doesNotMatch(source, /VITE_MAINNET_FACTORY=0x[0-9a-fA-F]{40}/)
   assert.doesNotMatch(
@@ -55,6 +73,8 @@ function testDashboardWiresExistingHelpers() {
 
 testBannerVisibility()
 testPrefersSepoliaThenFirstConfigured()
+testDevSimulateChainId()
 testSwitchLabel()
+testNoInventedMainnetEnv()
 testDashboardWiresExistingHelpers()
 console.log('verify-mainnet-unsupported-banner: ok')

--- a/app/src/lib/supportedChain.ts
+++ b/app/src/lib/supportedChain.ts
@@ -42,3 +42,12 @@ export function showMainnetUnsupportedBanner(
 export function switchToSupportedChainLabel(chainId: number | undefined): string {
   return chainId == null ? 'Switch network' : `Switch to ${getNetworkName(chainId)}`
 }
+
+/** DEV-only `?simulateChainId=1` so the mainnet banner can be exercised without a mainnet wallet. */
+export function readSimulatedChainId(search: string, enabled: boolean): number | undefined {
+  if (!enabled) return undefined
+  const raw = new URLSearchParams(search.startsWith('?') ? search : `?${search}`).get('simulateChainId')
+  if (!raw) return undefined
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : undefined
+}

--- a/app/src/lib/supportedChain.ts
+++ b/app/src/lib/supportedChain.ts
@@ -1,0 +1,44 @@
+/** Sepolia — preferred when a Factory or Registry is already configured. */
+export const SEPOLIA_CHAIN_ID = 11_155_111
+
+/** Display name for wallet/config banners. Does not invent chain metadata. */
+export function getNetworkName(chainId: number, configuredName?: string): string {
+  switch (chainId) {
+    case 1:
+      return 'Mainnet'
+    case SEPOLIA_CHAIN_ID:
+      return 'Sepolia'
+    case 8453:
+      return 'Base'
+    case 42161:
+      return 'Arbitrum'
+    case 31337:
+      return 'Localhost'
+    default:
+      return configuredName ?? `Chain ${chainId}`
+  }
+}
+
+/**
+ * Prefer Sepolia when it is in the configured-and-supported list, otherwise the
+ * first entry. Callers must pass only chains that already have a Factory or
+ * Registry — this does not invent addresses.
+ */
+export function pickPreferredSupportedChainId(
+  configuredSupportedIds: readonly number[],
+  prefer: number = SEPOLIA_CHAIN_ID,
+): number | undefined {
+  if (configuredSupportedIds.includes(prefer)) return prefer
+  return configuredSupportedIds[0]
+}
+
+export function showMainnetUnsupportedBanner(
+  chainId: number,
+  mainnetConfigured: boolean,
+): boolean {
+  return chainId === 1 && !mainnetConfigured
+}
+
+export function switchToSupportedChainLabel(chainId: number | undefined): string {
+  return chainId == null ? 'Switch network' : `Switch to ${getNetworkName(chainId)}`
+}

--- a/app/src/lib/wagmi.ts
+++ b/app/src/lib/wagmi.ts
@@ -5,6 +5,9 @@ import localDeployments from '@/contracts/deployments.json'
 import { alchemySupportsChain, getAlchemyApiKeyFromEnv, getAlchemyV2RpcUrl } from '@/lib/alchemy'
 import { ZERO_ADDRESS, isNonZeroAddress } from '@/lib/address'
 import { sepoliaDeploymentAddresses } from '@/lib/sepoliaDeployments'
+import { getNetworkName as networkNameFromId, pickPreferredSupportedChainId } from '@/lib/supportedChain'
+
+export { pickPreferredSupportedChainId } from '@/lib/supportedChain'
 
 export { isNonZeroAddress, ZERO_ADDRESS }
 
@@ -243,20 +246,7 @@ export function hasValidAddresses(chainId: number): boolean {
 
 /** Display name for wallet/config banners. Matches Dashboard copy. */
 export function getNetworkName(chainId: number): string {
-  switch (chainId) {
-    case 1:
-      return 'Mainnet'
-    case 11155111:
-      return 'Sepolia'
-    case 8453:
-      return 'Base'
-    case 42161:
-      return 'Arbitrum'
-    case 31337:
-      return 'Localhost'
-    default:
-      return config.chains.find((chain) => chain.id === chainId)?.name ?? `Chain ${chainId}`
-  }
+  return networkNameFromId(chainId, config.chains.find((chain) => chain.id === chainId)?.name)
 }
 
 /** RainbowKit/wagmi chains that already have a Factory or Registry address. */
@@ -269,4 +259,12 @@ export function getConfiguredChainIds(): number[] {
     ids.push(chain.id)
   }
   return ids
+}
+
+/**
+ * Prefer Sepolia when it has a Factory or Registry, otherwise the first wagmi
+ * chain that does. Does not invent addresses — only reads configured maps.
+ */
+export function getPreferredSupportedChainId(): number | undefined {
+  return pickPreferredSupportedChainId(getConfiguredChainIds())
 }

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,12 +1,28 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useAccount, useChainId, useReadContracts } from 'wagmi'
+import { useAccount, useChainId, useReadContracts, useSwitchChain } from 'wagmi'
 import { formatUnits, isAddress } from 'viem'
-import { FiLayers, FiPlus, FiAlertTriangle, FiUser, FiBriefcase, FiShield, FiArrowRight } from 'react-icons/fi'
+import { useChainModal } from '@rainbow-me/rainbowkit'
+import {
+  FiLayers,
+  FiPlus,
+  FiAlertTriangle,
+  FiUser,
+  FiBriefcase,
+  FiShield,
+  FiArrowRight,
+  FiRefreshCw,
+  FiLoader,
+} from 'react-icons/fi'
 import { useHasValidConfig, useMyChambers, useOrganizationsByNFT } from '@/hooks'
 import { erc721Abi } from '@/contracts'
-import { getNetworkName, isMainnetConfigured } from '@/lib/wagmi'
+import {
+  getNetworkName,
+  getPreferredSupportedChainId,
+  isMainnetConfigured,
+} from '@/lib/wagmi'
+import { showMainnetUnsupportedBanner, switchToSupportedChainLabel } from '@/lib/supportedChain'
 import ChamberCard from '@/components/ChamberCard'
 
 export default function Dashboard() {
@@ -14,9 +30,15 @@ export default function Dashboard() {
   const location = useLocation()
   const navigate = useNavigate()
   const chainId = useChainId()
+  const { switchChainAsync, isPending: isSwitching } = useSwitchChain()
+  const { openChainModal } = useChainModal()
   const [viewMode, setViewMode] = useState<'mine' | 'organizations'>('mine')
   const [openAddress, setOpenAddress] = useState('')
   const [openError, setOpenError] = useState<string | null>(null)
+  const preferredChainId = getPreferredSupportedChainId()
+  const showUnsupportedMainnet = showMainnetUnsupportedBanner(chainId, isMainnetConfigured)
+  const switchLabel = switchToSupportedChainLabel(preferredChainId)
+  const canSwitch = Boolean((preferredChainId && isConnected) || openChainModal)
 
   const {
     chambers: myChambers,
@@ -38,6 +60,19 @@ export default function Dashboard() {
     }
   }, [location.pathname, refetchMine])
 
+  const handleSwitchToSupportedChain = async () => {
+    if (preferredChainId && isConnected && switchChainAsync) {
+      try {
+        await switchChainAsync({ chainId: preferredChainId })
+        return
+      } catch {
+        openChainModal?.()
+        return
+      }
+    }
+    openChainModal?.()
+  }
+
   const handleOpenAddress = (e: React.FormEvent) => {
     e.preventDefault()
     const value = openAddress.trim()
@@ -52,20 +87,37 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-10">
-      {chainId === 1 && !isMainnetConfigured && (
+      {showUnsupportedMainnet && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
           className="panel p-4 border-slate-600/40 bg-slate-800/20"
         >
-          <p className="text-slate-300 text-sm">
-            This deployment does not include <strong className="text-slate-200">Ethereum mainnet</strong>. Use your
-            wallet to switch to <strong className="text-slate-200">Sepolia</strong> (or another supported network).
-          </p>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <p className="text-slate-300 text-sm">
+              This deployment does not include <strong className="text-slate-200">Ethereum mainnet</strong>. Use your
+              wallet to switch to <strong className="text-slate-200">Sepolia</strong> (or another supported network).
+            </p>
+            {canSwitch ? (
+              <button
+                type="button"
+                className="btn btn-primary shrink-0 self-start sm:self-auto"
+                onClick={() => void handleSwitchToSupportedChain()}
+                disabled={isSwitching}
+              >
+                {isSwitching ? (
+                  <FiLoader className="w-4 h-4 animate-spin" aria-hidden />
+                ) : (
+                  <FiRefreshCw className="w-4 h-4" aria-hidden />
+                )}
+                {isSwitching ? 'Switching…' : switchLabel}
+              </button>
+            ) : null}
+          </div>
         </motion.div>
       )}
 
-      {!isValid && !(chainId === 1 && !isMainnetConfigured) && (
+      {!isValid && !showUnsupportedMainnet && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -66,16 +66,16 @@ export default function Dashboard() {
   }, [location.pathname, refetchMine])
 
   const handleSwitchToSupportedChain = async () => {
-    if (preferredChainId && isConnected && switchChainAsync) {
+    if (!isConnected) {
+      openConnectModal?.()
+      return
+    }
+    if (preferredChainId && switchChainAsync) {
       try {
         await switchChainAsync({ chainId: preferredChainId })
         return
       } catch {
-        if (openChainModal) {
-          openChainModal()
-          return
-        }
-        openConnectModal?.()
+        openChainModal?.()
         return
       }
     }

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -22,7 +22,11 @@ import {
   getPreferredSupportedChainId,
   isMainnetConfigured,
 } from '@/lib/wagmi'
-import { showMainnetUnsupportedBanner, switchToSupportedChainLabel } from '@/lib/supportedChain'
+import {
+  readSimulatedChainId,
+  showMainnetUnsupportedBanner,
+  switchToSupportedChainLabel,
+} from '@/lib/supportedChain'
 import ChamberCard from '@/components/ChamberCard'
 
 export default function Dashboard() {
@@ -36,7 +40,8 @@ export default function Dashboard() {
   const [openAddress, setOpenAddress] = useState('')
   const [openError, setOpenError] = useState<string | null>(null)
   const preferredChainId = getPreferredSupportedChainId()
-  const showUnsupportedMainnet = showMainnetUnsupportedBanner(chainId, isMainnetConfigured)
+  const bannerChainId = readSimulatedChainId(location.search, import.meta.env.DEV) ?? chainId
+  const showUnsupportedMainnet = showMainnetUnsupportedBanner(bannerChainId, isMainnetConfigured)
   const switchLabel = switchToSupportedChainLabel(preferredChainId)
   const canSwitch = Boolean((preferredChainId && isConnected) || openChainModal)
 

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAccount, useChainId, useReadContracts, useSwitchChain } from 'wagmi'
 import { formatUnits, isAddress } from 'viem'
-import { useChainModal } from '@rainbow-me/rainbowkit'
+import { useChainModal, useConnectModal } from '@rainbow-me/rainbowkit'
 import {
   FiLayers,
   FiPlus,
@@ -36,6 +36,7 @@ export default function Dashboard() {
   const chainId = useChainId()
   const { switchChainAsync, isPending: isSwitching } = useSwitchChain()
   const { openChainModal } = useChainModal()
+  const { openConnectModal } = useConnectModal()
   const [viewMode, setViewMode] = useState<'mine' | 'organizations'>('mine')
   const [openAddress, setOpenAddress] = useState('')
   const [openError, setOpenError] = useState<string | null>(null)
@@ -43,7 +44,6 @@ export default function Dashboard() {
   const bannerChainId = readSimulatedChainId(location.search, import.meta.env.DEV) ?? chainId
   const showUnsupportedMainnet = showMainnetUnsupportedBanner(bannerChainId, isMainnetConfigured)
   const switchLabel = switchToSupportedChainLabel(preferredChainId)
-  const canSwitch = Boolean((preferredChainId && isConnected) || openChainModal)
 
   const {
     chambers: myChambers,
@@ -71,11 +71,19 @@ export default function Dashboard() {
         await switchChainAsync({ chainId: preferredChainId })
         return
       } catch {
-        openChainModal?.()
+        if (openChainModal) {
+          openChainModal()
+          return
+        }
+        openConnectModal?.()
         return
       }
     }
-    openChainModal?.()
+    if (openChainModal) {
+      openChainModal()
+      return
+    }
+    openConnectModal?.()
   }
 
   const handleOpenAddress = (e: React.FormEvent) => {
@@ -103,21 +111,19 @@ export default function Dashboard() {
               This deployment does not include <strong className="text-slate-200">Ethereum mainnet</strong>. Use your
               wallet to switch to <strong className="text-slate-200">Sepolia</strong> (or another supported network).
             </p>
-            {canSwitch ? (
-              <button
-                type="button"
-                className="btn btn-primary shrink-0 self-start sm:self-auto"
-                onClick={() => void handleSwitchToSupportedChain()}
-                disabled={isSwitching}
-              >
-                {isSwitching ? (
-                  <FiLoader className="w-4 h-4 animate-spin" aria-hidden />
-                ) : (
-                  <FiRefreshCw className="w-4 h-4" aria-hidden />
-                )}
-                {isSwitching ? 'Switching…' : switchLabel}
-              </button>
-            ) : null}
+            <button
+              type="button"
+              className="btn btn-primary shrink-0 self-start sm:self-auto"
+              onClick={() => void handleSwitchToSupportedChain()}
+              disabled={isSwitching}
+            >
+              {isSwitching ? (
+                <FiLoader className="w-4 h-4 animate-spin" aria-hidden />
+              ) : (
+                <FiRefreshCw className="w-4 h-4" aria-hidden />
+              )}
+              {isSwitching ? 'Switching…' : switchLabel}
+            </button>
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #233.

Dashboard `/` showed a text-only notice when `chainId === 1 && !isMainnetConfigured`. Founders on mainnet had no in-app path off the dead network.

Rebased onto latest `main` (includes #236). Conflict resolutions: kept `getNetworkName` / `getConfiguredChainIds` from #236; `getPreferredSupportedChainId` now reads that list; Dashboard Switch CTA is this PR only. Did not invent mainnet addresses.

## What changed
- Mainnet-unsupported banner keeps the existing non-custodial copy (no invented mainnet addresses).
- Primary **Switch to Sepolia** (or the first wagmi chain that already has a Factory/Registry) is always on the banner.
- Connected: `useSwitchChain` to that chain; on failure, RainbowKit `useChainModal` (same order as #236 `WrongNetworkPanel`).
- Disconnected: RainbowKit `useConnectModal` only.
- DEV-only `?simulateChainId=1` on `/` so the banner can be exercised without a mainnet wallet. Production builds ignore it.

## How to test
1. **Mainnet, no mainnet config** — Connect a wallet on Ethereum mainnet while `VITE_MAINNET_FACTORY` / `VITE_MAINNET_REGISTRY` are unset. Open `/`. Expect the slate banner plus **Switch to Sepolia**. Click it; the wallet should prompt to switch. After switch, the banner disappears.
2. **DEV stand-in** — `/?simulateChainId=1` with no mainnet env. Same banner + **Switch to Sepolia**. Without a connected wallet the button opens the RainbowKit connect modal.
3. **Sepolia / configured chain** — On `/` (no simulate param) the banner must not appear.
4. **Copy** — Banner text still says this deployment does not include Ethereum mainnet. No mainnet contract addresses.

## Verification
- Offline: `cd app && npm run test:mainnet-banner`
- Browser (DEV `?simulateChainId=1`, mainnet Factory/Registry unset):

Default `/` — no banner:

![Dashboard default, no mainnet banner](https://cursor.com/artifacts/c/art-71267031-9874-4301-a9dd-abee491ef7ef)

`/?simulateChainId=1` — banner + Switch to Sepolia:

![Mainnet unsupported banner with Switch to Sepolia](https://cursor.com/artifacts/c/art-98b80846-fd6e-40b8-bf14-2ff69c30fe7e)

Click Switch (disconnected) opens RainbowKit connect:

![Switch to Sepolia opens connect modal](https://cursor.com/artifacts/c/art-942c8c5d-1779-43ac-bbe2-75b263e5117d)

Mobile (~390px) — button still visible:

![Mainnet banner Switch CTA on mobile](https://cursor.com/artifacts/c/art-20222997-5518-42d1-a842-2bb0ba62e20c)

## Notes
- Independent of #230 (discovery gaps). One surface: Dashboard.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0207795d-e45a-4db7-b744-86f5b72f2d20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0207795d-e45a-4db7-b744-86f5b72f2d20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

