### PR TITLE
app: surface Mine discovery gaps instead of false empty

### DIFF
--- a/app/scripts/verify-chamber-discovery.ts
+++ b/app/scripts/verify-chamber-discovery.ts
@@ -8,9 +8,13 @@ import {
   INDEXER_CATCHUP_BLOCKS,
   UNBOUNDED_LOOKBACK_BLOCKS,
   clampDiscoveryFromBlock,
+  discoverChambers,
+  EMPTY_DISCOVERY_HEALTH,
   getEventLogsPaged,
+  isChamberDiscoveryIncomplete,
   parseStartBlock,
   SEPOLIA_DISCOVERY_START_BLOCK,
+  shouldShowDiscoveryGap,
   factoryCreatedEvent,
 } from '../src/lib/chamberDiscovery.ts'
 import type { PublicClient } from 'viem'
@@ -110,7 +114,176 @@ async function testPagedLogs() {
   )
 }
 
+function testDiscoveryGapRules() {
+  assert.equal(isChamberDiscoveryIncomplete(EMPTY_DISCOVERY_HEALTH), false)
+  assert.equal(
+    isChamberDiscoveryIncomplete({ ...EMPTY_DISCOVERY_HEALTH, catchupOnly: true }),
+    false,
+    'indexer success + catch-up getLogs is not a gap by itself',
+  )
+  assert.equal(isChamberDiscoveryIncomplete({ ...EMPTY_DISCOVERY_HEALTH, indexerFailed: true }), true)
+  assert.equal(isChamberDiscoveryIncomplete({ ...EMPTY_DISCOVERY_HEALTH, rpcErrored: true }), true)
+  assert.equal(
+    isChamberDiscoveryIncomplete({
+      ...EMPTY_DISCOVERY_HEALTH,
+      catchupOnly: true,
+      rpcErrored: true,
+    }),
+    true,
+    'catch-up getLogs that errors is a gap',
+  )
+
+  assert.equal(
+    shouldShowDiscoveryGap({ connected: false, loading: false, queryFailed: false }),
+    false,
+  )
+  assert.equal(
+    shouldShowDiscoveryGap({ connected: true, loading: true, queryFailed: false }),
+    false,
+  )
+  assert.equal(
+    shouldShowDiscoveryGap({
+      connected: true,
+      loading: false,
+      queryFailed: false,
+      health: EMPTY_DISCOVERY_HEALTH,
+    }),
+    false,
+    'true empty wallet: no banner',
+  )
+  assert.equal(
+    shouldShowDiscoveryGap({
+      connected: true,
+      loading: false,
+      queryFailed: false,
+      health: { ...EMPTY_DISCOVERY_HEALTH, indexerFailed: true },
+    }),
+    true,
+    'indexer configured but failed: banner',
+  )
+  assert.equal(
+    shouldShowDiscoveryGap({ connected: true, loading: false, queryFailed: true }),
+    true,
+    'query died (e.g. getBlockNumber): banner without raw RPC text',
+  )
+}
+
+function fakeClient(options: {
+  latest?: bigint
+  getLogs?: PublicClient['getLogs']
+}): PublicClient {
+  return {
+    getBlockNumber: async () => options.latest ?? 8_000_000n,
+    getLogs:
+      options.getLogs ??
+      (async () => [] as never),
+    getTransaction: async () => {
+      throw new Error('unused')
+    },
+  } as unknown as PublicClient
+}
+
+const FACTORY = '0x43aa92c8a26392f21f63cda88b6bab5031c40550' as const
+const USER = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
+
+async function testIndexerFailHealth() {
+  const prev = globalThis.fetch
+  globalThis.fetch = (async () => {
+    throw new Error('Indexer GraphQL ECONNRESET boom')
+  }) as typeof fetch
+
+  try {
+    const result = await discoverChambers({
+      client: fakeClient({}),
+      chainId: 11155111,
+      userAddress: USER,
+      factoryAddress: FACTORY,
+      indexerUrl: 'https://indexer.example.test',
+    })
+    assert.equal(result.health.indexerConfigured, true)
+    assert.equal(result.health.indexerFailed, true)
+    assert.equal(result.health.catchupOnly, false)
+    assert.equal(result.health.rpcErrored, false)
+    assert.equal(isChamberDiscoveryIncomplete(result.health), true)
+    assert.equal(
+      JSON.stringify(result.health).includes('ECONNRESET'),
+      false,
+      'health must not carry raw GraphQL/RPC text',
+    )
+  } finally {
+    globalThis.fetch = prev
+  }
+}
+
+async function testEmptyWalletHealth() {
+  const result = await discoverChambers({
+    client: fakeClient({}),
+    chainId: 11155111,
+    userAddress: USER,
+    factoryAddress: FACTORY,
+    indexerUrl: '',
+  })
+  assert.equal(result.addresses.length, 0)
+  assert.equal(result.health.indexerConfigured, false)
+  assert.equal(result.health.indexerFailed, false)
+  assert.equal(result.health.rpcErrored, false)
+  assert.equal(isChamberDiscoveryIncomplete(result.health), false)
+}
+
+async function testRpcErroredHealth() {
+  const result = await discoverChambers({
+    client: fakeClient({
+      latest: 7_453_900n,
+      getLogs: async () => {
+        throw new Error('eth_getLogs filter not found query returned more than 10000 results')
+      },
+    }),
+    chainId: 11155111,
+    userAddress: USER,
+    factoryAddress: FACTORY,
+    indexerUrl: '',
+  })
+  assert.equal(result.health.rpcErrored, true)
+  assert.equal(isChamberDiscoveryIncomplete(result.health), true)
+}
+
+async function testCatchupOnlyErroredHealth() {
+  const prev = globalThis.fetch
+  globalThis.fetch = (async () =>
+    ({
+      ok: true,
+      json: async () => ({
+        data: { created: { items: [] }, held: { items: [] } },
+      }),
+    }) as Response) as typeof fetch
+
+  try {
+    const result = await discoverChambers({
+      client: fakeClient({
+        getLogs: async () => {
+          throw new Error('block range too large')
+        },
+      }),
+      chainId: 11155111,
+      userAddress: USER,
+      factoryAddress: FACTORY,
+      indexerUrl: 'https://indexer.example.test',
+    })
+    assert.equal(result.health.indexerFailed, false)
+    assert.equal(result.health.catchupOnly, true)
+    assert.equal(result.health.rpcErrored, true)
+    assert.equal(isChamberDiscoveryIncomplete(result.health), true)
+  } finally {
+    globalThis.fetch = prev
+  }
+}
+
 testParseIndexer()
 testStartBlocks()
