### PR TITLE
fix(app): staking connect empty-state (parity with Delegation)

### DIFF
--- a/app/src/components/TreasuryOverview.tsx
+++ b/app/src/components/TreasuryOverview.tsx
@@ -12,7 +12,9 @@ import {
   FiAlertCircle,
   FiCheck,
   FiUnlock,
+  FiUser,
 } from 'react-icons/fi'
+import { ConnectButton } from '@rainbow-me/rainbowkit'
 import toast from 'react-hot-toast'
 import { 
   useDeposit, 
@@ -36,7 +38,7 @@ interface TreasuryOverviewProps {
 }
 
 export default function TreasuryOverview({ chamberAddress, chamberInfo, userBalance, totalDelegated = 0n }: TreasuryOverviewProps) {
-  const { address: userAddress } = useAccount()
+  const { address: userAddress, isConnected } = useAccount()
   const [depositAmount, setDepositAmount] = useState('')
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [pollAllowanceAfterApprove, setPollAllowanceAfterApprove] = useState(false)
@@ -326,8 +328,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
                   ? parseFloat(formatUnits(userBalance, 18)).toLocaleString(undefined, {
                       maximumFractionDigits: 4,
                     })
-                  : 'Connect Wallet'
-                }
+                  : '—'}
                 {userBalance !== undefined && chamberInfo.symbol && (
                   <span className="text-lg text-slate-400 ml-2">{chamberInfo.symbol}</span>
                 )}
@@ -342,7 +343,18 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
         </motion.div>
       </div>
 
-      {/* Deposit / Withdraw — matched layout, equal-height columns */}
+      {!isConnected ? (
+        <div className="panel p-10 text-center space-y-4">
+          <FiUser className="w-8 h-8 text-slate-600 mx-auto" />
+          <div>
+            <h3 className="font-heading text-lg font-semibold text-slate-300 mb-1">Connect your wallet</h3>
+            <p className="text-slate-500 text-sm">Connect to deposit assets and withdraw shares.</p>
+          </div>
+          <div className="flex justify-center pt-2">
+            <ConnectButton accountStatus="address" chainStatus="icon" showBalance={false} />
+          </div>
+        </div>
+      ) : (
       <div className="grid md:grid-cols-2 gap-5 md:items-stretch">
         {/* Deposit */}
         <motion.div
@@ -605,6 +617,7 @@ export default function TreasuryOverview({ chamberAddress, chamberInfo, userBala
           </div>
         </motion.div>
       </div>
+      )}
 
       {/* Info Box */}
       <div className="panel p-6 bg-accent-500/5 border-accent-500/20">

--- a/packages/operator/test/app-error-parity.test.ts
+++ b/packages/operator/test/app-error-parity.test.ts
@@ -28,3 +28,16 @@ test('operator error copy stays aligned with the React app', async () => {
   assert.equal(CHAMBER_ERROR_MESSAGES.EnforcedPause, 'This chamber is paused')
   assert.equal(CHAMBER_ERROR_MESSAGES.TransactionExpired, 'This transaction has expired')
 })
+
+test('TreasuryOverview disconnected empty-state matches Delegation ConnectButton pattern', async () => {
+  const treasury = await readApp('app/src/components/TreasuryOverview.tsx')
+  const delegation = await readApp('app/src/components/DelegationManager.tsx')
+
+  assert.match(delegation, /if \(!isConnected\)/)
+  assert.match(delegation, /ConnectButton/)
+  assert.match(treasury, /!isConnected/)
+  assert.match(treasury, /ConnectButton/)
+  assert.match(treasury, /Connect to deposit assets and withdraw shares/)
+  assert.doesNotMatch(treasury, /'Connect Wallet'/)
+  assert.match(treasury, /This chamber is paused\. Deposits and withdrawals are halted/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #231.

Staking (`TreasuryOverview`) showed “Connect Wallet” as share-balance text and still rendered Deposit/Withdraw with no connect CTA. Delegation already gates on `isConnected` with a short explanation + RainbowKit `ConnectButton`.

## Change
- Disconnected: same empty-state pattern as `DelegationManager` — heading, one-line explanation, `ConnectButton`. Deposit/Withdraw hidden until connected.
- “Your Shares” shows `—` instead of “Connect Wallet” as a fake number. Chamber-level Total Assets / Total Shares stay visible.
- Connected + paused: existing pause banner is unchanged.
- Does **not** touch #192 (hardcoded 18-decimal parse/format).

One surface: `app/src/components/TreasuryOverview.tsx`.

## How to test
1. **Disconnected** — Open `/chamber/<address>/staking` with no wallet. Expect the connect panel (same chrome as Delegation) and **no** Deposit/Withdraw forms. Click Connect; RainbowKit modal should open.
2. **Delegation parity** — Open `/chamber/<address>/delegation` disconnected. Staking empty-state should match that layout (icon, heading, copy, ConnectButton).
3. **Connected** — After connecting, Deposit/Withdraw return. Pause banner still appears when `chamberInfo.paused === true`.
4. **Decimals** — Deposit/withdraw still use 18-decimal `parseUnits`/`formatUnits` (leave #192 alone).

Offline: `cd packages/operator && npx tsx --test test/app-error-parity.test.ts`

Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca8f326e-384b-4a27-bec2-a6a8f9157b4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca8f326e-384b-4a27-bec2-a6a8f9157b4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