+testDiscoveryGapRules()
 await testPagedLogs()
+await testIndexerFailHealth()
+await testEmptyWalletHealth()
+await testRpcErroredHealth()
+await testCatchupOnlyErroredHealth()
 console.log('verify-chamber-discovery: ok')

--- a/app/scripts/verify-sepolia-discovery.ts
+++ b/app/scripts/verify-sepolia-discovery.ts
@@ -61,6 +61,7 @@ assert.ok(
   registryOnly.addresses.includes(KNOWN_OLD),
   'Factory-unset / Registry-only still lists Registry-created chambers',
 )
+assert.equal(registryOnly.health.rpcErrored, false, 'live getLogs should not mark rpcErrored')
 
 const factorySet = await discoverChambers({
   client: inner as PublicClient,

--- a/app/src/hooks/useMyChambers.ts
+++ b/app/src/hooks/useMyChambers.ts
@@ -3,7 +3,12 @@ import { useAccount, useChainId, usePublicClient } from 'wagmi'
 import { useQuery } from '@tanstack/react-query'
 import { multicall } from 'viem/actions'
 import { chamberAbi, factoryAbi, registryAbi } from '@/contracts/abis'
-import { discoverChambers } from '@/lib/chamberDiscovery'
+import {
+  discoverChambers,
+  EMPTY_DISCOVERY_HEALTH,
+  shouldShowDiscoveryGap,
+  type ChamberDiscoveryHealth,
+} from '@/lib/chamberDiscovery'
 import { getIndexerUrl, indexerAppliesToChain } from '@/lib/indexer'
 import { addRecentChamber, getRecentChambers } from '@/lib/recentChambers'
 import { isNonZeroAddress } from '@/lib/wagmi'
@@ -66,10 +71,12 @@ export function useMyChambers() {
       !!userAddress &&
       (factoryOk || registryOk || recents.length > 0 || !!indexerUrl),
     staleTime: 15_000,
-    queryFn: async () => {
-      if (!publicClient || !userAddress) return [] as MyChamberEntry[]
+    queryFn: async (): Promise<{ chambers: MyChamberEntry[]; health: ChamberDiscoveryHealth }> => {
+      if (!publicClient || !userAddress) {
+        return { chambers: [], health: EMPTY_DISCOVERY_HEALTH }
+      }
 
-      const { addresses: discovered, creators } = await discoverChambers({
+      const { addresses: discovered, creators, health } = await discoverChambers({
         client: publicClient,
         chainId,
         userAddress,
@@ -86,7 +93,7 @@ export function useMyChambers() {
         candidates.push(addr)
       }
 
-      if (candidates.length === 0) return [] as MyChamberEntry[]
+      if (candidates.length === 0) return { chambers: [], health }
 
       const user = userAddress.toLowerCase()
       const [dirs, bals] = await Promise.all([
@@ -125,14 +132,20 @@ export function useMyChambers() {
           mine.push({ address, isDirector, balance, isCreator })
         }
       }
-      return mine
+      return { chambers: mine, health }
     },
   })
 
   return {
-    chambers: query.data ?? [],
+    chambers: query.data?.chambers ?? [],
     isLoading: query.isLoading,
     error: query.error,
+    discoveryIncomplete: shouldShowDiscoveryGap({
+      connected: !!userAddress,
+      loading: query.isLoading,
+      queryFailed: query.isError,
+      health: query.data?.health,
+    }),
     refetch: query.refetch,
     recents,
     remember,

--- a/app/src/lib/chamberDiscovery.ts
+++ b/app/src/lib/chamberDiscovery.ts
@@ -11,6 +11,9 @@
  * Public Sepolia RPCs often reject or truncate a single from-0 `getLogs`.
  * Production RPC (Alchemy when `VITE_ALCHEMY_API_KEY` is set) can page history
  * older than 48h. A live Ponder host is optional.
+ *
+ * Failures are recorded on `health` (no raw GraphQL/RPC strings) so the
+ * Dashboard can tell incomplete discovery from a truly empty wallet.
  */
 
 import { parseAbiItem, type AbiEvent, type Address, type GetLogsReturnType, type PublicClient } from 'viem'
@@ -44,9 +47,42 @@ const MIN_LOG_CHUNK = 200n
 const LOG_CONCURRENCY = 4
 const TX_CONCURRENCY = 4
 
+export type ChamberDiscoveryHealth = {
+  indexerConfigured: boolean
+  indexerFailed: boolean
+  /** Indexer answered; getLogs only covers the recent catch-up window. */
+  catchupOnly: boolean
+  /** A getLogs window was abandoned or Factory/Registry collection threw. */
+  rpcErrored: boolean
+}
+
+export const EMPTY_DISCOVERY_HEALTH: ChamberDiscoveryHealth = {
+  indexerConfigured: false,
+  indexerFailed: false,
+  catchupOnly: false,
+  rpcErrored: false,
+}
+
+export function isChamberDiscoveryIncomplete(health: ChamberDiscoveryHealth): boolean {
+  return health.indexerFailed || health.rpcErrored
+}
+
+/** Production banner: connected, settled, and discovery is degraded or the query died. */
+export function shouldShowDiscoveryGap(options: {
+  connected: boolean
+  loading: boolean
+  queryFailed: boolean
+  health?: ChamberDiscoveryHealth
+}): boolean {
+  if (!options.connected || options.loading) return false
+  if (options.queryFailed) return true
+  return !!options.health && isChamberDiscoveryIncomplete(options.health)
+}
+
 export type DiscoveredChambers = {
   addresses: `0x${string}`[]
   creators: Map<string, `0x${string}`>
+  health: ChamberDiscoveryHealth
 }
 
 export function parseStartBlock(raw: string | undefined): bigint | undefined {
@@ -162,9 +198,12 @@ async function probeLogChunk<TEvent extends AbiEvent>(
   return MIN_LOG_CHUNK
 }
 
+export type LogPageSink = { errored?: boolean }
+
 export async function getEventLogsPaged<TEvent extends AbiEvent>(
   client: PublicClient,
   args: { address: `0x${string}`; event: TEvent; fromBlock: bigint; toBlock: bigint },
+  sink?: LogPageSink,
 ): Promise<EventLogs<TEvent>> {
   try {
     return await client.getLogs({
@@ -175,7 +214,7 @@ export async function getEventLogsPaged<TEvent extends AbiEvent>(
     })
   } catch {
     const chunk = await probeLogChunk(client, args, args.fromBlock, args.toBlock)
-    return collectLogs(client, args, args.fromBlock, args.toBlock, chunk)
+    return collectLogs(client, args, args.fromBlock, args.toBlock, chunk, sink)
   }
 }
 
@@ -185,6 +224,7 @@ async function collectLogs<TEvent extends AbiEvent>(
   fromBlock: bigint,
   toBlock: bigint,
   chunk: bigint,
+  sink?: LogPageSink,
 ): Promise<EventLogs<TEvent>> {
   if (toBlock < fromBlock) return [] as EventLogs<TEvent>
 
@@ -198,11 +238,14 @@ async function collectLogs<TEvent extends AbiEvent>(
         toBlock,
       })
     } catch {
-      if (span <= MIN_LOG_CHUNK) return [] as EventLogs<TEvent>
+      if (span <= MIN_LOG_CHUNK) {
+        if (sink) sink.errored = true
+        return [] as EventLogs<TEvent>
+      }
       const mid = fromBlock + span / 2n - 1n
       const [left, right] = await Promise.all([
-        collectLogs(client, args, fromBlock, mid, chunk),
-        collectLogs(client, args, mid + 1n, toBlock, chunk),
+        collectLogs(client, args, fromBlock, mid, chunk, sink),
+        collectLogs(client, args, mid + 1n, toBlock, chunk, sink),
       ])
       return [...left, ...right]
     }
@@ -215,7 +258,7 @@ async function collectLogs<TEvent extends AbiEvent>(
   }
 
   const batches = await mapPool(windows, LOG_CONCURRENCY, ([start, end]) =>
-    collectLogs(client, args, start, end, chunk),
+    collectLogs(client, args, start, end, chunk, sink),
   )
   return batches.flat()
 }
@@ -255,6 +298,8 @@ export async function discoverChambers(options: {
   userAddress: Address
   factoryAddress?: `0x${string}`
   registryAddress?: `0x${string}`
+  /** Test override. Unset uses `VITE_INDEXER_URL` when the chain matches. */
+  indexerUrl?: string
 }): Promise<DiscoveredChambers> {
   const { client, chainId, userAddress, factoryAddress, registryAddress } = options
   const addresses: `0x${string}`[] = []
@@ -263,7 +308,19 @@ export async function discoverChambers(options: {
 
   const factoryOk = isNonZeroAddress(factoryAddress)
   const registryOk = isNonZeroAddress(registryAddress)
-  const indexerUrl = indexerAppliesToChain(chainId) ? getIndexerUrl() : undefined
+  const indexerUrl =
+    options.indexerUrl !== undefined
+      ? options.indexerUrl.trim().replace(/\/+$/, '') || undefined
+      : indexerAppliesToChain(chainId)
+        ? getIndexerUrl()
+        : undefined
+
+  const health: ChamberDiscoveryHealth = {
+    indexerConfigured: !!indexerUrl,
+    indexerFailed: false,
+    catchupOnly: false,
+    rpcErrored: false,
+  }
 
   let indexerOk = false
   if (indexerUrl) {
@@ -272,53 +329,65 @@ export async function discoverChambers(options: {
       mergeIndexerRows(addresses, seen, creators, mine.created)
       mergeIndexerRows(addresses, seen, creators, mine.held)
       indexerOk = true
+      health.catchupOnly = true
     } catch {
-      // fall through to chunked getLogs
+      health.indexerFailed = true
     }
   }
 
   if (!factoryOk && !registryOk) {
-    return { addresses, creators }
+    return { addresses, creators, health }
   }
 
   const latest = await client.getBlockNumber()
 
   const collectFactory = async () => {
     if (!factoryOk || !factoryAddress) return
+    const sink: LogPageSink = {}
     try {
       const fromBlock = clampDiscoveryFromBlock(
         discoveryStartBlock(chainId, 'factory'),
         latest,
         indexerOk,
       )
-      const logs = await getEventLogsPaged(client, {
-        address: factoryAddress,
-        event: factoryCreatedEvent,
-        fromBlock,
-        toBlock: latest,
-      })
+      const logs = await getEventLogsPaged(
+        client,
+        {
+          address: factoryAddress,
+          event: factoryCreatedEvent,
+          fromBlock,
+          toBlock: latest,
+        },
+        sink,
+      )
       for (const log of logs) {
         pushChamber(addresses, seen, creators, log.args.chamber, log.args.creator)
       }
     } catch {
-      // RPC getLogs limits — indexer / recents / open-address still work
+      health.rpcErrored = true
     }
+    if (sink.errored) health.rpcErrored = true
   }
 
   const collectRegistry = async () => {
     if (!registryOk || !registryAddress) return
+    const sink: LogPageSink = {}
     try {
       const fromBlock = clampDiscoveryFromBlock(
         discoveryStartBlock(chainId, 'registry'),
         latest,
         indexerOk,
       )
-      const logs = await getEventLogsPaged(client, {
-        address: registryAddress,
-        event: registryCreatedEvent,
-        fromBlock,
-        toBlock: latest,
-      })
+      const logs = await getEventLogsPaged(
+        client,
+        {
+          address: registryAddress,
+          event: registryCreatedEvent,
+          fromBlock,
+          toBlock: latest,
+        },
+        sink,
+      )
       for (const log of logs) {
         pushChamber(addresses, seen, creators, log.args.chamber)
       }
@@ -326,10 +395,11 @@ export async function discoverChambers(options: {
         await recoverRegistryCreators(client, logs, creators)
       }
     } catch {
-      // leftover Registry index is best-effort
+      health.rpcErrored = true
     }
+    if (sink.errored) health.rpcErrored = true
   }
 
   await Promise.all([collectFactory(), collectRegistry()])
-  return { addresses, creators }
+  return { addresses, creators, health }
 }

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -23,6 +23,7 @@ export default function Dashboard() {
     isLoading,
     refetch: refetchMine,
     error: chambersError,
+    discoveryIncomplete,
     recents,
     remember,
     factoryAddress,
@@ -217,10 +218,17 @@ export default function Dashboard() {
           </div>
         </div>
 
-        <form onSubmit={handleOpenAddress} className="panel p-4 flex flex-col sm:flex-row gap-3 sm:items-end">
+        <form
+          id="open-chamber-address"
+          onSubmit={handleOpenAddress}
+          className="panel p-4 flex flex-col sm:flex-row gap-3 sm:items-end"
+        >
           <div className="flex-1 min-w-0">
-            <label className="block text-slate-400 text-xs font-medium mb-1.5">Open address</label>
+            <label htmlFor="open-chamber-address-input" className="block text-slate-400 text-xs font-medium mb-1.5">
+              Open address
+            </label>
             <input
+              id="open-chamber-address-input"
               type="text"
               placeholder="0x… chamber address"
               className="input font-mono"
@@ -252,6 +260,8 @@ export default function Dashboard() {
             ))}
           </div>
         )}
+
+        {isConnected && discoveryIncomplete && <DiscoveryGapBanner />}
 
         <AnimatePresence mode="wait">
           {viewMode === 'mine' ? (
@@ -386,6 +396,33 @@ function OrganizationGroup({ nftToken, chambers, index }: { nftToken: `0x${strin
         {chambers.map((address) => (
           <ChamberCard key={address} address={address} />
         ))}
+      </div>
+    </motion.div>
+  )
+}
+
+function DiscoveryGapBanner() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="panel p-4 border-amber-500/30 bg-amber-500/5"
+      role="status"
+    >
+      <div className="flex items-start gap-3">
+        <FiAlertTriangle className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" aria-hidden />
+        <div>
+          <h4 className="font-medium text-amber-400 mb-1">Discovery may be incomplete</h4>
+          <p className="text-slate-400 text-sm">
+            This list can miss chambers when lookup fails. Open an address above, or use Recents.
+          </p>
+          <a
+            href="#open-chamber-address"
+            className="text-accent-400 text-sm font-medium hover:text-accent-300 mt-2 inline-block"
+          >
+            Open an address →
+          </a>
+        </div>
       </div>
     </motion.div>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #230.

## Problem
`useMyChambers` / `discoverChambers` swallowed indexer and `getLogs` failures. Production Dashboard only showed “No chambers yet,” so an indexer/RPC gap looked like a truly empty wallet.

## Change
- `discoverChambers` now returns `health` (`indexerFailed`, `catchupOnly`, `rpcErrored`) with **no raw GraphQL/RPC strings**.
- Production Dashboard shows a non-blocking amber banner when discovery may be incomplete.
- One next action: **Open an address** (Recents still work). Empty-wallet copy and the DEV debug panel are unchanged.
- Does **not** include #233 (mainnet switch CTA).

## Banner vs empty wallet

| State | Banner? | Empty copy |
| --- | --- | --- |
| Indexer configured but fails (fallback getLogs may still return rows) | Yes — “Discovery may be incomplete” | Only if the list is still empty |
| getLogs catch-up **errored** (indexer answered; recent window failed) | Yes | Only if the list is still empty |
| Query died (e.g. `getBlockNumber`) | Yes — no raw RPC text | Yes if no cached list |
| Connected, discovery healthy, zero chambers | **No** | “No chambers yet” + Deploy |
| Wallet disconnected | **No** | “Connect to see your chambers” |

Catch-up-only after a **successful** indexer query is the happy path and does **not** show the banner unless that catch-up window errors.

## Test notes

Offline (no host):

```bash
cd app && npx tsx --tsconfig tsconfig.json scripts/verify-chamber-discovery.ts
```

Covers indexer-fail vs empty wallet vs RPC-errored vs catchup-only+errored, plus `shouldShowDiscoveryGap` rules. **Passed.**

Live Sepolia:

```bash
npx tsx --tsconfig tsconfig.json scripts/verify-sepolia-discovery.ts
```

Asserts `health.rpcErrored === false` on a working RPC. **Passed.**

`npx tsc --noEmit` and eslint on the touched app files. **Passed.**

Manual Dashboard (Vite `http://127.0.0.1:5173/`):
1. Disconnected / not discovering → no banner; “Connect to see your chambers”; Open address validation and Recents still work.
2. Forced incomplete-discovery render (local QA only, not in this branch) → amber banner, human copy only, “Open an address →” text link, Deploy remains the empty-state primary.
3. DEV debug panel unchanged (still gated on `import.meta.env.DEV`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf711d3b-c075-4d2f-8417-0cd320151fdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf711d3b-c075-4d2f-8417-0cd320151fdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

